### PR TITLE
Replace `trackMixedAccess` config with `usageOverMixed` excluder

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,13 +281,15 @@ class UserFacade
 ## Calls over unknown types
 - In order to prevent false positives, we support even calls over unknown types (e.g. `$unknown->method()`) by marking all methods named `method` as used
   - Such behaviour might not be desired for strictly typed codebases, because e.g. single `new $unknown()` will mark all constructors as used
-  - Thus, you can disable this feature in your `phpstan.neon.dist`:
-- The same applies to constant fetches over unknown types (e.g. `$unknown::CONSTANT`)
+  - The same applies to constant fetches over unknown types (e.g. `$unknown::CONSTANT`)
+  - Thus, you can disable this feature in your `phpstan.neon.dist` by excluding such usages:
 
 ```neon
 parameters:
     shipmonkDeadCode:
-        trackMixedAccess: false
+        usageExcluders:
+            usageOverMixed:
+                enabled: true
 ```
 
 - If you want to check how many of those cases are present in your codebase, you can run PHPStan analysis with `-vvv` and you will see some diagnostics:

--- a/rules.neon
+++ b/rules.neon
@@ -10,8 +10,8 @@ services:
     -
         class: ShipMonk\PHPStan\DeadCode\Debug\DebugUsagePrinter
         arguments:
-            trackMixedAccess: %shipmonkDeadCode.trackMixedAccess%
             editorUrl: %editorUrl%
+            mixedExcluderEnabled: %shipmonkDeadCode.usageExcluders.usageOverMixed.enabled%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider
@@ -69,7 +69,13 @@ services:
             - shipmonk.deadCode.memberUsageExcluder
         arguments:
             enabled: %shipmonkDeadCode.usageExcluders.tests.enabled%
-            devPaths: %shipmonkDeadCode.usageExcluders.tests.devPaths%
+
+    -
+        class: ShipMonk\PHPStan\DeadCode\Excluder\MixedUsageExcluder
+        tags:
+            - shipmonk.deadCode.memberUsageExcluder
+        arguments:
+            enabled: %shipmonkDeadCode.usageExcluders.usageOverMixed.enabled%
 
 
     -
@@ -77,7 +83,6 @@ services:
         tags:
             - phpstan.collector
         arguments:
-            trackMixedAccess: %shipmonkDeadCode.trackMixedAccess%
             memberUsageExcluders: tagged(shipmonk.deadCode.memberUsageExcluder)
 
     -
@@ -85,7 +90,6 @@ services:
         tags:
             - phpstan.collector
         arguments:
-            trackMixedAccess: %shipmonkDeadCode.trackMixedAccess%
             memberUsageExcluders: tagged(shipmonk.deadCode.memberUsageExcluder)
 
     -
@@ -113,11 +117,12 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Compatibility\BackwardCompatibilityChecker
         arguments:
             servicesWithOldTag: tagged(shipmonk.deadCode.entrypointProvider)
+            trackMixedAccessParameterValue: %shipmonkDeadCode.trackMixedAccess%
 
 
 parameters:
     shipmonkDeadCode:
-        trackMixedAccess: true
+        trackMixedAccess: null
         reportTransitivelyDeadMethodAsSeparateError: false
         usageProviders:
             vendor:
@@ -139,12 +144,14 @@ parameters:
             tests:
                 enabled: false
                 devPaths: null
