### PR TITLE
Use `AnalysisResult::withFileSpecificErrors()` instead of constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^2.1.23"
+        "phpstan/phpstan": "^2.1.41"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "602931105142deb047e4870e10a24897",
+    "content-hash": "f77642a5b3037bbed8c2249b9a0b5f9a",
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.42",
+            "version": "2.1.46",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
-                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-17T14:58:32+00:00"
+            "time": "2026-04-01T09:25:14+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Formatter/FilterOutUnmatchedInlineIgnoresFormatter.php
+++ b/src/Formatter/FilterOutUnmatchedInlineIgnoresFormatter.php
@@ -53,18 +53,8 @@ final class FilterOutUnmatchedInlineIgnoresFormatter implements ErrorFormatter
             return $this->originalFormatter->formatErrors($analysisResult, $output);
         }
 
-        $modifiedAnalysisResult = new AnalysisResult( // @phpstan-ignore phpstanApi.constructor
+        $modifiedAnalysisResult = $analysisResult->withFileSpecificErrors(
             $this->filterErrors($analysisResult->getFileSpecificErrors()),
-            $analysisResult->getNotFileSpecificErrors(),
-            $analysisResult->getInternalErrorObjects(),
-            $analysisResult->getWarnings(),
-            $analysisResult->getCollectedData(),
-            $analysisResult->isDefaultLevelUsed(),
-            $analysisResult->getProjectConfigFile(),
-            $analysisResult->isResultCacheSaved(),
-            $analysisResult->getPeakMemoryUsageBytes(),
-            $analysisResult->isResultCacheUsed(),
-            $analysisResult->getChangedProjectExtensionFilesOutsideOfAnalysedPaths(),
         );
 
         return $this->originalFormatter->formatErrors($modifiedAnalysisResult, $output);


### PR DESCRIPTION
Simplify `FilterOutUnmatchedInlineIgnoresFormatter` by using the new public API method instead of calling the internal constructor directly.

- See phpstan/phpstan-src#5034