### PR TITLE
Symfony & Doctrine: improve provider extendability

### DIFF
--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -51,7 +51,12 @@ class OldListenerHeuristics {
 class MySubscriber implements \Doctrine\Common\EventSubscriber {
 
     public function getSubscribedEvents() {
-        return [];
+        return [
+            'someMethod',
+        ];
     }
+
+    public function someMethod(): void {}
+    public function someMethod2(): void {}
 
 }

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -51,6 +51,10 @@ class SomeSubscriber implements EventSubscriberInterface
     {
     }
 
+    public function onNonsense(): void
+    {
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
@@ -62,6 +66,12 @@ class SomeSubscriber implements EventSubscriberInterface
 
 #[AsController]
 class HelloController
+{
+    public function __construct() {}
+}
+
+#[AsCommand('name')]
+class HelloCommand
 {
     public function __construct() {}
 }


### PR DESCRIPTION
With this, one can easily disable such provider and implement own child with adjusted logic while reusing most of the native logic.