### PR TITLE
feat(phpunit): consider data providers in children classes as valid test entrypoints

### DIFF
--- a/src/Provider/PhpUnitEntrypointProvider.php
+++ b/src/Provider/PhpUnitEntrypointProvider.php
@@ -43,10 +43,6 @@ class PhpUnitEntrypointProvider implements MethodEntrypointProvider
         $entrypoints = [];
 
         foreach ($classReflection->getNativeReflection()->getMethods() as $method) {
-            if ($method->getDeclaringClass()->getName() !== $classReflection->getName()) {
-                continue;
-            }
-
             $dataProviders = array_merge(
                 $this->getDataProvidersFromAnnotations($method->getDocComment()),
                 $this->getDataProvidersFromAttributes($method),

--- a/tests/Rule/data/DeadMethodRule/providers/phpunit.php
+++ b/tests/Rule/data/DeadMethodRule/providers/phpunit.php
@@ -80,3 +80,21 @@ class SomeTest extends TestCase
     }
 
 }
+
+abstract class TestCaseBase extends TestCase
+{
+    abstract public static function providerTest(): array;
+
+    #[DataProvider('providerTest')]
+    public function testFoo(string|null $phpValue, string|null $serialized): void
+    {
+    }
+}
+
+final class SomeExtendingTest extends TestCaseBase
+{
+    public static function providerTest(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
_I expected this would break some tests but it does not_ 🤷🏾‍♀️ 

```php
abstract class TestCaseBase extends TestCase
{
    abstract public static function providerTest(): array;

    #[DataProvider('providerTest')]
    public function testFoo(string|null $phpValue, string|null $serialized): void
    {
    }
}

final class SomeExtendingTest extends TestCaseBase
{
    public static function providerTest(): array
    {
        return [];
    }
}
```

Data providers in children classes are also valid entrypoints.