### PR TITLE
Doctrine: precise `Doctrine\Common\EventSubscriber` detection

### DIFF
--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -57,6 +57,6 @@ class MySubscriber implements \Doctrine\Common\EventSubscriber {
     }
 
     public function someMethod(): void {}
-    public function someMethod2(): void {}
+    public function someMethod2(): void {} // error: Unused Doctrine\MySubscriber::someMethod2
 
 }


### PR DESCRIPTION
Previously, all methods of `EventSubscriber` were marked as used. Now only those referenced in `getSubscribedEvents` + their transitive usages.