### PR TITLE
Report dead method line at its name

### DIFF
--- a/src/Collector/ClassDefinitionCollector.php
+++ b/src/Collector/ClassDefinitionCollector.php
@@ -76,7 +76,7 @@ class ClassDefinitionCollector implements Collector
 
         foreach ($node->getMethods() as $method) {
             $methods[$method->name->toString()] = [
-                'line' => $method->getStartLine(),
+                'line' => $method->name->getStartLine(),
                 'params' => count($method->params),
                 'abstract' => $method->isAbstract() || $node instanceof Interface_,
                 'visibility' => $method->flags & (Visibility::PUBLIC | Visibility::PROTECTED | Visibility::PRIVATE),

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -546,7 +546,7 @@ class DeadCodeRuleTest extends RuleTestCase
             [
                 [
                     'Unused AttributeGrouping\Foo::endpoint',
-                    9,
+                    10,
                 ],
             ],
         ];
@@ -761,6 +761,9 @@ class DeadCodeRuleTest extends RuleTestCase
         yield 'mixed-member-const-traits-10' => [__DIR__ . '/data/mixed-member/traits-const-10.php'];
         yield 'mixed-member-const-traits-14' => [__DIR__ . '/data/mixed-member/traits-const-14.php'];
         yield 'mixed-member-const-traits-21' => [__DIR__ . '/data/mixed-member/traits-const-21.php'];
+
+        // other
+        yield 'report-lines' => [__DIR__ . '/data/other/report-lines.php'];
     }
 
     /**

--- a/tests/Rule/data/other/report-lines.php
+++ b/tests/Rule/data/other/report-lines.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace ReportLines;
+
+class Foo
+{
+    public
+    const
+    BAR // error: Unused ReportLines\Foo::BAR
+    =
+    1
+    ;
+
+    #[
+        Bar
+    ]
+    public
+    function
+    endpoint // error: Unused ReportLines\Foo::endpoint
+    ()
+    :
+    void
+    {
+    }
+
+}

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -31,8 +31,8 @@ class SomeController {
     {
     }
 
-    #[Unknown] // error: Unused Symfony\SomeController::dead
-    public function dead(): void
+    #[Unknown]
+    public function dead(): void // error: Unused Symfony\SomeController::dead
     {
     }
 


### PR DESCRIPTION
Minor **BC break for inline ignores when method had attribute** or some crazy-rare code-style:

```diff
-#[Deprecated] // @phpstan-ignore shipmonk.deadMethod
-public function someMethod(): void
+#[Deprecated]
+public function someMethod(): void // @phpstan-ignore shipmonk.deadMethod
```