### PR TITLE
ReflectionUsageProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ includes:
     - vendor/shipmonk/dead-code-detector/rules.neon
 ```
 
-## Supported libraries
-- Any overridden method that originates in `vendor` is not reported as dead
-- We also support many magic calls in following libraries:
+## Supported libraries:
 
 #### Symfony:
 - **constructor calls for DIC services!**
@@ -71,6 +69,18 @@ parameters:
             phpunit:
                 enabled: true
 ```
+
+## Generic usage providers:
+
+#### Reflection:
+- Any constant or method accessed via `ReflectionClass` is detected as used
+  - e.g. `$reflection->getConstructor()`, `$reflection->getConstant('NAME')`, `$reflection->getMethods()`, ...
+
+#### Vendor:
+- Any overridden method that originates in `vendor` is not reported as dead
+  - e.g. implementing `Psr\Log\LoggerInterface::log` is automatically considered used
+
+Those providers are enabled by default, but you can disable them if needed.
 
 ## Customization:
 - If your application does some magic calls unknown to this library, you can implement your own usage provider.

--- a/rules.neon
+++ b/rules.neon
@@ -15,6 +15,13 @@ services:
             enabled: %shipmonkDeadCode.usageProviders.vendor.enabled%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.reflection.enabled%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider
         tags:
             - shipmonk.deadCode.memberUsageProvider
@@ -97,6 +104,8 @@ parameters:
         usageProviders:
             vendor:
                 enabled: true
+            reflection:
+                enabled: true
             phpstan:
                 enabled: true
             phpunit:
