### PR TITLE
Drop provided usage class existence validation

### DIFF
--- a/src/Collector/ProvidedUsagesCollector.php
+++ b/src/Collector/ProvidedUsagesCollector.php
@@ -83,9 +83,6 @@ class ProvidedUsagesCollector implements Collector
         Scope $scope
     ): void
     {
-        $memberRef = $usage->getMemberRef();
-        $memberRefClass = $memberRef->getClassName();
-
         $origin = $usage->getOrigin();
         $originClass = $origin->getClassName();
         $originMethod = $origin->getMethodName();
@@ -98,10 +95,6 @@ class ProvidedUsagesCollector implements Collector
             $scope->getFile(),
             $node->getStartLine(),
         );
-
-        if (($memberRefClass !== null) && !$this->reflectionProvider->hasClass($memberRefClass)) {
-            throw new LogicException("Class '$memberRefClass' does not exist. $context");
-        }
 
         if ($originClass !== null) {
             if (!$this->reflectionProvider->hasClass($originClass)) {


### PR DESCRIPTION
It fails e.g. when analysing phpstan-src:


```
Class 'PHPStan\ExtensionInstaller\GeneratedConfig' does not exist. 
It emitted usage of PHPStan\ExtensionInstaller\GeneratedConfig::PHPSTAN_VERSION_CONSTRAINT 
by ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider 
for node 'PhpParser\Node\Expr\MethodCall' 
in '/home/honza/Development/phpstan-src/src/Command/CommandHelper.php' 
on line 303
```