### PR TITLE
Use the real method name when in a trait context

### DIFF
--- a/src/Rule/DeadMethodRule.php
+++ b/src/Rule/DeadMethodRule.php
@@ -197,7 +197,7 @@ class DeadMethodRule implements Rule
 
             $this->errors[$declaringTraitMethodKey] = RuleErrorBuilder::message("Unused {$declaringTraitMethodKey}")
                 ->file($declaringTraitReflection->getFileName()) // @phpstan-ignore-line
-                ->line($declaringTraitReflection->getMethod($methodDefinition->methodName)->getStartLine()) // @phpstan-ignore-line
+                ->line($declaringTraitReflection->getMethod($declaringTraitMethodDefinition->methodName)->getStartLine()) // @phpstan-ignore-line
                 ->identifier('shipmonk.deadMethod')
                 ->build();
 


### PR DESCRIPTION
This example would throw an error trying to get line of method `talk` from trait `Speak`

```php
trait Speak {
    function say() {}
}

class Person
{
    use Speak {
        say as talk;
    }
}
```