### PR TITLE
Dependabot: try yet another only-whitelisted approach

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
                     - minor
         ignore:
             - dependency-name: "*"
+        allow:
+            - dependency-name: "phpstan/*"
+            - dependency-name: "shipmonk/*"
+            - dependency-name: "phpunit/*"
+            - dependency-name: "editorconfig-checker/*"
+            - dependency-name: "ergebnis/composer-normalize"
+            - dependency-name: "slevomat/coding-standard"


### PR DESCRIPTION
Previous attempt #61 probably still does not work according to [logs](https://github.com/shipmonk-rnd/dead-code-detector/actions/runs/10700538117/job/29664498275):

> updater | 2024/09/04 11:14:58 WARN <job_879238385> Skipping update group for 'ci-tools' as it does not match any allowed dependencies.
