### PR TITLE
Remove memberAlternativesCache

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -43,7 +43,6 @@ use function array_unique;
 use function array_values;
 use function in_array;
 use function ksort;
-use function serialize;
 use function strpos;
 
 /**
@@ -114,11 +113,6 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
      * @var array<MemberType::*, array<string, array<string, array<string, string>>>>
      */
     private array $traitMembers = [];
-
-    /**
-     * @var array<string, list<string>>
-     */
-    private array $memberAlternativesCache = [];
 
     private bool $reportTransitivelyDeadAsSeparateError;
 
@@ -548,12 +542,6 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             throw new LogicException('Those were eliminated above, should never happen');
         }
 
-        $cacheKey = serialize([$member, $accessType]);
-
-        if (isset($this->memberAlternativesCache[$cacheKey])) {
-            return $this->memberAlternativesCache[$cacheKey];
-        }
-
         $descendantsToCheck = $member->isPossibleDescendant() ? $this->classHierarchy->getClassDescendants($member->getClassName()) : [];
         $meAndDescendants = [
             $member->getClassName(),
@@ -575,11 +563,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             }
         }
 
-        $result = array_values(array_unique($result));
-
-        $this->memberAlternativesCache[$cacheKey] = $result;
-
-        return $result;
+        return array_values(array_unique($result));
     }
 
     /**


### PR DESCRIPTION
## Project Info

| Metric                  | Value      |
|-------------------------|------------|
| Result cache size       | 805 MB     |
| Main process memory     | 4,283 MB   |
| Total max memory (all)  | 27.05 GB   |
| Total files             | 22,268     |

### DeadCodeRule only measurements:

#### AMD Ryzen AI MAX+ 395

|            | Memory Usage | Time   |
|------------|-------------:|-------:|
| With cache | 766 MB       | 6.49s  |
| No cache   | 582 MB       | 8.63s  |
| **Δ**      | **−184 MB**  | **+2.14s (33% slower)** |

#### Intel Core i7-1255U

|            | Memory Usage | Time    |
|------------|-------------:|--------:|
| With cache | 788 MB       | 10.70s  |
| No cache   | 608 MB       | 14.83s  |
| **Δ**      | **−180 MB**  | **+4.13s (39% slower)** |


------------


But the main takeaways is that it does not affect overall memory and not even max memory of the main process. The only case I found where it affects max memory of main process (but still far from overall memory) was in phpstan-src.