### PR TITLE
Cannot realpath phar paths

### DIFF
--- a/src/Excluder/TestsUsageExcluder.php
+++ b/src/Excluder/TestsUsageExcluder.php
@@ -209,6 +209,10 @@ class TestsUsageExcluder implements MemberUsageExcluder
 
     private function realpath(string $path): string
     {
+        if (strpos($path, 'phar://') === 0) {
+            return $path;
+        }
+
         $realPath = realpath($path);
 
         if ($realPath === false) {


### PR DESCRIPTION
Closes https://github.com/shipmonk-rnd/dead-code-detector/issues/152

[Docs](https://www.php.net/manual/en/function.realpath.php):
> The function realpath() will not work for a file which is inside a Phar as such path would be a virtual path, not a real one.