### PR TITLE
Symfony: autodetect constants used in yamls 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ includes:
 - `#[Route]` attributes
 - `EventSubscriberInterface::getSubscribedEvents`
 - `onKernelResponse`, `onKernelRequest`, etc
+- `!php const` references in `config` yamls
 
 #### Doctrine:
 - `#[AsEntityListener]` attribute

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -80,8 +80,7 @@
                     intval=>null,
                     strval=>null,
                     settype=>null,
-                    exit=>null,
-                    reset=>array_key_first
+                    exit=>null
                 "
             />
         </properties>

--- a/rules.neon
+++ b/rules.neon
@@ -112,6 +112,7 @@ parameters:
                 enabled: null
             symfony:
                 enabled: null
+                configDir: null
             doctrine:
                 enabled: null
             nette:
@@ -136,6 +137,7 @@ parametersSchema:
             ])
             symfony: structure([
                 enabled: schema(bool(), nullable())
+                configDir: schema(string(), nullable())
             ])
             doctrine: structure([
                 enabled: schema(bool(), nullable())

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -397,23 +397,12 @@ class DeadCodeRuleTest extends RuleTestCase
                 self::getContainer()->getByType(ReflectionProvider::class),
                 true,
             ),
-            $this->createSymfonyUsageProvider(),
-        ];
-    }
-
-    private function createSymfonyUsageProvider(): SymfonyUsageProvider
-    {
-        /** @var SymfonyUsageProvider|null $cache */
-        static $cache = null;
-
-        if ($cache === null) {
-            $cache = new SymfonyUsageProvider(
+            new SymfonyUsageProvider(
                 new Configuration(['containerXmlPath' => __DIR__ . '/data/providers/symfony/services.xml']), // @phpstan-ignore phpstanApi.constructor
                 true,
-            );
-        }
-
-        return $cache;
+                __DIR__ . '/data/providers/symfony/',
+            ),
+        ];
     }
 
     private function createPhpStanContainerMock(): Container

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -108,3 +108,7 @@ class DicClass3 {
         return new self();
     }
 }
+
+class Sftp {
+    const RETRY_LIMIT = 3; // used in yaml via !php/const
+}

--- a/tests/Rule/data/providers/symfony/config/sftp.yaml
+++ b/tests/Rule/data/providers/symfony/config/sftp.yaml
@@ -1,0 +1,7 @@
+some_package:
+    sftp:
+        options:
+            host: "%foo_ftp_host%"
+            username: "%foo_ftp_username%"
+            password: "%foo_ftp_password%"
+            maxTries: !php/const Symfony\Sftp::RETRY_LIMIT


### PR DESCRIPTION
e.g. `!php/const Foo\Bar::BAZ`