### PR TITLE
Fix infinite run for huge unused subtrees

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -662,9 +662,11 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             }
 
             $result[] = $calleeKey;
+            $visitedKeys[$calleeKey] = null;
 
-            foreach ($this->getTransitiveDeadCalls($calleeKey, array_merge($visitedKeys, [$calleeKey => null])) as $transitiveDead) {
+            foreach ($this->getTransitiveDeadCalls($calleeKey, $visitedKeys) as $transitiveDead) {
                 $result[] = $transitiveDead;
+                $visitedKeys[$transitiveDead] = null;
             }
         }
 


### PR DESCRIPTION
This can happen even for mid-size codebases where (for some reason) not a single entrypoint is found (e.g. disabled vendor provider). Or when most usages are excluded. Then, everything becomes dead and complex usage graph can cause this issue.

#### How to recognize it:
- PHPStan execution gets stuck after storing result cache:
```
$ vendor/bin/phpstan -vv
Result cache restored. 0 files will be reanalysed.
 272/272 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% < 1 sec/< 1 sec

Result cache is saved.

(hanging)
```
- It disappears with `reportTransitivelyDeadMethodAsSeparateError: true`
