### PR TITLE
Dependabot: update only whitelisted packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
         versioning-strategy: lockfile-only
         groups:
             ci-tools:
+                exclude-patterns:
+                    - "*"
                 patterns:
                     - "phpstan/*"
                     - "shipmonk/*"


### PR DESCRIPTION
We dont need stuff like https://github.com/shipmonk-rnd/dead-code-detector/pull/58