### PR TITLE
feat: exclude paths based on fqcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ parameters:
                 enabled: true
 ```
 
+## Exclude Paths:
+
+To exclude paths, configure the `exclude` entrypoint as following, based on class FQCN:
+
+```neon
+# phpstan.neon.dist
+parameters:
+    shipmonkDeadCode:
+        entrypoints:
+            exclude:
+                enabled: true
+                paths:
+                    # supports fqcn
+                    - 'App\Foo\Bar'
+                    # supports fqcn with regex
+                    - '/^App\\Foo\\.+$/i'
+```
+
 ## Customization:
 - If your application does some magic calls unknown to this library, you can implement your own entrypoint provider.
 - Just tag it with `shipmonk.deadCode.entrypointProvider` and implement `ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider`

--- a/rules.neon
+++ b/rules.neon
@@ -38,6 +38,14 @@ services:
             enabled: %shipmonkDeadCode.entrypoints.phpstan.enabled%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\ExcludeEntrypointProvider
+        tags:
+            - shipmonk.deadCode.entrypointProvider
+        arguments:
+            paths: %shipmonkDeadCode.entrypoints.exclude.paths%
+            enabled: %shipmonkDeadCode.entrypoints.exclude.enabled%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector
         tags:
             - phpstan.collector
@@ -73,6 +81,9 @@ parameters:
                 enabled: null
             doctrine:
                 enabled: null
+            exclude:
+                enabled: true
+                paths: []
 
 parametersSchema:
     shipmonkDeadCode: structure([
@@ -91,6 +102,10 @@ parametersSchema:
             ])
             doctrine: structure([
                 enabled: schema(bool(), nullable())
+            ])
+            exclude: structure([
+                enabled: schema(bool(), nullable())
+                paths: listOf(string())
             ])
         ])
     ])

--- a/src/Provider/ExcludeEntrypointProvider.php
+++ b/src/Provider/ExcludeEntrypointProvider.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use ReflectionMethod;
+use function count;
+use function preg_match;
+
+/**
+ * Excludes paths based on patterns.
+ *
+ * <code>
+ *  parameters:
+ *      shipmonkDeadCode:
+ *          entrypoints:
+ *              exclude:
+ *                  enabled: true
+ *                  paths:
+ *                      # supports fqcn
+ *                      - 'App\Foo\Bar'
+ *                      # supports fqcn with regex
+ *                      - '/^App\\\Foo\\\.+$/i'
+ * </code>
+ */
+class ExcludeEntrypointProvider implements EntrypointProvider
+{
+
+    /**
+     * @var list<string>
+     */
+    private array $paths;
+
+    private bool $enabled;
+
+    /**
+     * @param list<string> $paths
+     */
+    public function __construct(array $paths, bool $enabled)
+    {
+        $this->paths = $paths;
+        $this->enabled = $enabled;
+    }
+
+    public function isEntrypoint(ReflectionMethod $method): bool
+    {
+        if (!$this->enabled || count($this->paths) === 0) {
+            return false;
+        }
+
+        $className = $method->getDeclaringClass()->getName();
+
+        foreach ($this->paths as $path) {
+            // check if path is a regex
+            // prevents regex error like "preg_match(): Delimiter must not be alphanumeric, backslash, or NUL"
+            if (preg_match('/^[A-Za-z\d\\\].+/', $path) === 1) {
+                // path doesn't seem to be a regexp
+                if ($path === $className) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (preg_match($path, $className) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/tests/Rule/DeadMethodRuleTest.php
+++ b/tests/Rule/DeadMethodRuleTest.php
@@ -17,6 +17,7 @@ use ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\MethodDefinitionCollector;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\ExcludeEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\NetteEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpStanEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpUnitEntrypointProvider;
@@ -78,6 +79,7 @@ class DeadMethodRuleTest extends RuleTestCase
      */
     public static function provideFiles(): iterable
     {
+        yield 'exclude' => [[__DIR__ . '/data/DeadMethodRule/providers/exclude-by-class-name.php', __DIR__ . '/data/DeadMethodRule/providers/exclude-by-class-regex.php']];
         yield 'enum' => [__DIR__ . '/data/DeadMethodRule/enum.php', 80_000];
         yield 'code' => [__DIR__ . '/data/DeadMethodRule/basic.php'];
         yield 'ctor' => [__DIR__ . '/data/DeadMethodRule/ctor.php'];
@@ -158,6 +160,13 @@ class DeadMethodRuleTest extends RuleTestCase
             ),
             new NetteEntrypointProvider(
                 self::getContainer()->getByType(ReflectionProvider::class),
+                true,
+            ),
+            new ExcludeEntrypointProvider(
+                [
+                    'Exclude\ByClassName\ExcludedClass',
+                    '/^Exclude\\\ByClassRegex\\\.+$/',
+                ],
                 true,
             ),
         ];

--- a/tests/Rule/data/DeadMethodRule/providers/exclude-by-class-name.php
+++ b/tests/Rule/data/DeadMethodRule/providers/exclude-by-class-name.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Exclude\ByClassName;
+
+class ExcludedClass
+{
+
+    public function __construct() {}
+
+    public function someUnused(): void {}
+}

--- a/tests/Rule/data/DeadMethodRule/providers/exclude-by-class-regex.php
+++ b/tests/Rule/data/DeadMethodRule/providers/exclude-by-class-regex.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Exclude\ByClassRegex;
+
+class ExcludedClass
+{
+
+    public function __construct() {}
+
+    public function someUnused(): void {}
+}


### PR DESCRIPTION
Exclude paths based on fqcn:

```neon
# phpstan.neon.dist
parameters:
    shipmonkDeadCode:
        entrypoints:
            exclude:
                enabled: true
                paths:
                    # supports fqcn
                    - 'App\Foo\Bar'
                    # supports fqcn with regex
                    - '/^App\\Foo\\.+$/i'
```