### PR TITLE
Virtual usages always require note

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,18 @@ services:
 ```php
 
 use ReflectionMethod;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 
 class FuzzyTwigUsageProvider extends ReflectionBasedMemberUsageProvider
 {
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
     {
-        return $method->getDeclaringClass()->implementsInterface(UsedInTwigMarkerInterface::class);
+        if ($method->getDeclaringClass()->implementsInterface(UsedInTwigMarkerInterface::class)) {
+            return VirtualUsage::withNote('Probably used in twig');
+        }
+        return null;
     }
 
 }
@@ -341,13 +345,18 @@ parameters:
   - The easiest way to ignore it is via custom `MemberUsageProvider`:
 
 ```php
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 
 class IgnoreDeadInterfaceUsageProvider extends ReflectionBasedMemberUsageProvider
 {
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
     {
-        return $method->getDeclaringClass()->isInterface();
+        if ($method->getDeclaringClass()->isInterface()) {
+            return VirtualUsage::withNote('Interface method, kept for unification even when possibly unused');
+        }
+
+        return null;
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -127,16 +127,16 @@ services:
 ```php
 
 use ReflectionMethod;
-use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 
 class FuzzyTwigUsageProvider extends ReflectionBasedMemberUsageProvider
 {
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         if ($method->getDeclaringClass()->implementsInterface(UsedInTwigMarkerInterface::class)) {
-            return VirtualUsage::withNote('Probably used in twig');
+            return VirtualUsageData::withNote('Probably used in twig');
         }
         return null;
     }
@@ -345,15 +345,15 @@ parameters:
   - The easiest way to ignore it is via custom `MemberUsageProvider`:
 
 ```php
-use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 
 class IgnoreDeadInterfaceUsageProvider extends ReflectionBasedMemberUsageProvider
 {
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         if ($method->getDeclaringClass()->isInterface()) {
-            return VirtualUsage::withNote('Interface method, kept for unification even when possibly unused');
+            return VirtualUsageData::withNote('Interface method, kept for unification even when possibly unused');
         }
 
         return null;

--- a/src/Graph/UsageOrigin.php
+++ b/src/Graph/UsageOrigin.php
@@ -50,9 +50,9 @@ final class UsageOrigin
     /**
      * Creates virtual usage origin with no reference to any place in code
      *
-     * @param ?string $note More detailed identification why provider emitted this virtual usage
+     * @param string $note More detailed info why provider emitted this virtual usage
      */
-    public static function createVirtual(MemberUsageProvider $provider, ?string $note = null): self
+    public static function createVirtual(MemberUsageProvider $provider, string $note): self
     {
         return new self(
             null,

--- a/src/Graph/UsageOrigin.php
+++ b/src/Graph/UsageOrigin.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
 use function get_class;
 
 /**
@@ -49,10 +50,8 @@ final class UsageOrigin
 
     /**
      * Creates virtual usage origin with no reference to any place in code
-     *
-     * @param string $note More detailed info why provider emitted this virtual usage
      */
-    public static function createVirtual(MemberUsageProvider $provider, string $note): self
+    public static function createVirtual(MemberUsageProvider $provider, VirtualUsageData $data): self
     {
         return new self(
             null,
@@ -60,7 +59,7 @@ final class UsageOrigin
             null,
             null,
             get_class($provider),
-            $note,
+            $data->getNote(),
         );
     }
 

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -216,7 +216,7 @@ class DoctrineUsageProvider implements MemberUsageProvider
     private function createMethodUsage(ExtendedMethodReflection $methodReflection, string $note): ClassMethodUsage
     {
         return new ClassMethodUsage(
-            UsageOrigin::createVirtual($this, $note),
+            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
             new ClassMethodRef(
                 $methodReflection->getDeclaringClass()->getName(),
                 $methodReflection->getName(),

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -39,7 +39,7 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->enabled = $enabled ?? $this->isNetteInstalled();
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         if (!$this->enabled) {
             return null;
@@ -53,39 +53,39 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         return $this->isNetteMagic($reflection, $methodName);
     }
 
-    private function isNetteMagic(ClassReflection $reflection, string $methodName): ?VirtualUsage
+    private function isNetteMagic(ClassReflection $reflection, string $methodName): ?VirtualUsageData
     {
         if (
             $reflection->is(SignalReceiver::class)
             && strpos($methodName, 'handle') === 0
         ) {
-            return VirtualUsage::withNote('Signal handler method');
+            return VirtualUsageData::withNote('Signal handler method');
         }
 
         if (
             $reflection->is(Container::class)
             && strpos($methodName, 'createComponent') === 0
         ) {
-            return VirtualUsage::withNote('Component factory method');
+            return VirtualUsageData::withNote('Component factory method');
         }
 
         if (
             $reflection->is(Control::class)
             && strpos($methodName, 'render') === 0
         ) {
-            return VirtualUsage::withNote('Render method');
+            return VirtualUsageData::withNote('Render method');
         }
 
         if (
             $reflection->is(Presenter::class) && strpos($methodName, 'action') === 0
         ) {
-            return VirtualUsage::withNote('Presenter action method');
+            return VirtualUsageData::withNote('Presenter action method');
         }
 
         if (
             $reflection->is(Presenter::class) && strpos($methodName, 'inject') === 0
         ) {
-            return VirtualUsage::withNote('Presenter inject method');
+            return VirtualUsageData::withNote('Presenter inject method');
         }
 
         if (
@@ -108,7 +108,7 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
                 $property = $this->getMagicProperties($reflection)[$name] ?? null;
 
                 if ($property !== null) {
-                    return VirtualUsage::withNote('Access method for magic property ' . $name);
+                    return VirtualUsageData::withNote('Access method for magic property ' . $name);
                 }
             }
         }

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -39,10 +39,10 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->enabled = $enabled ?? $this->isNetteInstalled();
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
     {
         if (!$this->enabled) {
-            return false;
+            return null;
         }
 
         $methodName = $method->getName();
@@ -53,37 +53,39 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         return $this->isNetteMagic($reflection, $methodName);
     }
 
-    private function isNetteMagic(ClassReflection $reflection, string $methodName): bool
+    private function isNetteMagic(ClassReflection $reflection, string $methodName): ?VirtualUsage
     {
         if (
             $reflection->is(SignalReceiver::class)
             && strpos($methodName, 'handle') === 0
         ) {
-            return true;
+            return VirtualUsage::withNote('Signal handler method');
         }
 
         if (
             $reflection->is(Container::class)
             && strpos($methodName, 'createComponent') === 0
         ) {
-            return true;
+            return VirtualUsage::withNote('Component factory method');
         }
 
         if (
             $reflection->is(Control::class)
             && strpos($methodName, 'render') === 0
         ) {
-            return true;
+            return VirtualUsage::withNote('Render method');
         }
 
         if (
-            $reflection->is(Presenter::class)
-            && (
-                strpos($methodName, 'action') === 0
-                || strpos($methodName, 'inject') === 0
-            )
+            $reflection->is(Presenter::class) && strpos($methodName, 'action') === 0
         ) {
-            return true;
+            return VirtualUsage::withNote('Presenter action method');
+        }
+
+        if (
+            $reflection->is(Presenter::class) && strpos($methodName, 'inject') === 0
+        ) {
+            return VirtualUsage::withNote('Presenter inject method');
         }
 
         if (
@@ -106,12 +108,12 @@ class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
                 $property = $this->getMagicProperties($reflection)[$name] ?? null;
 
                 if ($property !== null) {
-                    return true;
+                    return VirtualUsage::withNote('Access method for magic property ' . $name);
                 }
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/Provider/PhpStanUsageProvider.php
+++ b/src/Provider/PhpStanUsageProvider.php
@@ -18,7 +18,7 @@ class PhpStanUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->container = $container;
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         if (!$this->enabled) {
             return null;
@@ -27,14 +27,14 @@ class PhpStanUsageProvider extends ReflectionBasedMemberUsageProvider
         return $this->isConstructorCallInPhpStanDic($method);
     }
 
-    private function isConstructorCallInPhpStanDic(ReflectionMethod $method): ?VirtualUsage
+    private function isConstructorCallInPhpStanDic(ReflectionMethod $method): ?VirtualUsageData
     {
         if (!$method->isConstructor()) {
             return null;
         }
 
         if ($this->container->findServiceNamesByType($method->getDeclaringClass()->getName()) !== []) {
-            return VirtualUsage::withNote('Constructor call from PHPStan DI container');
+            return VirtualUsageData::withNote('Constructor call from PHPStan DI container');
         }
 
         return null;

--- a/src/Provider/PhpStanUsageProvider.php
+++ b/src/Provider/PhpStanUsageProvider.php
@@ -18,22 +18,26 @@ class PhpStanUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->container = $container;
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
     {
         if (!$this->enabled) {
-            return false;
+            return null;
         }
 
         return $this->isConstructorCallInPhpStanDic($method);
     }
 
-    private function isConstructorCallInPhpStanDic(ReflectionMethod $method): bool
+    private function isConstructorCallInPhpStanDic(ReflectionMethod $method): ?VirtualUsage
     {
         if (!$method->isConstructor()) {
-            return false;
+            return null;
         }
 
-        return $this->container->findServiceNamesByType($method->getDeclaringClass()->getName()) !== [];
+        if ($this->container->findServiceNamesByType($method->getDeclaringClass()->getName()) !== []) {
+            return VirtualUsage::withNote('Constructor call from PHPStan DI container');
+        }
+
+        return null;
     }
 
 }

--- a/src/Provider/PhpUnitUsageProvider.php
+++ b/src/Provider/PhpUnitUsageProvider.php
@@ -57,12 +57,12 @@ class PhpUnitUsageProvider implements MemberUsageProvider
 
             foreach ($dataProviders as $dataProvider) {
                 if ($classReflection->hasNativeMethod($dataProvider)) {
-                    $usages[] = $this->createUsage($classReflection->getNativeMethod($dataProvider), 'data provider method');
+                    $usages[] = $this->createUsage($classReflection->getNativeMethod($dataProvider), 'Data provider method');
                 }
             }
 
             if ($this->isTestCaseMethod($method)) {
-                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), 'test method');
+                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), 'Test method');
             }
         }
 

--- a/src/Provider/PhpUnitUsageProvider.php
+++ b/src/Provider/PhpUnitUsageProvider.php
@@ -145,7 +145,7 @@ class PhpUnitUsageProvider implements MemberUsageProvider
     private function createUsage(ExtendedMethodReflection $getNativeMethod, string $reason): ClassMethodUsage
     {
         return new ClassMethodUsage(
-            UsageOrigin::createVirtual($this, $reason),
+            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($reason)),
             new ClassMethodRef(
                 $getNativeMethod->getDeclaringClass()->getName(),
                 $getNativeMethod->getName(),

--- a/src/Provider/ReflectionBasedMemberUsageProvider.php
+++ b/src/Provider/ReflectionBasedMemberUsageProvider.php
@@ -36,12 +36,12 @@ abstract class ReflectionBasedMemberUsageProvider implements MemberUsageProvider
         return [];
     }
 
-    protected function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    protected function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         return null; // Expected to be overridden by subclasses.
     }
 
-    protected function shouldMarkConstantAsUsed(ReflectionClassConstant $constant): ?VirtualUsage
+    protected function shouldMarkConstantAsUsed(ReflectionClassConstant $constant): ?VirtualUsageData
     {
         return null; // Expected to be overridden by subclasses.
     }
@@ -63,7 +63,7 @@ abstract class ReflectionBasedMemberUsageProvider implements MemberUsageProvider
             $usage = $this->shouldMarkMethodAsUsed($nativeMethodReflection);
 
             if ($usage !== null) {
-                $usages[] = $this->createMethodUsage($nativeMethodReflection, $usage->getNote());
+                $usages[] = $this->createMethodUsage($nativeMethodReflection, $usage);
             }
         }
 
@@ -87,17 +87,17 @@ abstract class ReflectionBasedMemberUsageProvider implements MemberUsageProvider
             $usage = $this->shouldMarkConstantAsUsed($nativeConstantReflection);
 
             if ($usage !== null) {
-                $usages[] = $this->createConstantUsage($nativeConstantReflection, $usage->getNote());
+                $usages[] = $this->createConstantUsage($nativeConstantReflection, $usage);
             }
         }
 
         return $usages;
     }
 
-    private function createConstantUsage(ReflectionClassConstant $constantReflection, string $note): ClassConstantUsage
+    private function createConstantUsage(ReflectionClassConstant $constantReflection, VirtualUsageData $data): ClassConstantUsage
     {
         return new ClassConstantUsage(
-            UsageOrigin::createVirtual($this, $note),
+            UsageOrigin::createVirtual($this, $data),
             new ClassConstantRef(
                 $constantReflection->getDeclaringClass()->getName(),
                 $constantReflection->getName(),
@@ -106,10 +106,10 @@ abstract class ReflectionBasedMemberUsageProvider implements MemberUsageProvider
         );
     }
 
-    private function createMethodUsage(ReflectionMethod $methodReflection, string $note): ClassMethodUsage
+    private function createMethodUsage(ReflectionMethod $methodReflection, VirtualUsageData $data): ClassMethodUsage
     {
         return new ClassMethodUsage(
-            UsageOrigin::createVirtual($this, $note),
+            UsageOrigin::createVirtual($this, $data),
             new ClassMethodRef(
                 $methodReflection->getDeclaringClass()->getName(),
                 $methodReflection->getName(),

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -508,7 +508,7 @@ class SymfonyUsageProvider implements MemberUsageProvider
     private function createUsage(ExtendedMethodReflection $methodReflection, string $reason): ClassMethodUsage
     {
         return new ClassMethodUsage(
-            UsageOrigin::createVirtual($this, $reason),
+            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($reason)),
             new ClassMethodRef(
                 $methodReflection->getDeclaringClass()->getName(),
                 $methodReflection->getName(),
@@ -594,7 +594,7 @@ class SymfonyUsageProvider implements MemberUsageProvider
             }
 
             $usages[] = new ClassConstantUsage(
-                UsageOrigin::createVirtual($this, 'Referenced in config in ' . $configFile),
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Referenced in config in ' . $configFile)),
                 new ClassConstantRef(
                     $classReflection->getName(),
                     $constantName,

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -50,6 +50,8 @@ class SymfonyUsageProvider implements MemberUsageProvider
 
     private bool $enabled;
 
+    private ?string $configDir;
+
     /**
      * class => [method => true]
      *
@@ -58,9 +60,9 @@ class SymfonyUsageProvider implements MemberUsageProvider
     private array $dicCalls = [];
 
     /**
-     * class => [constant]
+     * class => [constant => config file]
      *
-     * @var array<string, list<string>>
+     * @var array<string, array<string, string>>
      */
     private array $dicConstants = [];
 
@@ -71,15 +73,15 @@ class SymfonyUsageProvider implements MemberUsageProvider
     )
     {
         $this->enabled = $enabled ?? $this->isSymfonyInstalled();
-        $resolvedConfigDir = $configDir ?? $this->autodetectConfigDir();
+        $this->configDir = $configDir ?? $this->autodetectConfigDir();
         $containerXmlPath = $this->getContainerXmlPath($container);
 
         if ($this->enabled && $containerXmlPath !== null) {
             $this->fillDicClasses($containerXmlPath);
         }
 
-        if ($this->enabled && $resolvedConfigDir !== null) {
-            $this->fillDicConstants($resolvedConfigDir);
+        if ($this->enabled && $this->configDir !== null) {
+            $this->fillDicConstants($this->configDir);
         }
     }
 
@@ -211,15 +213,17 @@ class SymfonyUsageProvider implements MemberUsageProvider
 
         foreach ($nativeReflection->getMethods() as $method) {
             if (isset($this->dicCalls[$className][$method->getName()])) {
-                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), 'called via DIC');
+                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), 'Called via DIC');
             }
 
             if ($method->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
                 continue;
             }
 
-            if ($this->shouldMarkAsUsed($method)) {
-                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), null);
+            $note = $this->shouldMarkAsUsed($method);
+
+            if ($note !== null) {
+                $usages[] = $this->createUsage($classReflection->getNativeMethod($method->getName()), $note);
             }
         }
 
@@ -296,15 +300,37 @@ class SymfonyUsageProvider implements MemberUsageProvider
         return $usages;
     }
 
-    protected function shouldMarkAsUsed(ReflectionMethod $method): bool
+    protected function shouldMarkAsUsed(ReflectionMethod $method): ?string
     {
-        return $this->isBundleConstructor($method)
-            || $this->isEventListenerMethodWithAsEventListenerAttribute($method)
-            || $this->isAutowiredWithRequiredAttribute($method)
-            || $this->isConstructorWithAsCommandAttribute($method)
-            || $this->isConstructorWithAsControllerAttribute($method)
-            || $this->isMethodWithRouteAttribute($method)
-            || $this->isProbablySymfonyListener($method);
+        if ($this->isBundleConstructor($method)) {
+            return 'Bundle constructor (created by Kernel)';
+        }
+
+        if ($this->isEventListenerMethodWithAsEventListenerAttribute($method)) {
+            return 'Event listener method via #[AsEventListener] attribute';
+        }
+
+        if ($this->isAutowiredWithRequiredAttribute($method)) {
+            return 'Autowired with #[Required] (called by DIC)';
+        }
+
+        if ($this->isConstructorWithAsCommandAttribute($method)) {
+            return 'Class has #[AsCommand] attribute';
+        }
+
+        if ($this->isConstructorWithAsControllerAttribute($method)) {
+            return 'Class has #[AsController] attribute';
+        }
+
+        if ($this->isMethodWithRouteAttribute($method)) {
+            return 'Route method via #[Route] attribute';
+        }
+
+        if ($this->isProbablySymfonyListener($method)) {
+            return 'Probable listener method';
+        }
+
+        return null;
     }
 
     protected function fillDicClasses(string $containerXmlPath): void
@@ -479,7 +505,7 @@ class SymfonyUsageProvider implements MemberUsageProvider
             || InstalledVersions::isInstalled('symfony/dependency-injection');
     }
 
-    private function createUsage(ExtendedMethodReflection $methodReflection, ?string $reason): ClassMethodUsage
+    private function createUsage(ExtendedMethodReflection $methodReflection, string $reason): ClassMethodUsage
     {
         return new ClassMethodUsage(
             UsageOrigin::createVirtual($this, $reason),
@@ -551,7 +577,7 @@ class SymfonyUsageProvider implements MemberUsageProvider
 
         foreach ($matches[1] as $usedConstants) {
             [$className, $constantName] = explode('::', $usedConstants); // @phpstan-ignore offsetAccess.notFound
-            $this->dicConstants[$className][] = $constantName;
+            $this->dicConstants[$className][$constantName] = $yamlFile;
         }
     }
 
@@ -562,13 +588,13 @@ class SymfonyUsageProvider implements MemberUsageProvider
     {
         $usages = [];
 
-        foreach ($this->dicConstants[$classReflection->getName()] ?? [] as $constantName) {
+        foreach ($this->dicConstants[$classReflection->getName()] ?? [] as $constantName => $configFile) {
             if (!$classReflection->hasConstant($constantName)) {
                 continue;
             }
 
             $usages[] = new ClassConstantUsage(
-                UsageOrigin::createVirtual($this, 'used in DIC'),
+                UsageOrigin::createVirtual($this, 'Referenced in config in ' . $configFile),
                 new ClassConstantRef(
                     $classReflection->getName(),
                     $constantName,

--- a/src/Provider/VendorUsageProvider.php
+++ b/src/Provider/VendorUsageProvider.php
@@ -26,36 +26,38 @@ class VendorUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->enabled = $enabled;
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
     {
         if (!$this->enabled) {
-            return false;
+            return null;
         }
 
         $reflectionClass = $method->getDeclaringClass();
         $methodName = $method->getName();
 
+        $usage = VirtualUsage::withNote('Method overrides vendor one, thus is expected to be used by vendor code');
+
         do {
             if ($this->isForeignMethod($reflectionClass, $methodName)) {
-                return true;
+                return $usage;
             }
 
             foreach ($reflectionClass->getInterfaces() as $interface) {
                 if ($this->isForeignMethod($interface, $methodName)) {
-                    return true;
+                    return $usage;
                 }
             }
 
             foreach ($reflectionClass->getTraits() as $trait) {
                 if ($this->isForeignMethod($trait, $methodName)) {
-                    return true;
+                    return $usage;
                 }
             }
 
             $reflectionClass = $reflectionClass->getParentClass();
         } while ($reflectionClass !== false);
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/Provider/VendorUsageProvider.php
+++ b/src/Provider/VendorUsageProvider.php
@@ -26,7 +26,7 @@ class VendorUsageProvider extends ReflectionBasedMemberUsageProvider
         $this->enabled = $enabled;
     }
 
-    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
         if (!$this->enabled) {
             return null;
@@ -35,7 +35,7 @@ class VendorUsageProvider extends ReflectionBasedMemberUsageProvider
         $reflectionClass = $method->getDeclaringClass();
         $methodName = $method->getName();
 
-        $usage = VirtualUsage::withNote('Method overrides vendor one, thus is expected to be used by vendor code');
+        $usage = VirtualUsageData::withNote('Method overrides vendor one, thus is expected to be used by vendor code');
 
         do {
             if ($this->isForeignMethod($reflectionClass, $methodName)) {

--- a/src/Provider/VirtualUsage.php
+++ b/src/Provider/VirtualUsage.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+class VirtualUsage
+{
+
+    private string $note;
+
+    private function __construct(string $note)
+    {
+        $this->note = $note;
+    }
+
+    public static function withNote(string $note): self
+    {
+        return new self($note);
+    }
+
+    public function getNote(): string
+    {
+        return $this->note;
+    }
+
+}

--- a/src/Provider/VirtualUsageData.php
+++ b/src/Provider/VirtualUsageData.php
@@ -2,7 +2,7 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Provider;
 
-class VirtualUsage
+class VirtualUsageData
 {
 
     private string $note;
@@ -12,6 +12,9 @@ class VirtualUsage
         $this->note = $note;
     }
 
+    /**
+     * @param string $note More detailed info why provider emitted this virtual usage
+     */
     public static function withNote(string $note): self
     {
         return new self($note);

--- a/src/Provider/VirtualUsageData.php
+++ b/src/Provider/VirtualUsageData.php
@@ -2,7 +2,7 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Provider;
 
-class VirtualUsageData
+final class VirtualUsageData
 {
 
     private string $note;

--- a/tests/AllServicesInConfigTest.php
+++ b/tests/AllServicesInConfigTest.php
@@ -23,7 +23,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
-use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
 use ShipMonk\PHPStan\DeadCode\Transformer\RemoveClassMemberVisitor;
 use ShipMonk\PHPStan\DeadCode\Transformer\RemoveDeadCodeTransformer;
 use function array_keys;
@@ -57,7 +57,7 @@ class AllServicesInConfigTest extends PHPStanTestCase
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
         $missingClassNames = [];
         $excluded = [
-            VirtualUsage::class,
+            VirtualUsageData::class,
             UsageOrigin::class,
             ClassMethodUsage::class,
             ClassMethodRef::class,

--- a/tests/AllServicesInConfigTest.php
+++ b/tests/AllServicesInConfigTest.php
@@ -23,6 +23,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
 use ShipMonk\PHPStan\DeadCode\Transformer\RemoveClassMemberVisitor;
 use ShipMonk\PHPStan\DeadCode\Transformer\RemoveDeadCodeTransformer;
 use function array_keys;
@@ -56,6 +57,7 @@ class AllServicesInConfigTest extends PHPStanTestCase
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
         $missingClassNames = [];
         $excluded = [
+            VirtualUsage::class,
             UsageOrigin::class,
             ClassMethodUsage::class,
             ClassMethodRef::class,

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -38,6 +38,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
 use ShipMonk\PHPStan\DeadCode\Transformer\FileSystem;
 use function file_get_contents;
 use function is_array;
@@ -576,9 +577,13 @@ class DeadCodeRuleTest extends RuleTestCase
             new class extends ReflectionBasedMemberUsageProvider
             {
 
-                public function shouldMarkMethodAsUsed(ReflectionMethod $method): bool
+                public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
                 {
-                    return $method->getDeclaringClass()->getName() === 'DeadEntrypoint\Entrypoint';
+                    if ($method->getDeclaringClass()->getName() === 'DeadEntrypoint\Entrypoint') {
+                        return VirtualUsage::withNote('test');
+                    }
+
+                    return null;
                 }
 
             },

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -38,7 +38,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider;
-use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsage;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
 use ShipMonk\PHPStan\DeadCode\Transformer\FileSystem;
 use function file_get_contents;
 use function is_array;
@@ -577,10 +577,10 @@ class DeadCodeRuleTest extends RuleTestCase
             new class extends ReflectionBasedMemberUsageProvider
             {
 
-                public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsage
+                public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
                 {
                     if ($method->getDeclaringClass()->getName() === 'DeadEntrypoint\Entrypoint') {
-                        return VirtualUsage::withNote('test');
+                        return VirtualUsageData::withNote('test');
                     }
 
                     return null;

--- a/tests/Rule/data/debug/expected_output.txt
+++ b/tests/Rule/data/debug/expected_output.txt
@@ -59,11 +59,11 @@ DebugNever\Foo::__get
 DebugVirtual\FooTest::testFoo
 |
 | Marked as alive at:
-| entry virtual usage from ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider (test method)
+| entry virtual usage from ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider (Test method)
 |   calls DebugVirtual\FooTest::testFoo
 |
 | Found 1 usage:
-|  • virtual usage from ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider (test method)
+|  • virtual usage from ShipMonk\PHPStan\DeadCode\Provider\PhpUnitUsageProvider (Test method)
 
 
 DebugGlobal\Foo::chain2
@@ -99,7 +99,7 @@ DebugCycle\Foo::__construct
 DebugRegular\Another::call
 |
 | Marked as alive at:
-| entry virtual usage from ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider
+| entry virtual usage from ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider (Route method via #[Route] attribute)
 |   calls DebugRegular\FooController::dummyAction:12
 |     calls DebugRegular\Another::call
 |


### PR DESCRIPTION
BC break for users of `ReflectionBasedMemberUsageProvider`, but with easy fix:
- `true => VirtualUsageData::withNote('why considered used')`
- `false => null`