### PR TITLE
Support libraries with `@api` phpdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ If you set up `editorUrl` [parameter](https://phpstan.org/user-guide/output-form
 ## Usage in libraries:
 - Libraries typically contain public api, that is unused
   - If you mark such methods with `@api` phpdoc, those will be considered entrypoints
+  - You can also mark whole method or interface with `@api` to mark all its methods as entrypoints
 
 ## Future scope:
 - Dead class property detection

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ If you set up `editorUrl` [parameter](https://phpstan.org/user-guide/output-form
 ## Usage in libraries:
 - Libraries typically contain public api, that is unused
   - If you mark such methods with `@api` phpdoc, those will be considered entrypoints
-  - You can also mark whole method or interface with `@api` to mark all its methods as entrypoints
+  - You can also mark whole class or interface with `@api` to mark all its methods as entrypoints
 
 ## Future scope:
 - Dead class property detection

--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ If you set up `editorUrl` [parameter](https://phpstan.org/user-guide/output-form
 > [!TIP]
 > You can change the list of debug references without affecting result cache, so rerun is instant!
 
+## Usage in libraries:
+- Libraries typically contain public api, that is unused
+  - If you mark such methods with `@api` phpdoc, those will be considered entrypoints
+
 ## Future scope:
 - Dead class property detection
 - Dead class detection

--- a/rules.neon
+++ b/rules.neon
@@ -15,6 +15,13 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Debug\DebugUsagePrinter
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.apiPhpDoc.enabled%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider
         tags:
             - shipmonk.deadCode.memberUsageProvider
@@ -137,6 +144,8 @@ parameters:
         trackMixedAccess: null
         reportTransitivelyDeadMethodAsSeparateError: false
         usageProviders:
+            apiPhpDoc:
+                enabled: true
             vendor:
                 enabled: true
             reflection:
@@ -168,6 +177,9 @@ parametersSchema:
         trackMixedAccess: schema(bool(), nullable()) # deprecated, use usageExcluders.usageOverMixed.enabled
         reportTransitivelyDeadMethodAsSeparateError: bool()
         usageProviders: structure([
+            apiPhpDoc: structure([
+                enabled: bool()
+            ])
             vendor: structure([
                 enabled: bool()
             ])

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -5,9 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Debug;
 use LogicException;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\Container;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
-use ReflectionException;
 use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
 use ShipMonk\PHPStan\DeadCode\Error\BlackMember;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
@@ -15,6 +13,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
+use ShipMonk\PHPStan\DeadCode\Reflection\ReflectionHasOwnMemberTrait;
 use function array_map;
 use function array_sum;
 use function array_unique;
@@ -30,6 +29,8 @@ use function strpos;
 
 class DebugUsagePrinter
 {
+
+    use ReflectionHasOwnMemberTrait;
 
     public const ANY_MEMBER = "\0";
 
@@ -364,43 +365,6 @@ class DebugUsagePrinter
         }
 
         return $result;
-    }
-
-    private function hasOwnMethod(ClassReflection $classReflection, string $methodName): bool
-    {
-        if (!$classReflection->hasMethod($methodName)) {
-            return false;
-        }
-
-        try {
-            return $classReflection->getNativeReflection()->getMethod($methodName)->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
-        } catch (ReflectionException $e) {
-            return false;
-        }
-    }
-
-    private function hasOwnConstant(ClassReflection $classReflection, string $constantName): bool
-    {
-        $constantReflection = $classReflection->getNativeReflection()->getReflectionConstant($constantName);
-
-        if ($constantReflection === false) {
-            return false;
-        }
-
-        return $constantReflection->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
-    }
-
-    private function hasOwnProperty(ClassReflection $classReflection, string $propertyName): bool
-    {
-        if (!$classReflection->hasProperty($propertyName)) {
-            return false;
-        }
-
-        try {
-            return $classReflection->getNativeReflection()->getProperty($propertyName)->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
-        } catch (ReflectionException $e) {
-            return false;
-        }
     }
 
     /**

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -13,7 +13,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
-use ShipMonk\PHPStan\DeadCode\Reflection\ReflectionHasOwnMemberTrait;
+use ShipMonk\PHPStan\DeadCode\Reflection\ReflectionHelper;
 use function array_map;
 use function array_sum;
 use function array_unique;
@@ -29,8 +29,6 @@ use function strpos;
 
 class DebugUsagePrinter
 {
-
-    use ReflectionHasOwnMemberTrait;
 
     public const ANY_MEMBER = "\0";
 
@@ -346,13 +344,13 @@ class DebugUsagePrinter
 
             $classReflection = $this->reflectionProvider->getClass($normalizedClass);
 
-            if ($this->hasOwnMethod($classReflection, $memberName)) {
+            if (ReflectionHelper::hasOwnMethod($classReflection, $memberName)) {
                 $key = ClassMethodRef::buildKey($normalizedClass, $memberName);
 
-            } elseif ($this->hasOwnConstant($classReflection, $memberName)) {
+            } elseif (ReflectionHelper::hasOwnConstant($classReflection, $memberName)) {
                 $key = ClassConstantRef::buildKey($normalizedClass, $memberName);
 
-            } elseif ($this->hasOwnProperty($classReflection, $memberName)) {
+            } elseif (ReflectionHelper::hasOwnProperty($classReflection, $memberName)) {
                 throw new LogicException("Cannot debug '$debugMember', properties are not supported yet");
 
             } else {

--- a/src/Provider/ApiPhpDocUsageProvider.php
+++ b/src/Provider/ApiPhpDocUsageProvider.php
@@ -5,7 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 use ReflectionClass;
 use ReflectionClassConstant;
 use ReflectionMethod;
-use function str_contains;
+use function strpos;
 use function ucfirst;
 
 class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
@@ -69,7 +69,7 @@ class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
     {
         $phpDoc = $reflection->getDocComment();
 
-        if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+        if ($phpDoc !== false && strpos($phpDoc, '@api') !== false) {
             return true;
         }
 
@@ -84,7 +84,7 @@ class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
         if ($reflection->hasMethod($memberName)) {
             $phpDoc = $reflection->getMethod($memberName)->getDocComment(); // @phpstan-ignore missingType.checkedException (ReflectionException handled by hasMethod)
 
-            if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+            if ($phpDoc !== false && strpos($phpDoc, '@api') !== false) {
                 return true;
             }
         }
@@ -94,7 +94,7 @@ class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
             $constant = $reflection->getReflectionConstant($memberName);
             $phpDoc = $constant->getDocComment();
 
-            if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+            if ($phpDoc !== false && strpos($phpDoc, '@api') !== false) {
                 return true;
             }
         }

--- a/src/Provider/ApiPhpDocUsageProvider.php
+++ b/src/Provider/ApiPhpDocUsageProvider.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use ReflectionClass;
+use ReflectionClassConstant;
+use ReflectionMethod;
+use function str_contains;
+use function ucfirst;
+
+class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
+{
+
+    private bool $enabled;
+
+    public function __construct(bool $enabled)
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
+    {
+        return $this->enabled ? $this->shouldMarkMemberAsUsed($method) : null;
+    }
+
+    public function shouldMarkConstantAsUsed(ReflectionClassConstant $constant): ?VirtualUsageData
+    {
+        return $this->enabled ? $this->shouldMarkMemberAsUsed($constant) : null;
+    }
+
+    /**
+     * @param ReflectionClassConstant|ReflectionMethod $member
+     */
+    public function shouldMarkMemberAsUsed(object $member): ?VirtualUsageData
+    {
+        $reflectionClass = $member->getDeclaringClass();
+        $memberType = $member instanceof ReflectionClassConstant ? 'constant' : 'method';
+        $memberName = $member->getName();
+
+        if ($this->isApiClass($reflectionClass)) {
+            return VirtualUsageData::withNote("Class {$reflectionClass->getName()} is public @api");
+        }
+
+        do {
+            if ($this->isApiMember($reflectionClass, $memberName)) {
+                return VirtualUsageData::withNote(ucfirst("$memberType {$reflectionClass->getName()}::{$memberName} is public @api"));
+            }
+
+            foreach ($reflectionClass->getInterfaces() as $interface) {
+                if ($this->isApiClass($interface)) {
+                    return VirtualUsageData::withNote("Interface {$interface->getName()} is public @api");
+                }
+
+                if ($this->isApiMember($interface, $memberName)) {
+                    return VirtualUsageData::withNote("Interface $memberType {$interface->getName()}::{$memberName} is public @api");
+                }
+            }
+
+            $reflectionClass = $reflectionClass->getParentClass();
+        } while ($reflectionClass !== false);
+
+        return null;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function isApiClass(ReflectionClass $reflection): bool
+    {
+        $phpDoc = $reflection->getDocComment();
+
+        if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function isApiMember(ReflectionClass $reflection, string $memberName): bool
+    {
+        if ($reflection->hasMethod($memberName)) {
+            $phpDoc = $reflection->getMethod($memberName)->getDocComment(); // @phpstan-ignore missingType.checkedException (ReflectionException handled by hasMethod)
+
+            if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+                return true;
+            }
+        }
+
+        if ($reflection->hasConstant($memberName)) {
+            /** @var ReflectionClassConstant $constant */
+            $constant = $reflection->getReflectionConstant($memberName);
+            $phpDoc = $constant->getDocComment();
+
+            if ($phpDoc !== false && str_contains($phpDoc, '@api')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/Provider/ApiPhpDocUsageProvider.php
+++ b/src/Provider/ApiPhpDocUsageProvider.php
@@ -6,13 +6,11 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use ReflectionClassConstant;
 use ReflectionMethod;
-use ShipMonk\PHPStan\DeadCode\Reflection\ReflectionHasOwnMemberTrait;
+use ShipMonk\PHPStan\DeadCode\Reflection\ReflectionHelper;
 use function strpos;
 
 class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
 {
-
-    use ReflectionHasOwnMemberTrait;
 
     private ReflectionProvider $reflectionProvider;
 
@@ -108,10 +106,10 @@ class ApiPhpDocUsageProvider extends ReflectionBasedMemberUsageProvider
     private function hasOwnMember(ClassReflection $reflection, object $member): bool
     {
         if ($member instanceof ReflectionClassConstant) {
-            return $this->hasOwnConstant($reflection, $member->getName());
+            return ReflectionHelper::hasOwnConstant($reflection, $member->getName());
         }
 
-        return $this->hasOwnMethod($reflection, $member->getName());
+        return ReflectionHelper::hasOwnMethod($reflection, $member->getName());
     }
 
     private function isApiClass(ClassReflection $reflection): bool

--- a/src/Reflection/ReflectionHasOwnMemberTrait.php
+++ b/src/Reflection/ReflectionHasOwnMemberTrait.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Reflection;
+
+use PHPStan\Reflection\ClassReflection;
+use ReflectionException;
+
+trait ReflectionHasOwnMemberTrait
+{
+
+    private function hasOwnMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (!$classReflection->hasMethod($methodName)) {
+            return false;
+        }
+
+        try {
+            return $classReflection->getNativeReflection()->getMethod($methodName)->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
+        } catch (ReflectionException $e) {
+            return false;
+        }
+    }
+
+    private function hasOwnConstant(ClassReflection $classReflection, string $constantName): bool
+    {
+        $constantReflection = $classReflection->getNativeReflection()->getReflectionConstant($constantName);
+
+        if ($constantReflection === false) {
+            return false;
+        }
+
+        return $constantReflection->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
+    }
+
+    private function hasOwnProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (!$classReflection->hasProperty($propertyName)) {
+            return false;
+        }
+
+        try {
+            return $classReflection->getNativeReflection()->getProperty($propertyName)->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
+        } catch (ReflectionException $e) {
+            return false;
+        }
+    }
+
+}

--- a/src/Reflection/ReflectionHelper.php
+++ b/src/Reflection/ReflectionHelper.php
@@ -5,10 +5,10 @@ namespace ShipMonk\PHPStan\DeadCode\Reflection;
 use PHPStan\Reflection\ClassReflection;
 use ReflectionException;
 
-trait ReflectionHasOwnMemberTrait
+final class ReflectionHelper
 {
 
-    private function hasOwnMethod(ClassReflection $classReflection, string $methodName): bool
+    public static function hasOwnMethod(ClassReflection $classReflection, string $methodName): bool
     {
         if (!$classReflection->hasMethod($methodName)) {
             return false;
@@ -21,7 +21,7 @@ trait ReflectionHasOwnMemberTrait
         }
     }
 
-    private function hasOwnConstant(ClassReflection $classReflection, string $constantName): bool
+    public static function hasOwnConstant(ClassReflection $classReflection, string $constantName): bool
     {
         $constantReflection = $classReflection->getNativeReflection()->getReflectionConstant($constantName);
 
@@ -32,7 +32,7 @@ trait ReflectionHasOwnMemberTrait
         return $constantReflection->getBetterReflection()->getDeclaringClass()->getName() === $classReflection->getName();
     }
 
-    private function hasOwnProperty(ClassReflection $classReflection, string $propertyName): bool
+    public static function hasOwnProperty(ClassReflection $classReflection, string $propertyName): bool
     {
         if (!$classReflection->hasProperty($propertyName)) {
             return false;

--- a/tests/AllServicesInConfigTest.php
+++ b/tests/AllServicesInConfigTest.php
@@ -20,6 +20,7 @@ use ShipMonk\PHPStan\DeadCode\Transformer\RemoveClassMemberVisitor;
 use ShipMonk\PHPStan\DeadCode\Transformer\RemoveDeadCodeTransformer;
 use function array_merge;
 use function class_exists;
+use function count;
 use function in_array;
 use function interface_exists;
 use function str_replace;
@@ -71,6 +72,10 @@ class AllServicesInConfigTest extends PHPStanTestCase
                 continue;
             }
 
+            if ($this->hasAllMethodsStatic($reflectionClass)) {
+                continue;
+            }
+
             if (in_array($className, $excluded, true)) {
                 continue;
             }
@@ -104,6 +109,26 @@ class AllServicesInConfigTest extends PHPStanTestCase
         }
 
         return $classString;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private function hasAllMethodsStatic(ReflectionClass $reflectionClass): bool
+    {
+        $methods = $reflectionClass->getMethods();
+
+        if (count($methods) === 0) {
+            return false;
+        }
+
+        foreach ($methods as $method) {
+            if (!$method->isStatic()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -34,6 +34,7 @@ use ShipMonk\PHPStan\DeadCode\Formatter\RemoveDeadCodeFormatter;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
 use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
+use ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\NetteUsageProvider;
@@ -737,6 +738,7 @@ class DeadCodeRuleTest extends RuleTestCase
         yield 'provider-doctrine' => [__DIR__ . '/data/providers/doctrine.php', self::requiresPhp(8_00_00)];
         yield 'provider-phpstan' => [__DIR__ . '/data/providers/phpstan.php'];
         yield 'provider-nette' => [__DIR__ . '/data/providers/nette.php'];
+        yield 'provider-apiphpdoc' => [__DIR__ . '/data/providers/api-phpdoc.php'];
 
         // excluders
         yield 'excluder-tests' => [[__DIR__ . '/data/excluders/tests/src/code.php', __DIR__ . '/data/excluders/tests/tests/code.php']];
@@ -872,6 +874,10 @@ class DeadCodeRuleTest extends RuleTestCase
                 __DIR__ . '/data/providers/symfony/',
             ),
             new TwigUsageProvider(
+                $this->providersEnabled,
+            ),
+            new ApiPhpDocUsageProvider(
+                self::createReflectionProvider(),
                 $this->providersEnabled,
             ),
         ];

--- a/tests/Rule/data/providers/api-phpdoc.php
+++ b/tests/Rule/data/providers/api-phpdoc.php
@@ -9,8 +9,8 @@ interface PublicApiInterface {
     const CONST1 = 1;
     const CONST2 = 2;
 
-    public function method1() {}
-    public function method2() {}
+    public function method1();
+    public function method2();
 
 }
 
@@ -45,8 +45,8 @@ interface PartialPublicApiInterface {
     const CONST2 = 2; // error: Unused ApiPhpdoc1\PartialPublicApiInterface::CONST2
 
     /** @api */
-    public function method1() {}
-    public function method2() {} // error: Unused ApiPhpdoc1\PartialPublicApiInterface::method2
+    public function method1();
+    public function method2(); // error: Unused ApiPhpdoc1\PartialPublicApiInterface::method2
 
 }
 
@@ -80,9 +80,9 @@ interface InheritedPublicApi3 extends PublicApiInterface {
     const CONST2 = 2;
     const CONST3 = 3; // error: Unused ApiPhpdoc1\InheritedPublicApi3::CONST3
 
-    public function method1() {}
-    public function method2() {}
-    public function method3() {} // error: Unused ApiPhpdoc1\InheritedPublicApi3::method3
+    public function method1();
+    public function method2();
+    public function method3(); // error: Unused ApiPhpdoc1\InheritedPublicApi3::method3
 }
 
 class InheritedPublicApi4 implements PartialPublicApiInterface {

--- a/tests/Rule/data/providers/api-phpdoc.php
+++ b/tests/Rule/data/providers/api-phpdoc.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace ApiPhpdoc1;
+
+
+/** @api */
+interface PublicApiInterface {
+
+    const CONST1 = 1;
+    const CONST2 = 2;
+
+    public function method1() {}
+    public function method2() {}
+
+}
+
+/** @api */
+class PublicApi {
+
+    const CONST1 = 1;
+    const CONST2 = 2;
+
+    public function method1() {}
+    public function method2() {}
+
+}
+
+class PartialPublicApi {
+
+    /** @api */
+    const CONST1 = 1;
+    const CONST2 = 2; // error: Unused ApiPhpdoc1\PartialPublicApi::CONST2
+
+    /** @api */
+    public function method1() {}
+    public function method2() {} // error: Unused ApiPhpdoc1\PartialPublicApi::method2
+
+}
+
+
+interface PartialPublicApiInterface {
+
+    /** @api */
+    const CONST1 = 1;
+    const CONST2 = 2; // error: Unused ApiPhpdoc1\PartialPublicApiInterface::CONST2
+
+    /** @api */
+    public function method1() {}
+    public function method2() {} // error: Unused ApiPhpdoc1\PartialPublicApiInterface::method2
+
+}
+
+class InheritedPublicApi1 extends PublicApi {
+
+    const CONST1 = 1;
+    const CONST2 = 2;
+    const CONST3 = 3; // error: Unused ApiPhpdoc1\InheritedPublicApi1::CONST3
+
+    public function method1() {}
+    public function method2() {}
+    public function method3() {} // error: Unused ApiPhpdoc1\InheritedPublicApi1::method3
+
+}
+
+class InheritedPublicApi2 implements PublicApiInterface {
+
+    const CONST1 = 1;
+    const CONST2 = 2;
+    const CONST3 = 3; // error: Unused ApiPhpdoc1\InheritedPublicApi2::CONST3
+
+    public function method1() {}
+    public function method2() {}
+    public function method3() {} // error: Unused ApiPhpdoc1\InheritedPublicApi2::method3
+
+}
+
+interface InheritedPublicApi3 extends PublicApiInterface {
+
+    const CONST1 = 1;
+    const CONST2 = 2;
+    const CONST3 = 3; // error: Unused ApiPhpdoc1\InheritedPublicApi3::CONST3
+
+    public function method1() {}
+    public function method2() {}
+    public function method3() {} // error: Unused ApiPhpdoc1\InheritedPublicApi3::method3
+}
+
+class InheritedPublicApi4 implements PartialPublicApiInterface {
+
+    const CONST1 = 1;
+    const CONST2 = 2; // error: Unused ApiPhpdoc1\InheritedPublicApi4::CONST2
+    const CONST3 = 3; // error: Unused ApiPhpdoc1\InheritedPublicApi4::CONST3
+
+    public function method1() {}
+    public function method2() {} // error: Unused ApiPhpdoc1\InheritedPublicApi4::method2
+    public function method3() {} // error: Unused ApiPhpdoc1\InheritedPublicApi4::method3
+}


### PR DESCRIPTION
Any public API of libs is dead by design (used only in tests), libs often use `@api` to mark such entrypoints. Most used by PHPStan itself.