### PR TITLE
TestsExcluder not to exclude mixed usages in tests

### DIFF
--- a/src/Excluder/TestsUsageExcluder.php
+++ b/src/Excluder/TestsUsageExcluder.php
@@ -68,14 +68,14 @@ class TestsUsageExcluder implements MemberUsageExcluder
             return false;
         }
 
-        return $this->isWithinDevPaths($this->realpath($scope->getFile()))
-            && !$this->isWithinDevPaths($this->getDeclarationFile($usage->getMemberRef()->getClassName()));
+        return $this->isWithinDevPaths($this->realpath($scope->getFile())) === true
+            && $this->isWithinDevPaths($this->getDeclarationFile($usage->getMemberRef()->getClassName())) === false;
     }
 
-    private function isWithinDevPaths(?string $filePath): bool
+    private function isWithinDevPaths(?string $filePath): ?bool
     {
         if ($filePath === null) {
-            return false;
+            return null;
         }
 
         foreach ($this->devPaths as $devPath) {

--- a/tests/Rule/data/excluders/tests/src/code.php
+++ b/tests/Rule/data/excluders/tests/src/code.php
@@ -2,6 +2,7 @@
 
 class DeclaredInSrcUsedInTests {
     const CONST = 1; // error: Unused DeclaredInSrcUsedInTests::CONST (all usages excluded by tests excluder)
+    const MIXED = 2;
 }
 
 class DeclaredInSrcUsedInBoth {

--- a/tests/Rule/data/excluders/tests/tests/code.php
+++ b/tests/Rule/data/excluders/tests/tests/code.php
@@ -12,9 +12,10 @@ class DeclaredInTestsUsedInSrc {
     const CONST = 1;
 }
 
-function test1() {
+function test1($mixed) {
     echo DeclaredInSrcUsedInBoth::CONST;
     echo DeclaredInSrcUsedInTests::CONST;
     echo DeclaredInTestsUsedInTests::CONST;
     echo DeclaredInTestsUsedInBoth::CONST;
+    $mixed::MIXED;
 }


### PR DESCRIPTION
- We exclude only usages of src-defined classes. If we dont know the class, it should not be excluded.