### PR TITLE
feat: ignore methods with Override PHP Attribute

### DIFF
--- a/src/Rule/DeadMethodRule.php
+++ b/src/Rule/DeadMethodRule.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Rule;
 
+use Override;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -19,7 +20,9 @@ use ShipMonk\PHPStan\DeadCode\Reflection\ClassHierarchy;
 use function array_map;
 use function array_merge;
 use function array_values;
+use function count;
 use function strpos;
+use const PHP_VERSION_ID;
 
 /**
  * @implements Rule<CollectedDataNode>
@@ -231,6 +234,11 @@ class DeadMethodRule implements Rule
         $methodReflection = $reflection
             ->getNativeReflection()
             ->getMethod($methodDefinition->methodName);
+
+        // no need for a provider for such detection
+        if (PHP_VERSION_ID >= 80_300 && count($methodReflection->getAttributes(Override::class)) > 0) {
+            return true;
+        }
 
         foreach ($this->entrypointProviders as $entrypointProvider) {
             if ($entrypointProvider->isEntrypoint($methodReflection)) {

--- a/tests/Rule/DeadMethodRuleTest.php
+++ b/tests/Rule/DeadMethodRuleTest.php
@@ -118,6 +118,7 @@ class DeadMethodRuleTest extends RuleTestCase
         yield 'provider-doctrine' => [__DIR__ . '/data/DeadMethodRule/providers/doctrine.php', 80_000];
         yield 'provider-phpstan' => [__DIR__ . '/data/DeadMethodRule/providers/phpstan.php', 80_000];
         yield 'provider-nette' => [__DIR__ . '/data/DeadMethodRule/providers/nette.php'];
+        yield 'provider-override-attribute' => [__DIR__ . '/data/DeadMethodRule/providers/override-attribute.php', 80_300];
     }
 
     /**

--- a/tests/Rule/data/DeadMethodRule/providers/override-attribute.php
+++ b/tests/Rule/data/DeadMethodRule/providers/override-attribute.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OverrideAttribute;
+
+interface FooInterface
+{
+
+    public function doSomething(): void; // error: Unused OverrideAttribute\FooInterface::doSomething
+
+}
+
+class Foo implements FooInterface
+{
+
+    #[\Override]
+    public function doSomething(): void {}
+
+}
+
+abstract class AbstractBar
+{
+
+    abstract public function doSomething(): void; // error: Unused OverrideAttribute\AbstractBar::doSomething
+
+}
+
+class Bar extends AbstractBar
+{
+
+    #[\Override]
+    public function doSomething(): void {}
+
+}


### PR DESCRIPTION
Ignore methods with [Override PHP Attribute](https://wiki.php.net/rfc/marking_overriden_methods) as dead code should be detected on the interface or parent class.