### PR TITLE
Prevent DIC services to have ctors with defaults

### DIFF
--- a/src/Excluder/TestsUsageExcluder.php
+++ b/src/Excluder/TestsUsageExcluder.php
@@ -42,7 +42,7 @@ class TestsUsageExcluder implements MemberUsageExcluder
     public function __construct(
         ReflectionProvider $reflectionProvider,
         bool $enabled,
-        ?array $devPaths = null
+        ?array $devPaths
     )
     {
         $this->reflectionProvider = $reflectionProvider;


### PR DESCRIPTION
Ensures no more mistakes like https://github.com/shipmonk-rnd/dead-code-detector/pull/202