@@ -114,6 +123,9 @@ parametersSchema:
         reportTransitivelyDeadMethodAsSeparateError: bool()
         usageProviders: structure([
             vendor: structure([
+                enabled: bool()
+            ])
+            reflection: structure([
                 enabled: bool()
             ])
             phpstan: structure([

--- a/src/Provider/ReflectionUsageProvider.php
+++ b/src/Provider/ReflectionUsageProvider.php
@@ -1,0 +1,209 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use ReflectionClass;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use function array_key_first;
+use function count;
+use function in_array;
+
+class ReflectionUsageProvider implements MemberUsageProvider
+{
+
+    private bool $enabled;
+
+    public function __construct(bool $enabled)
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function getUsages(Node $node, Scope $scope): array
+    {
+        if (!$this->enabled) {
+            return [];
+        }
+
+        if ($node instanceof MethodCall) {
+            return $this->processMethodCall($node, $scope);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function processMethodCall(MethodCall $node, Scope $scope): array
+    {
+        $callerType = $scope->getType($node->var);
+        $methodNames = $this->getMethodNames($node, $scope);
+
+        $usedConstants = [];
+        $usedMethods = [];
+
+        foreach ($methodNames as $methodName) {
+            foreach ($callerType->getObjectClassReflections() as $reflection) {
+                if (!$reflection->is(ReflectionClass::class)) {
+                    continue;
+                }
+
+                foreach ($reflection->getActiveTemplateTypeMap()->getTypes() as $genericType) {
+                    foreach ($genericType->getObjectClassReflections() as $genericReflection) {
+                        $usedConstants = [
+                            ...$usedConstants,
+                            ...$this->extractConstantsUsedByReflection($methodName, $genericReflection, $node->getArgs(), $scope),
+                        ];
+                        $usedMethods = [
+                            ...$usedMethods,
+                            ...$this->extractMethodsUsedByReflection($methodName, $genericReflection, $node->getArgs(), $scope),
+                        ];
+                    }
+                }
+            }
+        }
+
+        return [
+            ...$usedConstants,
+            ...$usedMethods,
+        ];
+    }
+
+    /**
+     * @param array<Arg> $args
+     * @return list<ClassConstantUsage>
+     */
+    private function extractConstantsUsedByReflection(
+        string $methodName,
+        ClassReflection $genericReflection,
+        array $args,
+        Scope $scope
+    ): array
+    {
+        $usedConstants = [];
+
+        if ($methodName === 'getConstants' || $methodName === 'getReflectionConstants') {
+            foreach ($genericReflection->getNativeReflection()->getReflectionConstants() as $reflectionConstant) {
+                $usedConstants[] = $this->createConstantUsage($reflectionConstant->getDeclaringClass()->getName(), $reflectionConstant->getName());
+            }
+        }
+
+        if (($methodName === 'getConstant' || $methodName === 'getReflectionConstant') && count($args) === 1) {
+            $firstArg = $args[array_key_first($args)]; // @phpstan-ignore offsetAccess.notFound
+
+            foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {
+                if (!$genericReflection->hasConstant($constantString->getValue())) {
+                    continue;
+                }
+
+                $usedConstants[] = $this->createConstantUsage($genericReflection->getName(), $constantString->getValue());
+            }
+        }
+
+        return $usedConstants;
+    }
+
+    /**
+     * @param array<Arg> $args
+     * @return list<ClassMethodUsage>
+     */
+    private function extractMethodsUsedByReflection(
+        string $methodName,
+        ClassReflection $genericReflection,
+        array $args,
+        Scope $scope
+    ): array
+    {
+        $usedMethods = [];
+
+        if ($methodName === 'getMethods') {
+            foreach ($genericReflection->getNativeReflection()->getMethods() as $reflectionMethod) {
+                $usedMethods[] = $this->createMethodUsage($reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName());
+            }
+        }
+
+        if ($methodName === 'getMethod' && count($args) === 1) {
+            $firstArg = $args[array_key_first($args)]; // @phpstan-ignore offsetAccess.notFound
+
+            foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {
+                if (!$genericReflection->hasMethod($constantString->getValue())) {
+                    continue;
+                }
+
+                $usedMethods[] = $this->createMethodUsage($genericReflection->getName(), $constantString->getValue());
+            }
+        }
+
+        if (in_array($methodName, ['getConstructor', 'newInstance', 'newInstanceArgs'], true)) {
+            $constructor = $genericReflection->getNativeReflection()->getConstructor();
+
+            if ($constructor !== null) {
+                $usedMethods[] = $this->createMethodUsage($constructor->getDeclaringClass()->getName(), '__construct');
+            }
+        }
+
+        return $usedMethods;
+    }
+
+    /**
+     * @param NullsafeMethodCall|MethodCall|StaticCall|New_ $call
+     * @return list<string>
+     */
+    private function getMethodNames(CallLike $call, Scope $scope): array
+    {
+        if ($call instanceof New_) {
+            return ['__construct'];
+        }
+
+        if ($call->name instanceof Expr) {
+            $possibleMethodNames = [];
+
+            foreach ($scope->getType($call->name)->getConstantStrings() as $constantString) {
+                $possibleMethodNames[] = $constantString->getValue();
+            }
+
+            return $possibleMethodNames;
+        }
+
+        return [$call->name->toString()];
+    }
+
+    private function createConstantUsage(string $className, string $constantName): ClassConstantUsage
+    {
+        return new ClassConstantUsage(
+            null,
+            new ClassConstantRef(
+                $className,
+                $constantName,
+                false,
+            ),
+        );
+    }
+
+    private function createMethodUsage(string $className, string $methodName): ClassMethodUsage
+    {
+        return new ClassMethodUsage(
+            null,
+            new ClassMethodRef(
+                $className,
+                $methodName,
+                false,
+            ),
+        );
+    }
+
+}

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -319,7 +319,7 @@ class DeadCodeRuleTest extends RuleTestCase
 
         // method providers
         yield 'provider-vendor' => [__DIR__ . '/data/providers/vendor.php'];
-        yield 'provider-reflection' => [__DIR__ . '/data/providers/reflection.php'];
+        yield 'provider-reflection' => [__DIR__ . '/data/providers/reflection.php', 8_01_00];
         yield 'provider-symfony' => [__DIR__ . '/data/providers/symfony.php', 8_00_00];
         yield 'provider-phpunit' => [__DIR__ . '/data/providers/phpunit.php', 8_00_00];
         yield 'provider-doctrine' => [__DIR__ . '/data/providers/doctrine.php', 8_00_00];

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -28,6 +28,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\NetteUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpStanUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Transformer\FileSystem;
@@ -74,7 +75,7 @@ class DeadCodeRuleTest extends RuleTestCase
         return [
             new ProvidedUsagesCollector(
                 $reflectionProvider,
-                $this->getMethodUsageProviders(),
+                $this->getMemberUsageProviders(),
             ),
             new ClassDefinitionCollector(),
             new MethodCallCollector($this->trackMixedAccess),
@@ -318,6 +319,7 @@ class DeadCodeRuleTest extends RuleTestCase
 
         // method providers
         yield 'provider-vendor' => [__DIR__ . '/data/providers/vendor.php'];
+        yield 'provider-reflection' => [__DIR__ . '/data/providers/reflection.php'];
         yield 'provider-symfony' => [__DIR__ . '/data/providers/symfony.php', 8_00_00];
         yield 'provider-phpunit' => [__DIR__ . '/data/providers/phpunit.php', 8_00_00];
         yield 'provider-doctrine' => [__DIR__ . '/data/providers/doctrine.php', 8_00_00];
@@ -365,9 +367,10 @@ class DeadCodeRuleTest extends RuleTestCase
     /**
      * @return list<MemberUsageProvider>
      */
-    private function getMethodUsageProviders(): array
+    private function getMemberUsageProviders(): array
     {
         return [
+            new ReflectionUsageProvider(true),
             new class extends ReflectionBasedMemberUsageProvider
             {
 

--- a/tests/Rule/data/providers/reflection.php
+++ b/tests/Rule/data/providers/reflection.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace Reflection;
+
+
+interface MyParent
+{
+    const IFACE_CONSTANT = 1;
+}
+
+class Holder1 implements MyParent
+{
+    const CLASS_CONSTANT = 1;
+
+    public function used() {}
+    public function notUsed() {} // error: Unused Reflection\Holder1::notUsed
+}
+
+class Holder2
+{
+    const CONST1 = 1;
+    const CONST2 = 2; // error: Unused Reflection\Holder2::CONST2
+    const CONST3 = 3;
+
+    public function __construct() {}
+    public function notUsed() {} // error: Unused Reflection\Holder2::notUsed
+}
+
+class Holder3
+{
+    const CONST1 = 1;
+    const CONST2 = 2;
+    const CONST3 = 3;
+
+    public function used1() {}
+    public function used2() {}
+}
+
+class Holder4
+{
+    public function __construct() {} // error: Unused Reflection\Holder4::__construct
+}
+
+class Holder5
+{
+    public function __construct() {}
+}
+
+enum EnumHolder1 {
+    const CONST1 = 1;
+    public function used() {}
+}
+
+$reflection1 = new \ReflectionClass(Holder1::class);
+$reflection1->getConstants();
+$reflection1->getMethod('used');
+
+$reflection2 = new \ReflectionClass(Holder2::class);
+$reflection2->getReflectionConstant('CONST1');
+$reflection2->getConstant('CONST3');
+$reflection2->getConstructor();
+
+$reflection3 = new \ReflectionClass(Holder3::class);
+$reflection3->getMethods();
+$reflection3->getReflectionConstants();
+
+$reflection4 = new \ReflectionClass(Holder4::class);
+$reflection4->newInstanceWithoutConstructor();
+
+$reflection4 = new \ReflectionClass(Holder5::class);
+$reflection4->newInstance();
+
+$enumReflection1 = new \ReflectionClass(EnumHolder1::class);
+$enumReflection1->getConstants();
+$enumReflection1->getMethod('used');


### PR DESCRIPTION
- Any constant or method accessed via `ReflectionClass` is detected as used
  - e.g. `$reflection->getConstructor()`, `$reflection->getConstant('NAME')`, `$reflection->getMethods()`, 