### PR TITLE
Ensure deterministic representative selection for dead cycles

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -36,6 +36,7 @@ use function array_slice;
 use function array_sum;
 use function array_values;
 use function in_array;
+use function ksort;
 use function sprintf;
 use function strpos;
 
@@ -487,6 +488,8 @@ class DeadCodeRule implements Rule, DiagnoseExtension
      */
     private function groupDeadMembers(): array
     {
+        ksort($this->blackMembers);
+
         $deadGroups = [];
 
         /** @var array<string, true> $deadMethodsWithCaller */

--- a/tests/Rule/data/grouping/order/one.php
+++ b/tests/Rule/data/grouping/order/one.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace GroupingOrder;
+
+class ClassOne
+{
+    public static function one()
+    {
+        ClassTwo::two();
+    }
+
+}

--- a/tests/Rule/data/grouping/order/two.php
+++ b/tests/Rule/data/grouping/order/two.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace GroupingOrder;
+
+class ClassTwo
+{
+    public static function two()
+    {
+        ClassOne::one();
+    }
+
+}


### PR DESCRIPTION
Otherwise, ignoring cycles by its representative could break as collectors emit class definitions in random order.