### PR TITLE
Make Collector return type more explicit

### DIFF
--- a/src/Collector/EntrypointCollector.php
+++ b/src/Collector/EntrypointCollector.php
@@ -37,7 +37,7 @@ class EntrypointCollector implements Collector
 
     /**
      * @param InClassNode $node
-     * @return list<string>|null
+     * @return non-empty-list<string>|null
      */
     public function processNode(
         Node $node,

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -41,7 +41,7 @@ class MethodCallCollector implements Collector
     }
 
     /**
-     * @return list<string>|null
+     * @return non-empty-list<string>|null
      */
     public function processNode(
         Node $node,


### PR DESCRIPTION
while the previous return type was correct, it did not explicitly state/protect you from someone changing the collector and make it return a empty array.

thats a major problem which can happen, and I want to make sure this error will not bite you, like it did in my projects.

for in-detail context see https://github.com/phpstan/phpstan/discussions/11701#discussioncomment-10660711