### PR TITLE
ClassMemberRefs: encapsulate more

### DIFF
--- a/src/Collector/ProvidedUsagesCollector.php
+++ b/src/Collector/ProvidedUsagesCollector.php
@@ -74,10 +74,10 @@ class ProvidedUsagesCollector implements Collector
     ): void
     {
         $memberRef = $usage->getMemberRef();
-        $memberRefClass = $memberRef->className;
+        $memberRefClass = $memberRef->getClassName();
 
         $originRef = $usage->getOrigin();
-        $originRefClass = $originRef->className ?? null;
+        $originRefClass = $originRef === null ? null : $originRef->getClassName();
 
         $context = sprintf(
             "It was emitted as %s by %s for node '%s' in '%s' on line %s",
@@ -93,12 +93,12 @@ class ProvidedUsagesCollector implements Collector
                 throw new LogicException("Class '$memberRefClass' does not exist. $context");
             }
 
-            if ($memberRef instanceof ClassMethodRef && !$this->reflectionProvider->getClass($memberRefClass)->hasMethod($memberRef->memberName)) {
-                throw new LogicException("Method '{$memberRef->memberName}' does not exist in class '$memberRefClass'. $context");
+            if ($memberRef instanceof ClassMethodRef && !$this->reflectionProvider->getClass($memberRefClass)->hasMethod($memberRef->getMemberName())) {
+                throw new LogicException("Method '{$memberRef->getMemberName()}' does not exist in class '$memberRefClass'. $context");
             }
 
-            if ($memberRef instanceof ClassConstantRef && !$this->reflectionProvider->getClass($memberRefClass)->hasConstant($memberRef->memberName)) {
-                throw new LogicException("Constant '{$memberRef->memberName}' does not exist in class '$memberRefClass'. $context");
+            if ($memberRef instanceof ClassConstantRef && !$this->reflectionProvider->getClass($memberRefClass)->hasConstant($memberRef->getMemberName())) {
+                throw new LogicException("Constant '{$memberRef->getMemberName()}' does not exist in class '$memberRefClass'. $context");
             }
         }
 
@@ -110,8 +110,8 @@ class ProvidedUsagesCollector implements Collector
                 throw new LogicException("Class '{$originRefClass}' does not exist. $context");
             }
 
-            if (!$this->reflectionProvider->getClass($originRefClass)->hasMethod($originRef->memberName)) {
-                throw new LogicException("Method '{$originRef->memberName}' does not exist in class '$originRefClass'. $context");
+            if (!$this->reflectionProvider->getClass($originRefClass)->hasMethod($originRef->getMemberName())) {
+                throw new LogicException("Method '{$originRef->getMemberName()}' does not exist in class '$originRefClass'. $context");
             }
         }
     }

--- a/src/Error/BlackMember.php
+++ b/src/Error/BlackMember.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\PHPStan\DeadCode\Error;
 
 use LogicException;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberRef;
 use ShipMonk\PHPStan\DeadCode\Rule\DeadCodeRule;
 
@@ -24,11 +25,11 @@ class BlackMember
         int $line
     )
     {
-        if ($member->className === null) {
+        if ($member->getClassName() === null) {
             throw new LogicException('Class name must be known');
         }
 
-        if ($member->possibleDescendant) {
+        if ($member->isPossibleDescendant()) {
             throw new LogicException('Using possible descendant does not make sense here');
         }
 
@@ -39,7 +40,7 @@ class BlackMember
 
     public function getErrorIdentifier(): string
     {
-        return $this->member->memberType === ClassMemberRef::TYPE_CONSTANT
+        return $this->member instanceof ClassConstantRef
             ? DeadCodeRule::IDENTIFIER_CONSTANT
             : DeadCodeRule::IDENTIFIER_METHOD;
     }

--- a/src/Graph/ClassConstantRef.php
+++ b/src/Graph/ClassConstantRef.php
@@ -14,7 +14,7 @@ final class ClassConstantRef extends ClassMemberRef
         bool $possibleDescendant
     )
     {
-        parent::__construct($className, $constantName, $possibleDescendant, ClassMemberRef::TYPE_CONSTANT);
+        parent::__construct($className, $constantName, $possibleDescendant);
     }
 
     public static function buildKey(string $typeName, string $memberName): string

--- a/src/Graph/ClassMemberRef.php
+++ b/src/Graph/ClassMemberRef.php
@@ -11,33 +11,38 @@ abstract class ClassMemberRef
     public const TYPE_METHOD = 1;
     public const TYPE_CONSTANT = 2;
 
-    public const UNKNOWN_CLASS = '*';
+    private const UNKNOWN_CLASS = '*';
 
-    public ?string $className;
+    private ?string $className;
 
-    public string $memberName;
+    private string $memberName;
 
-    public bool $possibleDescendant;
+    private bool $possibleDescendant;
 
-    /**
-     * @var self::TYPE_*
-     */
-    public int $memberType;
-
-    /**
-     * @param self::TYPE_* $memberType
-     */
     public function __construct(
         ?string $className,
         string $memberName,
-        bool $possibleDescendant,
-        int $memberType
+        bool $possibleDescendant
     )
     {
         $this->className = $className;
         $this->memberName = $memberName;
         $this->possibleDescendant = $possibleDescendant;
-        $this->memberType = $memberType;
+    }
+
+    public function getClassName(): ?string
+    {
+        return $this->className;
+    }
+
+    public function getMemberName(): string
+    {
+        return $this->memberName;
+    }
+
+    public function isPossibleDescendant(): bool
+    {
+        return $this->possibleDescendant;
     }
 
     public function toHumanString(): string

--- a/src/Graph/ClassMemberUsage.php
+++ b/src/Graph/ClassMemberUsage.php
@@ -19,11 +19,11 @@ abstract class ClassMemberUsage
 
     public function __construct(?ClassMethodRef $origin)
     {
-        if ($origin !== null && $origin->possibleDescendant) {
+        if ($origin !== null && $origin->isPossibleDescendant()) {
             throw new LogicException('Origin should always be exact place in codebase.');
         }
 
-        if ($origin !== null && $origin->className === null) {
+        if ($origin !== null && $origin->getClassName() === null) {
             throw new LogicException('Origin should always be exact place in codebase, thus className should be known.');
         }
 

--- a/src/Graph/ClassMethodRef.php
+++ b/src/Graph/ClassMethodRef.php
@@ -18,7 +18,7 @@ final class ClassMethodRef extends ClassMemberRef
         bool $possibleDescendant
     )
     {
-        parent::__construct($className, $methodName, $possibleDescendant, ClassMemberRef::TYPE_METHOD);
+        parent::__construct($className, $methodName, $possibleDescendant);
     }
 
     public static function buildKey(string $typeName, string $memberName): string


### PR DESCRIPTION
Those are partially public api now (since users return them from `MemberUsageProvider`), lets not rely on `@immutable` only.