### PR TITLE
Remove all reflection work from main process

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ services:
 ```
 ```php
 
-use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
-use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
+use ReflectionMethod;
+use ShipMonk\PHPStan\DeadCode\Provider\MethodBasedEntrypointProvider;
 
 class ApiOutputEntrypointProvider extends MethodBasedEntrypointProvider
 {

--- a/README.md
+++ b/README.md
@@ -62,24 +62,26 @@ parameters:
 ## Customization:
 - If your application does some magic calls unknown to this library, you can implement your own entrypoint provider.
 - Just tag it with `shipmonk.deadCode.entrypointProvider` and implement `ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider`
+- You can simplify your implementation by extending `ShipMonk\PHPStan\DeadCode\Provider\MethodBasedEntrypointProvider`
 
 ```neon
 # phpstan.neon.dist
 services:
     -
-        class: App\MyEntrypointProvider
+        class: App\ApiOutputEntrypointProvider
         tags:
             - shipmonk.deadCode.entrypointProvider
 ```
 ```php
 
-use ReflectionMethod;
 use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
 
-class MyEntrypointProvider implements EntrypointProvider
+class ApiOutputEntrypointProvider extends MethodBasedEntrypointProvider
 {
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         return $method->getDeclaringClass()->implementsInterface(ApiOutput::class));
     }

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ services:
 ```php
 
 use ReflectionMethod;
-use ShipMonk\PHPStan\DeadCode\Provider\MethodBasedEntrypointProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\SimpleMethodEntrypointProvider;
 
-class ApiOutputEntrypointProvider extends MethodBasedEntrypointProvider
+class ApiOutputEntrypointProvider extends SimpleMethodEntrypointProvider
 {
 
     public function isEntrypointMethod(ReflectionMethod $method): bool

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -41,6 +41,6 @@ parameters:
                 PHPStan\Rules\Rule: Rule
                 PHPStan\Collectors\Collector: Collector
                 ShipMonk\PHPStan\DeadCode\Rule\RuleTestCase: RuleTest
-                ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider: EntrypointProvider
+                ShipMonk\PHPStan\DeadCode\Provider\MethodEntrypointProvider: EntrypointProvider
         enforceReadonlyPublicProperty:
             enabled: false # we support even PHP 7.4

--- a/rules.neon
+++ b/rules.neon
@@ -46,11 +46,15 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Collector\ClassDefinitionCollector
         tags:
             - phpstan.collector
+    -
+        class: ShipMonk\PHPStan\DeadCode\Collector\EntrypointCollector
+        tags:
+            - phpstan.collector
+        arguments:
+            entrypointProviders: tagged(shipmonk.deadCode.entrypointProvider)
 
     -
         class: ShipMonk\PHPStan\DeadCode\Rule\DeadMethodRule
-        arguments:
-            entrypointProviders: tagged(shipmonk.deadCode.entrypointProvider)
         tags:
             - phpstan.rules.rule
 

--- a/src/Collector/EntrypointCollector.php
+++ b/src/Collector/EntrypointCollector.php
@@ -12,7 +12,7 @@ use PHPStan\Reflection\MethodReflection;
 use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
 
 /**
- * @implements Collector<InClassNode, list<string>|null>
+ * @implements Collector<InClassNode, list<string>>
  */
 class EntrypointCollector implements Collector
 {

--- a/src/Collector/EntrypointCollector.php
+++ b/src/Collector/EntrypointCollector.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Collector;
+
+use Closure;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
+use PHPStan\Collectors\Collector;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\MethodReflection;
+use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
+
+/**
+ * @implements Collector<InClassNode, list<string>>
+ */
+class EntrypointCollector implements Collector
+{
+
+    /**
+     * @var list<EntrypointProvider>
+     */
+    private array $entrypointProviders;
+
+    /**
+     * @param list<EntrypointProvider> $entrypointProviders
+     */
+    public function __construct(
+        array $entrypointProviders
+    )
+    {
+        $this->entrypointProviders = $entrypointProviders;
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     * @return list<string>
+     */
+    public function processNode(
+        Node $node,
+        Scope $scope
+    ): array
+    {
+        $entrypoints = [];
+
+        foreach ($this->entrypointProviders as $entrypointProvider) {
+            foreach ($entrypointProvider->getEntrypoints($node->getClassReflection()) as $entrypointMethod) {
+                $entrypoints[] = $this->getRealDeclaringMethodKey($entrypointMethod);
+            }
+        }
+
+        return $entrypoints;
+    }
+
+    private function getRealDeclaringMethodKey(
+        MethodReflection $methodReflection
+    ): string
+    {
+        // @phpstan-ignore missingType.checkedException (method should always exist)
+        $nativeReflectionMethod = $methodReflection->getDeclaringClass()->getNativeReflection()->getMethod($methodReflection->getName());
+        $betterReflectionMethod = $nativeReflectionMethod->getBetterReflection();
+        $realDeclaringClass = $betterReflectionMethod->getDeclaringClass();
+
+        // when trait method name is aliased, we need the original name
+        $realName = Closure::bind(function (): string {
+            return $this->name;
+        }, $betterReflectionMethod, BetterReflectionMethod::class)();
+
+        return $realDeclaringClass->getName() . "::$realName";
+    }
+
+}

--- a/src/Collector/EntrypointCollector.php
+++ b/src/Collector/EntrypointCollector.php
@@ -9,7 +9,7 @@ use PHPStan\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMeth
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\InClassNode;
 use PHPStan\Reflection\MethodReflection;
-use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\MethodEntrypointProvider;
 
 /**
  * @implements Collector<InClassNode, list<string>>
@@ -18,12 +18,12 @@ class EntrypointCollector implements Collector
 {
 
     /**
-     * @var list<EntrypointProvider>
+     * @var list<MethodEntrypointProvider>
      */
     private array $entrypointProviders;
 
     /**
-     * @param list<EntrypointProvider> $entrypointProviders
+     * @param list<MethodEntrypointProvider> $entrypointProviders
      */
     public function __construct(
         array $entrypointProviders

--- a/src/Collector/EntrypointCollector.php
+++ b/src/Collector/EntrypointCollector.php
@@ -12,7 +12,7 @@ use PHPStan\Reflection\MethodReflection;
 use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
 
 /**
- * @implements Collector<InClassNode, list<string>>
+ * @implements Collector<InClassNode, list<string>|null>
  */
 class EntrypointCollector implements Collector
 {
@@ -39,12 +39,12 @@ class EntrypointCollector implements Collector
 
     /**
      * @param InClassNode $node
-     * @return list<string>
+     * @return list<string>|null
      */
     public function processNode(
         Node $node,
         Scope $scope
-    ): array
+    ): ?array
     {
         $entrypoints = [];
 
@@ -54,7 +54,7 @@ class EntrypointCollector implements Collector
             }
         }
 
-        return $entrypoints;
+        return $entrypoints === [] ? null : $entrypoints;
     }
 
     private function getRealDeclaringMethodKey(

--- a/src/Hierarchy/ClassHierarchy.php
+++ b/src/Hierarchy/ClassHierarchy.php
@@ -16,13 +16,6 @@ class ClassHierarchy
     private array $classDescendants = [];
 
     /**
-     * traitMethodKey => traitUserMethodKey[]
-     *
-     * @var array<string, list<MethodDefinition>>
-     */
-    private array $methodTraitUsages = [];
-
-    /**
      * traitUserMethodKey => declaringTraitMethodKey
      *
      * @var array<string, MethodDefinition>
@@ -39,7 +32,6 @@ class ClassHierarchy
         MethodDefinition $traitUsageMethodKey
     ): void
     {
-        $this->methodTraitUsages[$declaringTraitMethodKey->toString()][] = $traitUsageMethodKey;
         $this->declaringTraits[$traitUsageMethodKey->toString()] = $declaringTraitMethodKey;
     }
 
@@ -51,14 +43,6 @@ class ClassHierarchy
         return isset($this->classDescendants[$className])
             ? array_keys($this->classDescendants[$className])
             : [];
-    }
-
-    /**
-     * @return list<MethodDefinition>
-     */
-    public function getMethodTraitUsages(MethodDefinition $definition): array
-    {
-        return $this->methodTraitUsages[$definition->toString()] ?? [];
     }
 
     public function getDeclaringTraitMethodDefinition(MethodDefinition $definition): ?MethodDefinition

--- a/src/Provider/DoctrineEntrypointProvider.php
+++ b/src/Provider/DoctrineEntrypointProvider.php
@@ -7,7 +7,7 @@ use ReflectionClass;
 use ReflectionMethod;
 use const PHP_VERSION_ID;
 
-class DoctrineEntrypointProvider extends MethodBasedEntrypointProvider
+class DoctrineEntrypointProvider extends SimpleMethodEntrypointProvider
 {
 
     private bool $enabled;

--- a/src/Provider/DoctrineEntrypointProvider.php
+++ b/src/Provider/DoctrineEntrypointProvider.php
@@ -7,7 +7,7 @@ use ReflectionClass;
 use ReflectionMethod;
 use const PHP_VERSION_ID;
 
-class DoctrineEntrypointProvider implements EntrypointProvider
+class DoctrineEntrypointProvider extends MethodBasedEntrypointProvider
 {
 
     private bool $enabled;
@@ -17,7 +17,7 @@ class DoctrineEntrypointProvider implements EntrypointProvider
         $this->enabled = $enabled ?? $this->isDoctrineInstalled();
     }
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         if (!$this->enabled) {
             return false;

--- a/src/Provider/EntrypointProvider.php
+++ b/src/Provider/EntrypointProvider.php
@@ -2,13 +2,17 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Provider;
 
-use ReflectionMethod;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
 
 interface EntrypointProvider
 {
 
     public const TAG_ENTRYPOINT_PROVIDER = 'shipmonk.deadCode.entrypointProvider';
 
-    public function isEntrypoint(ReflectionMethod $method): bool;
+    /**
+     * @return list<MethodReflection>
+     */
+    public function getEntrypoints(ClassReflection $classReflection): array;
 
 }

--- a/src/Provider/EntrypointProvider.php
+++ b/src/Provider/EntrypointProvider.php
@@ -5,6 +5,17 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 
+/**
+ * Extension point for marking methods as entrypoints (not dead) based on custom reflection logic.
+ *
+ * Register in your phpstan.neon.dist:
+ *
+ * services:
+ *    -
+ *          class: App\MyEntrypointProvider
+ *          tags:
+ *              - shipmonk.deadCode.entrypointProvider
+ */
 interface EntrypointProvider
 {
 

--- a/src/Provider/MethodBasedEntrypointProvider.php
+++ b/src/Provider/MethodBasedEntrypointProvider.php
@@ -8,26 +8,25 @@ use ReflectionMethod;
 abstract class MethodBasedEntrypointProvider implements EntrypointProvider
 {
 
-    public function getEntrypoints(ClassReflection $reflection): array
+    public function getEntrypoints(ClassReflection $classReflection): array
     {
-        $nativeReflection = $reflection->getNativeReflection();
+        $nativeClassReflection = $classReflection->getNativeReflection();
 
         $entrypoints = [];
 
-        foreach ($nativeReflection->getMethods() as $method) {
-            if ($method->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
-                continue;
+        foreach ($nativeClassReflection->getMethods() as $nativeMethodReflection) {
+            if ($nativeMethodReflection->getDeclaringClass()->getName() !== $nativeClassReflection->getName()) {
+                continue; // skip methods from ancestors
             }
 
-            if ($this->isEntrypointMethod($method)) {
-                $entrypoints[] = $reflection->getNativeMethod($method->getName());
+            if ($this->isEntrypointMethod($nativeMethodReflection)) {
+                $entrypoints[] = $classReflection->getNativeMethod($nativeMethodReflection->getName());
             }
         }
 
         return $entrypoints;
     }
 
-    // TODO use PHPStan's MethodReflection?
     abstract protected function isEntrypointMethod(ReflectionMethod $method): bool;
 
 }

--- a/src/Provider/MethodBasedEntrypointProvider.php
+++ b/src/Provider/MethodBasedEntrypointProvider.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use PHPStan\Reflection\ClassReflection;
+use ReflectionMethod;
+
+abstract class MethodBasedEntrypointProvider implements EntrypointProvider
+{
+
+    public function getEntrypoints(ClassReflection $reflection): array
+    {
+        $nativeReflection = $reflection->getNativeReflection();
+
+        $entrypoints = [];
+
+        foreach ($nativeReflection->getMethods() as $method) {
+            if ($method->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
+                continue;
+            }
+
+            if ($this->isEntrypointMethod($method)) {
+                $entrypoints[] = $reflection->getNativeMethod($method->getName());
+            }
+        }
+
+        return $entrypoints;
+    }
+
+    // TODO use PHPStan's MethodReflection?
+    abstract protected function isEntrypointMethod(ReflectionMethod $method): bool;
+
+}

--- a/src/Provider/MethodEntrypointProvider.php
+++ b/src/Provider/MethodEntrypointProvider.php
@@ -16,7 +16,7 @@ use PHPStan\Reflection\MethodReflection;
  *          tags:
  *              - shipmonk.deadCode.entrypointProvider
  */
-interface EntrypointProvider
+interface MethodEntrypointProvider
 {
 
     public const TAG_ENTRYPOINT_PROVIDER = 'shipmonk.deadCode.entrypointProvider';

--- a/src/Provider/NetteEntrypointProvider.php
+++ b/src/Provider/NetteEntrypointProvider.php
@@ -19,7 +19,7 @@ use function substr;
 use function ucfirst;
 use const PREG_SET_ORDER;
 
-class NetteEntrypointProvider extends MethodBasedEntrypointProvider
+class NetteEntrypointProvider extends SimpleMethodEntrypointProvider
 {
 
     private ReflectionProvider $reflectionProvider;

--- a/src/Provider/NetteEntrypointProvider.php
+++ b/src/Provider/NetteEntrypointProvider.php
@@ -19,7 +19,7 @@ use function substr;
 use function ucfirst;
 use const PREG_SET_ORDER;
 
-class NetteEntrypointProvider implements EntrypointProvider
+class NetteEntrypointProvider extends MethodBasedEntrypointProvider
 {
 
     private ReflectionProvider $reflectionProvider;
@@ -40,7 +40,7 @@ class NetteEntrypointProvider implements EntrypointProvider
         $this->enabled = $enabled ?? $this->isNetteInstalled();
     }
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         if (!$this->enabled) {
             return false;

--- a/src/Provider/PhpStanEntrypointProvider.php
+++ b/src/Provider/PhpStanEntrypointProvider.php
@@ -5,7 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 use PHPStan\DependencyInjection\Container;
 use ReflectionMethod;
 
-class PhpStanEntrypointProvider implements EntrypointProvider
+class PhpStanEntrypointProvider extends MethodBasedEntrypointProvider
 {
 
     private bool $enabled;
@@ -18,7 +18,7 @@ class PhpStanEntrypointProvider implements EntrypointProvider
         $this->container = $container;
     }
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         if (!$this->enabled) {
             return false;

--- a/src/Provider/PhpStanEntrypointProvider.php
+++ b/src/Provider/PhpStanEntrypointProvider.php
@@ -5,7 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 use PHPStan\DependencyInjection\Container;
 use ReflectionMethod;
 
-class PhpStanEntrypointProvider extends MethodBasedEntrypointProvider
+class PhpStanEntrypointProvider extends SimpleMethodEntrypointProvider
 {
 
     private bool $enabled;

--- a/src/Provider/PhpUnitEntrypointProvider.php
+++ b/src/Provider/PhpUnitEntrypointProvider.php
@@ -14,7 +14,7 @@ use function is_string;
 use function strpos;
 use const PHP_VERSION_ID;
 
-class PhpUnitEntrypointProvider implements EntrypointProvider
+class PhpUnitEntrypointProvider implements MethodEntrypointProvider
 {
 
     private bool $enabled;

--- a/src/Provider/PhpUnitEntrypointProvider.php
+++ b/src/Provider/PhpUnitEntrypointProvider.php
@@ -12,7 +12,7 @@ use function is_string;
 use function strpos;
 use const PHP_VERSION_ID;
 
-class PhpUnitEntrypointProvider implements EntrypointProvider
+class PhpUnitEntrypointProvider extends MethodBasedEntrypointProvider // TODO better not to extend this one
 {
 
     /**
@@ -33,7 +33,7 @@ class PhpUnitEntrypointProvider implements EntrypointProvider
         $this->phpDocParser = $phpDocParser;
     }
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         if (!$this->enabled) {
             return false;

--- a/src/Provider/SimpleMethodEntrypointProvider.php
+++ b/src/Provider/SimpleMethodEntrypointProvider.php
@@ -5,7 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 use PHPStan\Reflection\ClassReflection;
 use ReflectionMethod;
 
-abstract class MethodBasedEntrypointProvider implements EntrypointProvider
+abstract class SimpleMethodEntrypointProvider implements MethodEntrypointProvider
 {
 
     public function getEntrypoints(ClassReflection $classReflection): array

--- a/src/Provider/SymfonyEntrypointProvider.php
+++ b/src/Provider/SymfonyEntrypointProvider.php
@@ -12,7 +12,7 @@ use ReflectionMethod;
 use Reflector;
 use const PHP_VERSION_ID;
 
-class SymfonyEntrypointProvider implements EntrypointProvider
+class SymfonyEntrypointProvider implements MethodEntrypointProvider
 {
 
     private bool $enabled;

--- a/src/Provider/VendorEntrypointProvider.php
+++ b/src/Provider/VendorEntrypointProvider.php
@@ -11,7 +11,7 @@ use function strlen;
 use function strpos;
 use function substr;
 
-class VendorEntrypointProvider implements EntrypointProvider
+class VendorEntrypointProvider extends MethodBasedEntrypointProvider
 {
 
     /**
@@ -27,7 +27,7 @@ class VendorEntrypointProvider implements EntrypointProvider
         $this->enabled = $enabled;
     }
 
-    public function isEntrypoint(ReflectionMethod $method): bool
+    public function isEntrypointMethod(ReflectionMethod $method): bool
     {
         if (!$this->enabled) {
             return false;

--- a/src/Provider/VendorEntrypointProvider.php
+++ b/src/Provider/VendorEntrypointProvider.php
@@ -11,7 +11,7 @@ use function strlen;
 use function strpos;
 use function substr;
 
-class VendorEntrypointProvider extends MethodBasedEntrypointProvider
+class VendorEntrypointProvider extends SimpleMethodEntrypointProvider
 {
 
     /**

--- a/src/Rule/DeadMethodRule.php
+++ b/src/Rule/DeadMethodRule.php
@@ -9,13 +9,12 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use ReflectionException;
 use ShipMonk\PHPStan\DeadCode\Collector\ClassDefinitionCollector;
+use ShipMonk\PHPStan\DeadCode\Collector\EntrypointCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector;
 use ShipMonk\PHPStan\DeadCode\Crate\Call;
 use ShipMonk\PHPStan\DeadCode\Crate\MethodDefinition;
 use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
-use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
 use function array_keys;
 use function array_merge;
 use function in_array;
@@ -51,23 +50,13 @@ class DeadMethodRule implements Rule
      */
     private array $methodsToMarkAsUsedCache = [];
 
-    /**
-     * @var list<EntrypointProvider>
-     */
-    private array $entrypointProviders;
-
-    /**
-     * @param list<EntrypointProvider> $entrypointProviders
-     */
     public function __construct(
         ReflectionProvider $reflectionProvider,
-        ClassHierarchy $classHierarchy,
-        array $entrypointProviders
+        ClassHierarchy $classHierarchy
     )
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->classHierarchy = $classHierarchy;
-        $this->entrypointProviders = $entrypointProviders;
     }
 
     public function getNodeType(): string
@@ -90,6 +79,7 @@ class DeadMethodRule implements Rule
 
         $methodDeclarationData = $node->get(ClassDefinitionCollector::class);
         $methodCallData = $node->get(MethodCallCollector::class);
+        $entrypointData = $node->get(EntrypointCollector::class);
 
         $declaredMethods = [];
 
@@ -143,15 +133,18 @@ class DeadMethodRule implements Rule
 
         unset($methodCallData);
 
+        foreach ($entrypointData as $file => $entrypointsInFile) {
+            foreach ($entrypointsInFile as $entrypoints) {
+                foreach ($entrypoints as $entrypoint) {
+                    unset($declaredMethods[$entrypoint]);
+                }
+            }
+        }
+
         $errors = [];
 
         foreach ($declaredMethods as $definitionString => [$file, $line]) {
             $definition = MethodDefinition::fromString($definitionString);
-
-            if ($this->isEntryPoint($definition)) {
-                continue;
-            }
-
             $errors[] = $this->buildError($definition, $file, $line);
         }
 
@@ -260,40 +253,6 @@ class DeadMethodRule implements Rule
             ->line($line)
             ->identifier('shipmonk.deadMethod')
             ->build();
-    }
-
-    private function isEntryPoint(MethodDefinition $methodDefinition): bool
-    {
-        if (!$this->reflectionProvider->hasClass($methodDefinition->className)) {
-            return false;
-        }
-
-        $reflection = $this->reflectionProvider->getClass($methodDefinition->className);
-
-        // if trait has users, we need to check entrypoint even from their context
-        if ($reflection->isTrait()) {
-            foreach ($this->classHierarchy->getMethodTraitUsages($methodDefinition) as $traitUsage) {
-                if ($this->isEntryPoint($traitUsage)) {
-                    return true;
-                }
-            }
-        }
-
-        try {
-            $methodReflection = $reflection
-                ->getNativeReflection()
-                ->getMethod($methodDefinition->methodName);
-        } catch (ReflectionException $e) {
-            return false; // to be removed once https://github.com/Roave/BetterReflection/pull/1453 is fixed
-        }
-
-        foreach ($this->entrypointProviders as $entrypointProvider) {
-            if ($entrypointProvider->isEntrypoint($methodReflection)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Rule/DeadMethodRule.php
+++ b/src/Rule/DeadMethodRule.php
@@ -229,11 +229,7 @@ class DeadMethodRule implements Rule
             $traitMethodDefinition = $this->classHierarchy->getDeclaringTraitMethodDefinition($methodDefinition);
 
             if ($traitMethodDefinition !== null) {
-                $result = array_merge(
-                    $result,
-                    [$traitMethodDefinition],
-                    $this->classHierarchy->getMethodTraitUsages($traitMethodDefinition),
-                );
+                $result[] = $traitMethodDefinition;
             }
         }
 

--- a/src/Rule/DeadMethodRule.php
+++ b/src/Rule/DeadMethodRule.php
@@ -5,7 +5,6 @@ namespace ShipMonk\PHPStan\DeadCode\Rule;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -25,8 +24,6 @@ use function strpos;
  */
 class DeadMethodRule implements Rule
 {
-
-    private ReflectionProvider $reflectionProvider;
 
     private ClassHierarchy $classHierarchy;
 
@@ -51,11 +48,9 @@ class DeadMethodRule implements Rule
     private array $methodsToMarkAsUsedCache = [];
 
     public function __construct(
-        ReflectionProvider $reflectionProvider,
         ClassHierarchy $classHierarchy
     )
     {
-        $this->reflectionProvider = $reflectionProvider;
         $this->classHierarchy = $classHierarchy;
     }
 

--- a/tests/Rule/DeadMethodRuleTest.php
+++ b/tests/Rule/DeadMethodRuleTest.php
@@ -70,7 +70,7 @@ class DeadMethodRuleTest extends RuleTestCase
      */
     public static function provideFiles(): iterable
     {
-        yield 'enum' => [__DIR__ . '/data/DeadMethodRule/enum.php', 80_000];
+        yield 'enum' => [__DIR__ . '/data/DeadMethodRule/enum.php', 8_01_00];
         yield 'code' => [__DIR__ . '/data/DeadMethodRule/basic.php'];
         yield 'ctor' => [__DIR__ . '/data/DeadMethodRule/ctor.php'];
         yield 'ctor-interface' => [__DIR__ . '/data/DeadMethodRule/ctor-interface.php'];
@@ -117,10 +117,10 @@ class DeadMethodRuleTest extends RuleTestCase
         yield 'array-map-1' => [__DIR__ . '/data/DeadMethodRule/array-map-1.php'];
         yield 'unknown-class' => [__DIR__ . '/data/DeadMethodRule/unknown-class.php'];
         yield 'provider-default' => [__DIR__ . '/data/DeadMethodRule/providers/default.php'];
-        yield 'provider-symfony' => [__DIR__ . '/data/DeadMethodRule/providers/symfony.php', 80_000];
-        yield 'provider-phpunit' => [__DIR__ . '/data/DeadMethodRule/providers/phpunit.php', 80_000];
-        yield 'provider-doctrine' => [__DIR__ . '/data/DeadMethodRule/providers/doctrine.php', 80_000];
-        yield 'provider-phpstan' => [__DIR__ . '/data/DeadMethodRule/providers/phpstan.php', 80_000];
+        yield 'provider-symfony' => [__DIR__ . '/data/DeadMethodRule/providers/symfony.php', 8_00_00];
+        yield 'provider-phpunit' => [__DIR__ . '/data/DeadMethodRule/providers/phpunit.php', 8_00_00];
+        yield 'provider-doctrine' => [__DIR__ . '/data/DeadMethodRule/providers/doctrine.php', 8_00_00];
+        yield 'provider-phpstan' => [__DIR__ . '/data/DeadMethodRule/providers/phpstan.php'];
         yield 'provider-nette' => [__DIR__ . '/data/DeadMethodRule/providers/nette.php'];
     }
 

--- a/tests/Rule/DeadMethodRuleTest.php
+++ b/tests/Rule/DeadMethodRuleTest.php
@@ -36,7 +36,6 @@ class DeadMethodRuleTest extends RuleTestCase
     protected function getRule(): DeadMethodRule
     {
         return new DeadMethodRule(
-            self::getContainer()->getByType(ReflectionProvider::class),
             new ClassHierarchy(),
         );
     }

--- a/tests/Rule/DeadMethodRuleTest.php
+++ b/tests/Rule/DeadMethodRuleTest.php
@@ -17,11 +17,11 @@ use ShipMonk\PHPStan\DeadCode\Collector\EntrypointCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector;
 use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineEntrypointProvider;
-use ShipMonk\PHPStan\DeadCode\Provider\EntrypointProvider;
-use ShipMonk\PHPStan\DeadCode\Provider\MethodBasedEntrypointProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\MethodEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\NetteEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpStanEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpUnitEntrypointProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\SimpleMethodEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\SymfonyEntrypointProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VendorEntrypointProvider;
 use function is_array;
@@ -125,12 +125,12 @@ class DeadMethodRuleTest extends RuleTestCase
     }
 
     /**
-     * @return list<EntrypointProvider>
+     * @return list<MethodEntrypointProvider>
      */
     private function getEntrypointProviders(): array
     {
         return [
-            new class extends MethodBasedEntrypointProvider
+            new class extends SimpleMethodEntrypointProvider
             {
 
                 public function isEntrypointMethod(ReflectionMethod $method): bool

--- a/tests/Rule/data/DeadMethodRule/providers/phpunit.php
+++ b/tests/Rule/data/DeadMethodRule/providers/phpunit.php
@@ -16,7 +16,9 @@ trait TraitTestCase {
 
 class SomeTest extends TestCase
 {
-    use TraitTestCase;
+    use TraitTestCase {
+        callBefore as anotherCallBefore;
+    }
 
     #[DataProvider('provideFromAttribute')]
     public function testFoo(string $arg): void


### PR DESCRIPTION
- This gains **performance boost at about ~20%** for our codebase
  - This is because static reflection is very costy and main process need to build all the reflection (costy ast parsing) again (even though that was already done in collectors)
  - In addition, PHPStan is not designed (performance-wise) for reflection heavy work in `Rule<CollectedDataNode>` as the reflection's underlying ast parser is doing ton of useless work, e.g. like parsing method bodies (such work is not useless in collectors/regular rules)
  - Thus, using reflection in `Rule<CollectedDataNode>` is almost always bad idea
- Contains also BC break of changed `EntrypointProvider` interface. 
  - This is needed to maintain the Symfony DIC constructors analysis precision. We do not have ClassHierarchy available in EntrypointProvider anymore and we need to be able to mark even children's methods as entrypoints.
  - Users can extend `SimpleMethodEntrypointProvider` for simple transition