+            usageOverMixed:
+                enabled: false
         debug:
             usagesOf: []
 
 parametersSchema:
     shipmonkDeadCode: structure([
-        trackMixedAccess: bool()
+        trackMixedAccess: schema(bool(), nullable()) # deprecated, use usageExcluders.usageOverMixed.enabled
         reportTransitivelyDeadMethodAsSeparateError: bool()
         usageProviders: structure([
             vendor: structure([
@@ -174,6 +181,9 @@ parametersSchema:
             tests: structure([
                 enabled: bool()
                 devPaths: schema(listOf(string()), nullable())
+            ])
+            usageOverMixed: structure([
+                enabled: bool()
             ])
         ])
         debug: structure([

--- a/src/Collector/ConstantFetchCollector.php
+++ b/src/Collector/ConstantFetchCollector.php
@@ -35,8 +35,6 @@ class ConstantFetchCollector implements Collector
 
     private ReflectionProvider $reflectionProvider;
 
-    private bool $trackMixedAccess;
-
     /**
      * @var list<MemberUsageExcluder>
      */
@@ -47,12 +45,10 @@ class ConstantFetchCollector implements Collector
      */
     public function __construct(
         ReflectionProvider $reflectionProvider,
-        bool $trackMixedAccess,
         array $memberUsageExcluders
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        $this->trackMixedAccess = $trackMixedAccess;
         $this->memberUsageExcluders = $memberUsageExcluders;
     }
 
@@ -185,7 +181,7 @@ class ConstantFetchCollector implements Collector
             }
         }
 
-        if ($this->trackMixedAccess && $result === []) {
+        if ($result === []) {
             $result[] = null; // call over unknown type
         }
 

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -35,8 +35,6 @@ class MethodCallCollector implements Collector
 
     use BufferedUsageCollector;
 
-    private bool $trackMixedAccess;
-
     /**
      * @var list<MemberUsageExcluder>
      */
@@ -46,11 +44,9 @@ class MethodCallCollector implements Collector
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
-        bool $trackMixedAccess,
         array $memberUsageExcluders
     )
     {
-        $this->trackMixedAccess = $trackMixedAccess;
         $this->memberUsageExcluders = $memberUsageExcluders;
     }
 
@@ -270,13 +266,11 @@ class MethodCallCollector implements Collector
             $result[] = new ClassMethodRef($classReflection->getName(), $methodName, $possibleDescendant);
         }
 
-        if ($this->trackMixedAccess) {
-            $canBeObjectCall = !$typeNoNull->isObject()->no() && !$isStaticCall->yes();
-            $canBeClassStringCall = !$typeNoNull->isClassString()->no() && !$isStaticCall->no();
+        $canBeObjectCall = !$typeNoNull->isObject()->no() && !$isStaticCall->yes();
+        $canBeClassStringCall = !$typeNoNull->isClassString()->no() && !$isStaticCall->no();
 
-            if ($result === [] && ($canBeObjectCall || $canBeClassStringCall)) {
-                $result[] = new ClassMethodRef(null, $methodName, true); // call over unknown type
-            }
+        if ($result === [] && ($canBeObjectCall || $canBeClassStringCall)) {
+            $result[] = new ClassMethodRef(null, $methodName, true); // call over unknown type
         }
 
         return $result;

--- a/src/Compatibility/BackwardCompatibilityChecker.php
+++ b/src/Compatibility/BackwardCompatibilityChecker.php
@@ -7,6 +7,7 @@ use function array_map;
 use function count;
 use function get_class;
 use function implode;
+use function var_export;
 
 class BackwardCompatibilityChecker
 {
@@ -16,12 +17,18 @@ class BackwardCompatibilityChecker
      */
     private array $servicesWithOldTag;
 
+    private ?bool $trackMixedAccessParameterValue;
+
     /**
      * @param list<object> $servicesWithOldTag
      */
-    public function __construct(array $servicesWithOldTag)
+    public function __construct(
+        array $servicesWithOldTag,
+        ?bool $trackMixedAccessParameterValue
+    )
     {
         $this->servicesWithOldTag = $servicesWithOldTag;
+        $this->trackMixedAccessParameterValue = $trackMixedAccessParameterValue;
     }
 
     public function check(): void
@@ -32,6 +39,11 @@ class BackwardCompatibilityChecker
             $isAre = count($this->servicesWithOldTag) > 1 ? 'are' : 'is';
 
             throw new LogicException("Service$plural $serviceClassNames $isAre registered with old tag 'shipmonk.deadCode.entrypointProvider'. Please update the tag to 'shipmonk.deadCode.memberUsageProvider'.");
+        }
+
+        if ($this->trackMixedAccessParameterValue !== null) {
+            $newValue = var_export(!$this->trackMixedAccessParameterValue, true);
+            throw new LogicException("Using deprecated parameter 'trackMixedAccess', please use 'parameters.shipmonkDeadCode.usageExcluders.usageOverMixed.enabled: $newValue' instead.");
         }
     }
 

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -37,8 +37,6 @@ class DebugUsagePrinter
 
     private ReflectionProvider $reflectionProvider;
 
-    private bool $trackMixedAccess;
-
     private ?string $editorUrl;
 
     /**
@@ -48,18 +46,20 @@ class DebugUsagePrinter
      */
     private array $debugMembers;
 
+    private bool $mixedExcluderEnabled;
+
     public function __construct(
         Container $container,
         RelativePathHelper $relativePathHelper,
         ReflectionProvider $reflectionProvider,
         ?string $editorUrl,
-        bool $trackMixedAccess
+        bool $mixedExcluderEnabled
     )
     {
         $this->relativePathHelper = $relativePathHelper;
         $this->reflectionProvider = $reflectionProvider;
+        $this->mixedExcluderEnabled = $mixedExcluderEnabled;
         $this->editorUrl = $editorUrl;
-        $this->trackMixedAccess = $trackMixedAccess;
         $this->debugMembers = $this->buildDebugMemberKeys(
             // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible, missingType.checkedException, argument.type
             $container->getParameter('shipmonkDeadCode')['debug']['usagesOf'], // prevents https://github.com/phpstan/phpstan/issues/12740
@@ -71,7 +71,7 @@ class DebugUsagePrinter
      */
     public function printMixedMemberUsages(Output $output, array $mixedMemberUsages): void
     {
-        if ($mixedMemberUsages === [] || !$output->isDebug() || !$this->trackMixedAccess) {
+        if ($mixedMemberUsages === [] || !$output->isDebug() || $this->mixedExcluderEnabled) {
             return;
         }
 

--- a/src/Excluder/MixedUsageExcluder.php
+++ b/src/Excluder/MixedUsageExcluder.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Excluder;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+
+class MixedUsageExcluder implements MemberUsageExcluder
+{
+
+    private bool $enabled;
+
+    public function __construct(bool $enabled)
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'usageOverMixed';
+    }
+
+    public function shouldExclude(ClassMemberUsage $usage, Node $node, Scope $scope): bool
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        return $usage->getMemberRef()->getClassName() === null;
+    }
+
+}

--- a/tests/Rule/data/constants/mixed/untracked.php
+++ b/tests/Rule/data/constants/mixed/untracked.php
@@ -5,9 +5,9 @@ namespace DeadConstMixed2;
 
 class Clazz {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\Clazz::CONST1
-    const CONST2 = 1; // error: Unused DeadConstMixed2\Clazz::CONST2
-    const CONST3 = 1; // error: Unused DeadConstMixed2\Clazz::CONST3
+    const CONST1 = 1; // error: Unused DeadConstMixed2\Clazz::CONST1 (all usages excluded by usageOverMixed excluder)
+    const CONST2 = 1; // error: Unused DeadConstMixed2\Clazz::CONST2 (all usages excluded by usageOverMixed excluder)
+    const CONST3 = 1; // error: Unused DeadConstMixed2\Clazz::CONST3 (all usages excluded by usageOverMixed excluder)
     const CONST4 = 1; // error: Unused DeadConstMixed2\Clazz::CONST4
     const CONST5 = 1;
     const CONST6 = 1; // error: Unused DeadConstMixed2\Clazz::CONST6
@@ -18,9 +18,9 @@ class Clazz {
 
 interface IFace {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\IFace::CONST1
-    const CONST2 = 1; // error: Unused DeadConstMixed2\IFace::CONST2
-    const CONST3 = 1; // error: Unused DeadConstMixed2\IFace::CONST3
+    const CONST1 = 1; // error: Unused DeadConstMixed2\IFace::CONST1 (all usages excluded by usageOverMixed excluder)
+    const CONST2 = 1; // error: Unused DeadConstMixed2\IFace::CONST2 (all usages excluded by usageOverMixed excluder)
+    const CONST3 = 1; // error: Unused DeadConstMixed2\IFace::CONST3 (all usages excluded by usageOverMixed excluder)
     const CONST4 = 1;
     const CONST5 = 1; // error: Unused DeadConstMixed2\IFace::CONST5
 
@@ -28,9 +28,9 @@ interface IFace {
 
 class Implementor implements IFace {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\Implementor::CONST1
-    const CONST2 = 1; // error: Unused DeadConstMixed2\Implementor::CONST2
-    const CONST3 = 1; // error: Unused DeadConstMixed2\Implementor::CONST3
+    const CONST1 = 1; // error: Unused DeadConstMixed2\Implementor::CONST1 (all usages excluded by usageOverMixed excluder)
+    const CONST2 = 1; // error: Unused DeadConstMixed2\Implementor::CONST2 (all usages excluded by usageOverMixed excluder)
+    const CONST3 = 1; // error: Unused DeadConstMixed2\Implementor::CONST3 (all usages excluded by usageOverMixed excluder)
     const CONST4 = 1;
     const CONST5 = 1; // error: Unused DeadConstMixed2\Implementor::CONST5
     const CONST6 = 1;

--- a/tests/Rule/data/methods/mixed/untracked.php
+++ b/tests/Rule/data/methods/mixed/untracked.php
@@ -5,24 +5,24 @@ namespace DeadMixed2;
 
 class Clazz {
 
-    public function getter1() {} // error: Unused DeadMixed2\Clazz::getter1
-    public function getter2() {} // error: Unused DeadMixed2\Clazz::getter2
-    public function getter3() {} // error: Unused DeadMixed2\Clazz::getter3
+    public function getter1() {} // error: Unused DeadMixed2\Clazz::getter1 (all usages excluded by usageOverMixed excluder)
+    public function getter2() {} // error: Unused DeadMixed2\Clazz::getter2 (all usages excluded by usageOverMixed excluder)
+    public function getter3() {} // error: Unused DeadMixed2\Clazz::getter3 (all usages excluded by usageOverMixed excluder)
     public function getter4() {} // error: Unused DeadMixed2\Clazz::getter4
     public function getter5() {}
     public function getter6() {} // error: Unused DeadMixed2\Clazz::getter6
 
     public function someMethod() {} // error: Unused DeadMixed2\Clazz::someMethod
     public function nonStaticMethod() {} // error: Unused DeadMixed2\Clazz::nonStaticMethod
-    public static function staticMethod() {} // error: Unused DeadMixed2\Clazz::staticMethod
+    public static function staticMethod() {} // error: Unused DeadMixed2\Clazz::staticMethod (all usages excluded by usageOverMixed excluder)
 
 }
 
 interface IFace {
 
-    public function getter1(); // error: Unused DeadMixed2\IFace::getter1
-    public function getter2(); // error: Unused DeadMixed2\IFace::getter2
-    public function getter3(); // error: Unused DeadMixed2\IFace::getter3
+    public function getter1(); // error: Unused DeadMixed2\IFace::getter1 (all usages excluded by usageOverMixed excluder)
+    public function getter2(); // error: Unused DeadMixed2\IFace::getter2 (all usages excluded by usageOverMixed excluder)
+    public function getter3(); // error: Unused DeadMixed2\IFace::getter3 (all usages excluded by usageOverMixed excluder)
     public function getter4();
     public function getter5(); // error: Unused DeadMixed2\IFace::getter5
 
@@ -30,9 +30,9 @@ interface IFace {
 
 class Implementor implements IFace {
 
-    public function getter1() {} // error: Unused DeadMixed2\Implementor::getter1
-    public function getter2() {} // error: Unused DeadMixed2\Implementor::getter2
-    public function getter3() {} // error: Unused DeadMixed2\Implementor::getter3
+    public function getter1() {} // error: Unused DeadMixed2\Implementor::getter1 (all usages excluded by usageOverMixed excluder)
+    public function getter2() {} // error: Unused DeadMixed2\Implementor::getter2 (all usages excluded by usageOverMixed excluder)
+    public function getter3() {} // error: Unused DeadMixed2\Implementor::getter3 (all usages excluded by usageOverMixed excluder)
     public function getter4() {}
     public function getter5() {} // error: Unused DeadMixed2\Implementor::getter5
     public function getter6() {}


### PR DESCRIPTION
- This improves visibility as **debug mode now shows the usages (and their exclusion)**. 
- Previously, one would see `No usages found` instead, which is not correct.

Breaking change:
```diff
parameters:
    shipmonkDeadCode:
-         trackMixedAccess: false
+         usageExcluders:
+           usageOverMixed:
+               enabled: true
```
