### PR TITLE
Autoremove: warn about kept excluded usages

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,5 +1,5 @@
 {
     "Exclude": [
-        "^tests/Rule/data/debug/expected_output.txt"
+        "output.txt$"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ class UserFacade
 ```
 
 - If you are excluding tests usages (see above), this will not cause the related tests to be removed alongside.
+  - But you will see all those kept usages in output (with links to your IDE if you set up `editorUrl` [parameter](https://phpstan.org/user-guide/output-format#opening-file-in-an-editor))
+
+```txt
+ • Removed method UserFacade::deadMethod
+   ! Excluded usage at tests/User/UserFacadeTest.php:241 left intact
+```
 
 
 ## Calls over unknown types

--- a/rules.neon
+++ b/rules.neon
@@ -6,11 +6,14 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy
     -
         class: ShipMonk\PHPStan\DeadCode\Transformer\FileSystem
+    -
+        class: ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer
+        arguments:
+            editorUrl: %editorUrl%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Debug\DebugUsagePrinter
         arguments:
-            editorUrl: %editorUrl%
             mixedExcluderEnabled: %shipmonkDeadCode.usageExcluders.usageOverMixed.enabled%
 
     -

--- a/src/Formatter/RemoveDeadCodeFormatter.php
+++ b/src/Formatter/RemoveDeadCodeFormatter.php
@@ -19,15 +19,15 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
 
     private FileSystem $fileSystem;
 
-    private OutputEnhancer $usagePrinter;
+    private OutputEnhancer $outputEnhancer;
 
     public function __construct(
         FileSystem $fileSystem,
-        OutputEnhancer $usagePrinter
+        OutputEnhancer $outputEnhancer
     )
     {
         $this->fileSystem = $fileSystem;
-        $this->usagePrinter = $usagePrinter;
+        $this->outputEnhancer = $outputEnhancer;
     }
 
     public function formatErrors(
@@ -78,21 +78,18 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
 
             $membersCount += count($deadConstants) + count($deadMethods);
 
-            $relativeFile = $this->usagePrinter->getRelativePath($file);
-            $output->writeLineFormatted("Processing $relativeFile...");
-
             $transformer = new RemoveDeadCodeTransformer(array_keys($deadMethods), array_keys($deadConstants));
             $oldCode = $this->fileSystem->read($file);
             $newCode = $transformer->transformCode($oldCode);
             $this->fileSystem->write($file, $newCode);
 
             foreach ($deadConstants as $constant => $excludedUsages) {
-                $output->writeLineFormatted(" • Removed constant $constant");
+                $output->writeLineFormatted(" • Removed constant <fg=white>$constant</>");
                 $this->printExcludedUsages($output, $excludedUsages);
             }
 
             foreach ($deadMethods as $method => $excludedUsages) {
-                $output->writeLineFormatted(" • Removed method $method");
+                $output->writeLineFormatted(" • Removed method <fg=white>$method</>");
                 $this->printExcludedUsages($output, $excludedUsages);
             }
         }
@@ -128,7 +125,7 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
             return null;
         }
 
-        return $this->usagePrinter->getOriginReference($origin);
+        return $this->outputEnhancer->getOriginReference($origin);
     }
 
 }

--- a/src/Formatter/RemoveDeadCodeFormatter.php
+++ b/src/Formatter/RemoveDeadCodeFormatter.php
@@ -67,7 +67,8 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
             }
         }
 
-        $count = 0;
+        $membersCount = 0;
+        $filesCount = count($deadMembersByFiles);
 
         foreach ($deadMembersByFiles as $file => $deadMembersByType) {
             /** @var array<string, list<ClassMemberUsage>> $deadConstants */
@@ -75,7 +76,7 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
             /** @var array<string, list<ClassMemberUsage>> $deadMethods */
             $deadMethods = $deadMembersByType[DeadCodeRule::IDENTIFIER_METHOD] ?? [];
 
-            $count += count($deadConstants) + count($deadMethods);
+            $membersCount += count($deadConstants) + count($deadMethods);
 
             $relativeFile = $this->usagePrinter->getRelativePath($file);
             $output->writeLineFormatted("Processing $relativeFile...");
@@ -96,8 +97,11 @@ class RemoveDeadCodeFormatter implements ErrorFormatter
             }
         }
 
+        $memberPlural = $membersCount === 1 ? '' : 's';
+        $filePlural = $filesCount === 1 ? '' : 's';
+
         $output->writeLineFormatted('');
-        $output->writeLineFormatted('Removed ' . $count . ' dead members in ' . count($deadMembersByFiles) . ' files.');
+        $output->writeLineFormatted("Removed $membersCount dead member$memberPlural in $filesCount file$filePlural.");
 
         return 0;
     }

--- a/src/Output/OutputEnhancer.php
+++ b/src/Output/OutputEnhancer.php
@@ -24,11 +24,6 @@ class OutputEnhancer
         $this->editorUrl = $editorUrl;
     }
 
-    public function getRelativePath(string $absoluteFile): string
-    {
-        return $this->relativePathHelper->getRelativePath($absoluteFile);
-    }
-
     public function getOriginLink(UsageOrigin $origin, string $title): string
     {
         $file = $origin->getFile();

--- a/src/Output/OutputEnhancer.php
+++ b/src/Output/OutputEnhancer.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Output;
+
+use LogicException;
+use PHPStan\File\RelativePathHelper;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function sprintf;
+use function str_replace;
+
+class OutputEnhancer
+{
+
+    private RelativePathHelper $relativePathHelper;
+
+    private ?string $editorUrl;
+
+    public function __construct(
+        RelativePathHelper $relativePathHelper,
+        ?string $editorUrl
+    )
+    {
+        $this->relativePathHelper = $relativePathHelper;
+        $this->editorUrl = $editorUrl;
+    }
+
+    public function getRelativePath(string $absoluteFile): string
+    {
+        return $this->relativePathHelper->getRelativePath($absoluteFile);
+    }
+
+    public function getOriginLink(UsageOrigin $origin, string $title): string
+    {
+        $file = $origin->getFile();
+        $line = $origin->getLine();
+
+        if ($line !== null) {
+            $title = sprintf('%s:%s', $title, $line);
+        }
+
+        if ($file !== null && $line !== null) {
+            return $this->getLinkOrPlain($title, $file, $line);
+        }
+
+        return $title;
+    }
+
+    public function getOriginReference(UsageOrigin $origin, bool $preferFileLine = true): string
+    {
+        $file = $origin->getFile();
+        $line = $origin->getLine();
+
+        if ($file !== null && $line !== null) {
+            $relativeFile = $this->relativePathHelper->getRelativePath($file);
+
+            $title = $origin->getClassName() !== null && $origin->getMethodName() !== null && !$preferFileLine
+                ? sprintf('%s::%s:%d', $origin->getClassName(), $origin->getMethodName(), $line)
+                : sprintf('%s:%s', $relativeFile, $line);
+
+            return $this->getLinkOrPlain($title, $file, $line);
+        }
+
+        if ($origin->getProvider() !== null) {
+            $note = $origin->getNote() !== null ? " ({$origin->getNote()})" : '';
+            return 'virtual usage from ' . $origin->getProvider() . $note;
+        }
+
+        throw new LogicException('Unknown state of usage origin');
+    }
+
+    private function getLinkOrPlain(string $title, string $file, int $line): string
+    {
+        if ($this->editorUrl === null) {
+            return $title;
+        }
+
+        $relativeFile = $this->relativePathHelper->getRelativePath($file);
+
+        return sprintf(
+            '<href=%s>%s</>',
+            str_replace(['%file%', '%relFile%', '%line%'], [$file, $relativeFile, (string) $line], $this->editorUrl),
+            $title,
+        );
+    }
+
+}

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -273,7 +273,6 @@ class DeadCodeRule implements Rule, DiagnoseExtension
         }
 
         foreach ($excludedMemberUsages as $excludedMemberUsage) {
-            $excludedBy = $excludedMemberUsage->getExcludedBy();
             $excludedMemberRef = $excludedMemberUsage->getUsage()->getMemberRef();
             $alternativeExcludedMemberKeys = $this->getAlternativeMemberKeys($excludedMemberRef);
 
@@ -282,7 +281,7 @@ class DeadCodeRule implements Rule, DiagnoseExtension
                     continue;
                 }
 
-                $this->blackMembers[$alternativeExcludedMemberKey]->markHasExcludedUsage($excludedBy);
+                $this->blackMembers[$alternativeExcludedMemberKey]->addExcludedUsage($excludedMemberUsage);
             }
 
             $this->debugUsagePrinter->recordUsage($excludedMemberUsage, $alternativeExcludedMemberKeys);
@@ -593,6 +592,7 @@ class DeadCodeRule implements Rule, DiagnoseExtension
 
         $humanMemberString = $representative->getMember()->toHumanString();
         $exclusionMessage = $representative->getExclusionMessage();
+        $excludedUsages = $representative->getExcludedUsages();
 
         $builder = RuleErrorBuilder::message("Unused {$humanMemberString}{$exclusionMessage}")
             ->file($representative->getFile())
@@ -604,6 +604,7 @@ class DeadCodeRule implements Rule, DiagnoseExtension
             'file' => $representative->getFile(),
             'line' => $representative->getLine(),
             'transitive' => false,
+            'excludedUsages' => $excludedUsages,
         ];
 
         $tips = [];
@@ -611,12 +612,14 @@ class DeadCodeRule implements Rule, DiagnoseExtension
         foreach (array_slice($blackMembersGroup, 1) as $transitivelyDeadMember) {
             $transitiveDeadMemberRef = $transitivelyDeadMember->getMember()->toHumanString();
             $exclusionMessage = $transitivelyDeadMember->getExclusionMessage();
+            $excludedUsages = $transitivelyDeadMember->getExcludedUsages();
 
             $tips[$transitiveDeadMemberRef] = "Thus $transitiveDeadMemberRef is transitively also unused{$exclusionMessage}";
             $metadata[$transitiveDeadMemberRef] = [
                 'file' => $transitivelyDeadMember->getFile(),
                 'line' => $transitivelyDeadMember->getLine(),
                 'transitive' => true,
+                'excludedUsages' => $excludedUsages,
             ];
         }
 

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -339,7 +339,7 @@ class DeadCodeRuleTest extends RuleTestCase
 
         $expectedOutputFile = $this->getAutoremoveOutputFilePath($file);
         self::assertFileExists($expectedOutputFile);
-        self::assertSame(file_get_contents($expectedOutputFile), $writtenOutput);
+        self::assertSame(file_get_contents($expectedOutputFile), $this->trimFgColors($writtenOutput));
     }
 
     /**

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -324,7 +324,7 @@ class DeadCodeRuleTest extends RuleTestCase
             ->method('write')
             ->willReturnCallback(
                 function (string $file, string $content): void {
-                    $expectedFile = $this->getTransformedFilePath($file);
+                    $expectedFile = $this->getAutoremoveTransformedFilePath($file);
                     self::assertFileExists($expectedFile);
 
                     $expectedNewCode = file_get_contents($expectedFile);
@@ -337,7 +337,7 @@ class DeadCodeRuleTest extends RuleTestCase
         $formatter = new RemoveDeadCodeFormatter($fileSystem, $this->createOutputEnhancer());
         $formatter->formatErrors($this->createAnalysisResult($analyserErrors), $output);
 
-        $expectedOutputFile = $this->getOutputFilePath($file);
+        $expectedOutputFile = $this->getAutoremoveOutputFilePath($file);
         self::assertFileExists($expectedOutputFile);
         self::assertSame(file_get_contents($expectedOutputFile), $writtenOutput);
     }
@@ -577,12 +577,12 @@ class DeadCodeRuleTest extends RuleTestCase
         yield 'no-namespace' => [__DIR__ . '/data/removing/no-namespace.php'];
     }
 
-    private function getTransformedFilePath(string $file): string
+    private function getAutoremoveTransformedFilePath(string $file): string
     {
         return str_replace('.php', '.transformed.php', $file);
     }
 
-    private function getOutputFilePath(string $file): string
+    private function getAutoremoveOutputFilePath(string $file): string
     {
         return str_replace('.php', '.output.txt', $file);
     }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -16,6 +16,7 @@ use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionMethod;
 use ShipMonk\PHPStan\DeadCode\Collector\ClassDefinitionCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\ConstantFetchCollector;
@@ -29,6 +30,7 @@ use ShipMonk\PHPStan\DeadCode\Excluder\TestsUsageExcluder;
 use ShipMonk\PHPStan\DeadCode\Formatter\RemoveDeadCodeFormatter;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
+use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\NetteUsageProvider;
@@ -77,9 +79,8 @@ class DeadCodeRuleTest extends RuleTestCase
             $this->rule = new DeadCodeRule(
                 new DebugUsagePrinter(
                     $container,
-                    new SimpleRelativePathHelper(__DIR__), // @phpstan-ignore phpstanApi.constructor
+                    $this->createOutputEnhancer(),
                     self::createReflectionProvider(),
-                    null,
                     !$this->trackMixedAccess,
                 ),
                 new ClassHierarchy(),
@@ -301,6 +302,15 @@ class DeadCodeRuleTest extends RuleTestCase
      */
     public function testAutoRemove(string $file): void
     {
+        $writtenOutput = '';
+
+        $output = $this->createOutput();
+        $output->expects(self::atLeastOnce())
+            ->method('writeLineFormatted')
+            ->willReturnCallback(static function (string $message) use (&$writtenOutput): void {
+                $writtenOutput .= $message . "\n";
+            });
+
         $fileSystem = $this->createMock(FileSystem::class);
         $fileSystem->expects(self::once())
             ->method('read')
@@ -324,8 +334,12 @@ class DeadCodeRuleTest extends RuleTestCase
 
         $analyserErrors = $this->gatherAnalyserErrors([$file]);
 
-        $formatter = new RemoveDeadCodeFormatter($fileSystem);
-        $formatter->formatErrors($this->createAnalysisResult($analyserErrors), $this->createOutput());
+        $formatter = new RemoveDeadCodeFormatter($fileSystem, $this->createOutputEnhancer());
+        $formatter->formatErrors($this->createAnalysisResult($analyserErrors), $output);
+
+        $expectedOutputFile = $this->getOutputFilePath($file);
+        self::assertFileExists($expectedOutputFile);
+        self::assertSame(file_get_contents($expectedOutputFile), $writtenOutput);
     }
 
     /**
@@ -336,6 +350,9 @@ class DeadCodeRuleTest extends RuleTestCase
         return new AnalysisResult($errors, [], [], [], [], false, null, false, 0, false, []); // @phpstan-ignore phpstanApi.constructor
     }
 
+    /**
+     * @return Output&MockObject
+     */
     private function createOutput(): Output
     {
         return $this->createMock(Output::class);
@@ -565,6 +582,11 @@ class DeadCodeRuleTest extends RuleTestCase
         return str_replace('.php', '.transformed.php', $file);
     }
 
+    private function getOutputFilePath(string $file): string
+    {
+        return str_replace('.php', '.output.txt', $file);
+    }
+
     /**
      * @return list<MemberUsageProvider>
      */
@@ -646,6 +668,14 @@ class DeadCodeRuleTest extends RuleTestCase
         }
 
         return $excluders;
+    }
+
+    private function createOutputEnhancer(): OutputEnhancer
+    {
+        return new OutputEnhancer(
+            new SimpleRelativePathHelper(__DIR__), // @phpstan-ignore phpstanApi.constructor
+            null,
+        );
     }
 
     private function createPhpStanContainerMock(): Container

--- a/tests/Rule/data/removing/no-namespace.output.txt
+++ b/tests/Rule/data/removing/no-namespace.output.txt
@@ -2,4 +2,4 @@ Processing data/removing/no-namespace.php...
  • Removed constant Remove::DEAD
  • Removed method Remove::dead
 
-Removed 2 dead members in 1 files.
+Removed 2 dead members in 1 file.

--- a/tests/Rule/data/removing/no-namespace.output.txt
+++ b/tests/Rule/data/removing/no-namespace.output.txt
@@ -1,0 +1,5 @@
+Processing data/removing/no-namespace.php...
+ • Removed constant Remove::DEAD
+ • Removed method Remove::dead
+
+Removed 2 dead members in 1 files.

--- a/tests/Rule/data/removing/no-namespace.output.txt
+++ b/tests/Rule/data/removing/no-namespace.output.txt
@@ -1,4 +1,3 @@
-Processing data/removing/no-namespace.php...
  • Removed constant Remove::DEAD
  • Removed method Remove::dead
 

--- a/tests/Rule/data/removing/sample.output.txt
+++ b/tests/Rule/data/removing/sample.output.txt
@@ -10,4 +10,4 @@ Processing data/removing/sample.php...
  • Removed method Removal\Child2::mixedExcludedUsage
    ! Excluded usage at data/removing/sample.php:48 left intact
 
-Removed 9 dead members in 1 files.
+Removed 9 dead members in 1 file.

--- a/tests/Rule/data/removing/sample.output.txt
+++ b/tests/Rule/data/removing/sample.output.txt
@@ -1,0 +1,13 @@
+Processing data/removing/sample.php...
+ • Removed constant Removal\Interface1::DEAD_IFACE_CONST1
+ • Removed constant Removal\Interface1::DEAD_IFACE_CONST2
+ • Removed constant Removal\Interface1::DEAD_IFACE_CONST3
+ • Removed constant Removal\Child2::DEAD_CONST
+ • Removed method Removal\Interface1::foo
+ • Removed method Removal\Interface2::foo
+ • Removed method Removal\AbstractClass::foo
+ • Removed method Removal\Child1::foo
+ • Removed method Removal\Child2::mixedExcludedUsage
+   ! Excluded usage at data/removing/sample.php:48 left intact
+
+Removed 9 dead members in 1 files.

--- a/tests/Rule/data/removing/sample.output.txt
+++ b/tests/Rule/data/removing/sample.output.txt
@@ -1,4 +1,3 @@
-Processing data/removing/sample.php...
  • Removed constant Removal\Interface1::DEAD_IFACE_CONST1
  • Removed constant Removal\Interface1::DEAD_IFACE_CONST2
  • Removed constant Removal\Interface1::DEAD_IFACE_CONST3

--- a/tests/Rule/data/removing/sample.php
+++ b/tests/Rule/data/removing/sample.php
@@ -36,9 +36,14 @@ class Child2 extends AbstractClass
     {
         echo self::USED_CONST;
     }
+
+    public function mixedExcludedUsage(): void {
+
+    }
 }
 
 function testIt(Child2 $child2): void
 {
     $child2->foo();
+    $child2->mixedExcludedUsage();
 }

--- a/tests/Rule/data/removing/sample.transformed.php
+++ b/tests/Rule/data/removing/sample.transformed.php
@@ -31,4 +31,5 @@ class Child2 extends AbstractClass
 function testIt(Child2 $child2): void
 {
     $child2->foo();
+    $child2->mixedExcludedUsage();
 }


### PR DESCRIPTION

```txt
 • Removed method UserFacade::deadMethod
   ! Excluded usage at tests/User/UserFacadeTest.php:241 left intact
```