### PR TITLE
Store collector data in own cache, emit only hashes to PHPStan

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,7 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage
         arguments:
             tmpDir: %tmpDir%
+            useOwnCache: %shipmonkDeadCode.cache.useOwnCache%
     -
         class: ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy
     -
@@ -229,6 +230,8 @@ parameters:
     shipmonkDeadCode:
         trackMixedAccess: null
         reportTransitivelyDeadMethodAsSeparateError: false
+        cache:
+            useOwnCache: true
         detect:
             deadMethods: true
             deadConstants: true
@@ -299,6 +302,9 @@ parametersSchema:
     shipmonkDeadCode: structure([
         trackMixedAccess: schema(bool(), nullable()) # deprecated, use usageExcluders.usageOverMixed.enabled
         reportTransitivelyDeadMethodAsSeparateError: bool()
+        cache: structure([
+            useOwnCache: bool()
+        ])
         detect: structure([
             deadMethods: bool()
             deadConstants: bool()

--- a/rules.neon
+++ b/rules.neon
@@ -12,7 +12,7 @@ services:
         class: ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage
         arguments:
             tmpDir: %tmpDir%
-            useOwnCache: %shipmonkDeadCode.cache.useOwnCache%
+            offloadCollectorData: %shipmonkDeadCode.cache.offloadCollectorData%
     -
         class: ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy
     -
@@ -231,7 +231,7 @@ parameters:
         trackMixedAccess: null
         reportTransitivelyDeadMethodAsSeparateError: false
         cache:
-            useOwnCache: true
+            offloadCollectorData: true
         detect:
             deadMethods: true
             deadConstants: true
@@ -303,7 +303,7 @@ parametersSchema:
         trackMixedAccess: schema(bool(), nullable()) # deprecated, use usageExcluders.usageOverMixed.enabled
         reportTransitivelyDeadMethodAsSeparateError: bool()
         cache: structure([
-            useOwnCache: bool()
+            offloadCollectorData: bool()
         ])
         detect: structure([
             deadMethods: bool()

--- a/rules.neon
+++ b/rules.neon
@@ -9,6 +9,10 @@ services:
             identifiers: %shipmonkDeadCode.filterOutUnmatchedInlineIgnoresDuringPartialAnalysis.identifiers%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage
+        arguments:
+            tmpDir: %tmpDir%
+    -
         class: ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy
     -
         class: ShipMonk\PHPStan\DeadCode\Transformer\FileSystem

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -64,7 +64,9 @@ final class UsageCacheStorage
 
         if (!file_exists($filePath)) {
             $this->ensureDirectoryExists($hash);
-            file_put_contents($filePath, $content);
+            if (file_put_contents($filePath, $content) === false) {
+                throw new LogicException("Failed to write DCD cache file: {$filePath}");
+            }
         }
 
         return [$hash];

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -23,7 +23,7 @@ final class UsageCacheStorage
 
     private string $cacheDir;
 
-    private readonly bool $useOwnCache;
+    private readonly bool $offloadCollectorData;
 
     /**
      * @var array<string, true>
@@ -32,11 +32,11 @@ final class UsageCacheStorage
 
     public function __construct(
         string $tmpDir,
-        bool $useOwnCache,
+        bool $offloadCollectorData,
     )
     {
         $this->cacheDir = $tmpDir . '/dcd';
-        $this->useOwnCache = $useOwnCache;
+        $this->offloadCollectorData = $offloadCollectorData;
     }
 
     /**
@@ -53,7 +53,7 @@ final class UsageCacheStorage
             $usages,
         );
 
-        if (!$this->useOwnCache) {
+        if (!$this->offloadCollectorData) {
             return $serialized;
         }
 
@@ -78,7 +78,7 @@ final class UsageCacheStorage
         string $scopeFile,
     ): array
     {
-        if (!$this->useOwnCache) {
+        if (!$this->offloadCollectorData) {
             return [CollectedUsage::deserialize($data, $scopeFile)];
         }
 
@@ -107,7 +107,7 @@ final class UsageCacheStorage
 
     public function gc(): void
     {
-        if (!$this->useOwnCache || !is_dir($this->cacheDir)) {
+        if (!$this->offloadCollectorData || !is_dir($this->cacheDir)) {
             return;
         }
 

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -15,6 +15,7 @@ use function implode;
 use function is_dir;
 use function md5;
 use function mkdir;
+use function substr;
 use function unlink;
 
 final class UsageCacheStorage
@@ -52,7 +53,7 @@ final class UsageCacheStorage
         $filePath = $this->getFilePath($hash);
 
         if (!file_exists($filePath)) {
-            $this->ensureDirectoryExists();
+            $this->ensureDirectoryExists($hash);
             file_put_contents($filePath, $content);
         }
 
@@ -97,33 +98,49 @@ final class UsageCacheStorage
         }
 
         try {
-            $iterator = new DirectoryIterator($this->cacheDir);
+            $subdirs = new DirectoryIterator($this->cacheDir);
         } catch (RuntimeException $e) {
             return;
         }
 
-        foreach ($iterator as $file) {
-            if ($file->isDot() || $file->isDir()) {
+        foreach ($subdirs as $subdir) {
+            if ($subdir->isDot() || !$subdir->isDir()) {
                 continue;
             }
 
-            $hash = $file->getBasename('.dat');
+            try {
+                $files = new DirectoryIterator($subdir->getPathname());
+            } catch (RuntimeException $e) {
+                continue;
+            }
 
-            if (!isset($this->referencedHashes[$hash])) {
-                @unlink($file->getPathname());
+            foreach ($files as $file) {
+                if ($file->isDot() || $file->isDir()) {
+                    continue;
+                }
+
+                $hash = $subdir->getFilename() . $file->getBasename('.dat');
+
+                if (!isset($this->referencedHashes[$hash])) {
+                    @unlink($file->getPathname());
+                }
             }
         }
     }
 
     private function getFilePath(string $hash): string
     {
-        return $this->cacheDir . '/' . $hash . '.dat';
+        $prefix = substr($hash, 0, 2);
+
+        return $this->cacheDir . '/' . $prefix . '/' . substr($hash, 2) . '.dat';
     }
 
-    private function ensureDirectoryExists(): void
+    private function ensureDirectoryExists(string $hash): void
     {
-        if (!is_dir($this->cacheDir)) {
-            @mkdir($this->cacheDir, 0777, true);
+        $dir = $this->cacheDir . '/' . substr($hash, 0, 2);
+
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0777, true);
         }
     }
 

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -43,7 +43,7 @@ final class UsageCacheStorage
      * @param non-empty-list<CollectedUsage> $usages
      * @return non-empty-list<string>
      */
-    public function write(
+    public function pack(
         array $usages,
         string $scopeFile,
     ): array
@@ -73,7 +73,7 @@ final class UsageCacheStorage
     /**
      * @return non-empty-list<CollectedUsage>
      */
-    public function read(
+    public function unpack(
         string $data,
         string $scopeFile,
     ): array

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Cache;
+
+use DirectoryIterator;
+use LogicException;
+use RuntimeException;
+use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
+use function array_map;
+use function explode;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function getmypid;
+use function implode;
+use function is_dir;
+use function md5;
+use function mkdir;
+use function rename;
+use function unlink;
+
+final class UsageCacheStorage
+{
+
+    private string $cacheDir;
+
+    /**
+     * @var array<string, true>
+     */
+    private array $referencedHashes = [];
+
+    public function __construct(string $tmpDir)
+    {
+        $this->cacheDir = $tmpDir . '/dcd';
+    }
+
+    /**
+     * @param non-empty-list<CollectedUsage> $usages
+     * @return string Hash identifier
+     */
+    public function write(
+        array $usages,
+        string $scopeFile
+    ): string
+    {
+        $serialized = array_map(
+            static fn (CollectedUsage $usage): string => $usage->serialize($scopeFile),
+            $usages,
+        );
+
+        $content = implode("\n", $serialized);
+        $hash = md5($content);
+
+        $filePath = $this->getFilePath($hash);
+
+        if (!file_exists($filePath)) {
+            $this->ensureDirectoryExists();
+
+            $tmpFile = $filePath . '.' . getmypid() . '.tmp';
+            file_put_contents($tmpFile, $content);
+            rename($tmpFile, $filePath);
+        }
+
+        return $hash;
+    }
+
+    /**
+     * @return non-empty-list<CollectedUsage>
+     */
+    public function read(
+        string $hash,
+        string $scopeFile
+    ): array
+    {
+        $this->referencedHashes[$hash] = true;
+
+        $filePath = $this->getFilePath($hash);
+
+        if (!file_exists($filePath)) {
+            throw new LogicException(
+                "DCD cache file not found for hash '{$hash}' at '{$filePath}'. "
+                . 'Please clear the PHPStan result cache and re-run the analysis.',
+            );
+        }
+
+        $content = file_get_contents($filePath);
+
+        if ($content === false) {
+            throw new LogicException("Could not read DCD cache file: {$filePath}");
+        }
+
+        return array_map(
+            static fn (string $data): CollectedUsage => CollectedUsage::deserialize($data, $scopeFile),
+            explode("\n", $content),
+        );
+    }
+
+    public function gc(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        try {
+            $iterator = new DirectoryIterator($this->cacheDir);
+        } catch (RuntimeException $e) {
+            return;
+        }
+
+        foreach ($iterator as $file) {
+            if ($file->isDot() || $file->isDir()) {
+                continue;
+            }
+
+            $hash = $file->getBasename('.dat');
+
+            if (!isset($this->referencedHashes[$hash])) {
+                @unlink($file->getPathname());
+            }
+        }
+    }
+
+    private function getFilePath(string $hash): string
+    {
+        return $this->cacheDir . '/' . $hash . '.dat';
+    }
+
+    private function ensureDirectoryExists(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            @mkdir($this->cacheDir, 0777, true);
+        }
+    }
+
+}

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -23,29 +23,39 @@ final class UsageCacheStorage
 
     private string $cacheDir;
 
+    private readonly bool $useOwnCache;
+
     /**
      * @var array<string, true>
      */
     private array $referencedHashes = [];
 
-    public function __construct(string $tmpDir)
+    public function __construct(
+        string $tmpDir,
+        bool $useOwnCache,
+    )
     {
         $this->cacheDir = $tmpDir . '/dcd';
+        $this->useOwnCache = $useOwnCache;
     }
 
     /**
      * @param non-empty-list<CollectedUsage> $usages
-     * @return string Hash identifier
+     * @return non-empty-list<string>
      */
     public function write(
         array $usages,
         string $scopeFile,
-    ): string
+    ): array
     {
         $serialized = array_map(
             static fn (CollectedUsage $usage): string => $usage->serialize($scopeFile),
             $usages,
         );
+
+        if (!$this->useOwnCache) {
+            return $serialized;
+        }
 
         $content = implode("\n", $serialized);
         $hash = md5($content);
@@ -57,24 +67,28 @@ final class UsageCacheStorage
             file_put_contents($filePath, $content);
         }
 
-        return $hash;
+        return [$hash];
     }
 
     /**
      * @return non-empty-list<CollectedUsage>
      */
     public function read(
-        string $hash,
+        string $data,
         string $scopeFile,
     ): array
     {
-        $this->referencedHashes[$hash] = true;
+        if (!$this->useOwnCache) {
+            return [CollectedUsage::deserialize($data, $scopeFile)];
+        }
 
-        $filePath = $this->getFilePath($hash);
+        $this->referencedHashes[$data] = true;
+
+        $filePath = $this->getFilePath($data);
 
         if (!file_exists($filePath)) {
             throw new LogicException(
-                "DCD cache file not found for hash '{$hash}' at '{$filePath}'. "
+                "DCD cache file not found for hash '{$data}' at '{$filePath}'. "
                 . 'Please clear the PHPStan result cache and re-run the analysis.',
             );
         }
@@ -86,14 +100,14 @@ final class UsageCacheStorage
         }
 
         return array_map(
-            static fn (string $data): CollectedUsage => CollectedUsage::deserialize($data, $scopeFile),
+            static fn (string $line): CollectedUsage => CollectedUsage::deserialize($line, $scopeFile),
             explode("\n", $content),
         );
     }
 
     public function gc(): void
     {
-        if (!is_dir($this->cacheDir)) {
+        if (!$this->useOwnCache || !is_dir($this->cacheDir)) {
             return;
         }
 

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -28,7 +28,7 @@ final class UsageCacheStorage
     /**
      * @var array<string, true>
      */
-    private array $referencedHashes = [];
+    private array $readHashes = [];
 
     public function __construct(
         string $tmpDir,
@@ -82,7 +82,7 @@ final class UsageCacheStorage
             return [CollectedUsage::deserialize($data, $scopeFile)];
         }
 
-        $this->referencedHashes[$data] = true;
+        $this->readHashes[$data] = true;
 
         $filePath = $this->getFilePath($data);
 
@@ -105,6 +105,9 @@ final class UsageCacheStorage
         );
     }
 
+    /**
+     * Delete all files in cacheDir that were not read by this cache instance
+     */
     public function gc(): void
     {
         if (!is_dir($this->cacheDir)) {
@@ -135,7 +138,7 @@ final class UsageCacheStorage
 
                 $hash = $subdir->getFilename() . $file->getBasename('.dat');
 
-                if (!isset($this->referencedHashes[$hash])) {
+                if (!isset($this->readHashes[$hash])) {
                     @unlink($file->getPathname());
                 }
             }

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -21,7 +21,7 @@ use function unlink;
 final class UsageCacheStorage
 {
 
-    private string $cacheDir;
+    private readonly string $cacheDir;
 
     private readonly bool $offloadCollectorData;
 

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -11,12 +11,10 @@ use function explode;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
-use function getmypid;
 use function implode;
 use function is_dir;
 use function md5;
 use function mkdir;
-use function rename;
 use function unlink;
 
 final class UsageCacheStorage
@@ -55,10 +53,7 @@ final class UsageCacheStorage
 
         if (!file_exists($filePath)) {
             $this->ensureDirectoryExists();
-
-            $tmpFile = $filePath . '.' . getmypid() . '.tmp';
-            file_put_contents($tmpFile, $content);
-            rename($tmpFile, $filePath);
+            file_put_contents($filePath, $content);
         }
 
         return $hash;

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -107,7 +107,7 @@ final class UsageCacheStorage
 
     public function gc(): void
     {
-        if (!$this->offloadCollectorData || !is_dir($this->cacheDir)) {
+        if (!is_dir($this->cacheDir)) {
             return;
         }
 

--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -38,7 +38,7 @@ final class UsageCacheStorage
      */
     public function write(
         array $usages,
-        string $scopeFile
+        string $scopeFile,
     ): string
     {
         $serialized = array_map(
@@ -64,7 +64,7 @@ final class UsageCacheStorage
      */
     public function read(
         string $hash,
-        string $scopeFile
+        string $scopeFile,
     ): array
     {
         $this->referencedHashes[$hash] = true;

--- a/src/Collector/BufferedUsageCollector.php
+++ b/src/Collector/BufferedUsageCollector.php
@@ -27,7 +27,7 @@ trait BufferedUsageCollector
      */
     private function tryFlushBuffer(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): ?array
     {
         if ($this->usages !== [] && (!$scope->isInClass() || $node instanceof ClassMethodsNode)) { // @phpstan-ignore phpstanApi.instanceofAssumption

--- a/src/Collector/BufferedUsageCollector.php
+++ b/src/Collector/BufferedUsageCollector.php
@@ -32,7 +32,7 @@ trait BufferedUsageCollector
     {
         if ($this->usages !== [] && (!$scope->isInClass() || $node instanceof ClassMethodsNode)) { // @phpstan-ignore phpstanApi.instanceofAssumption
             try {
-                return $this->usageCacheStorage->write($this->usages, $scope->getFile());
+                return $this->usageCacheStorage->pack($this->usages, $scope->getFile());
             } finally {
                 $this->usages = [];
             }

--- a/src/Collector/BufferedUsageCollector.php
+++ b/src/Collector/BufferedUsageCollector.php
@@ -32,9 +32,7 @@ trait BufferedUsageCollector
     {
         if ($this->usages !== [] && (!$scope->isInClass() || $node instanceof ClassMethodsNode)) { // @phpstan-ignore phpstanApi.instanceofAssumption
             try {
-                $hash = $this->usageCacheStorage->write($this->usages, $scope->getFile());
-
-                return [$hash];
+                return $this->usageCacheStorage->write($this->usages, $scope->getFile());
             } finally {
                 $this->usages = [];
             }

--- a/src/Collector/BufferedUsageCollector.php
+++ b/src/Collector/BufferedUsageCollector.php
@@ -2,10 +2,12 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Collector;
 
+use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
+use PHPStan\Node\ClassMethodsNode;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
-use function array_map;
 
 /**
  * @phpstan-require-implements Collector
@@ -18,21 +20,27 @@ trait BufferedUsageCollector
      */
     private array $usages = [];
 
+    private UsageCacheStorage $usageCacheStorage;
+
     /**
      * @return non-empty-list<string>|null
      */
-    private function emitUsages(Scope $scope): ?array
+    private function tryFlushBuffer(
+        Node $node,
+        Scope $scope
+    ): ?array
     {
-        try {
-            return $this->usages === []
-                ? null
-                : array_map(
-                    static fn (CollectedUsage $usage): string => $usage->serialize($scope->getFile()),
-                    $this->usages,
-                );
-        } finally {
-            $this->usages = [];
+        if ($this->usages !== [] && (!$scope->isInClass() || $node instanceof ClassMethodsNode)) { // @phpstan-ignore phpstanApi.instanceofAssumption
+            try {
+                $hash = $this->usageCacheStorage->write($this->usages, $scope->getFile());
+
+                return [$hash];
+            } finally {
+                $this->usages = [];
+            }
         }
+
+        return null;
     }
 
 }

--- a/src/Collector/ConstantFetchCollector.php
+++ b/src/Collector/ConstantFetchCollector.php
@@ -15,6 +15,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Excluder\MemberUsageExcluder;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
@@ -38,10 +39,12 @@ final class ConstantFetchCollector implements Collector
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
+        UsageCacheStorage $usageCacheStorage,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly array $memberUsageExcluders,
     )
     {
+        $this->usageCacheStorage = $usageCacheStorage;
     }
 
     public function getNodeType(): string
@@ -65,7 +68,7 @@ final class ConstantFetchCollector implements Collector
             $this->registerFunctionCall($node, $scope);
         }
 
-        return $this->emitUsages($scope);
+        return $this->tryFlushBuffer($node, $scope);
     }
 
     private function registerFunctionCall(

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -23,6 +23,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Excluder\MemberUsageExcluder;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
@@ -44,9 +45,11 @@ final class MethodCallCollector implements Collector
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
+        UsageCacheStorage $usageCacheStorage,
         private readonly array $memberUsageExcluders,
     )
     {
+        $this->usageCacheStorage = $usageCacheStorage;
     }
 
     public function getNodeType(): string
@@ -94,7 +97,7 @@ final class MethodCallCollector implements Collector
             $this->registerAttribute($node, $scope);
         }
 
-        return $this->emitUsages($scope);
+        return $this->tryFlushBuffer($node, $scope);
     }
 
     /**

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -12,6 +12,7 @@ use PHPStan\Node\InClassMethodNode;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Excluder\MemberUsageExcluder;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
@@ -32,9 +33,11 @@ final class PropertyAccessCollector implements Collector
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
+        UsageCacheStorage $usageCacheStorage,
         private readonly array $memberUsageExcluders,
     )
     {
+        $this->usageCacheStorage = $usageCacheStorage;
     }
 
     public function getNodeType(): string
@@ -66,7 +69,7 @@ final class PropertyAccessCollector implements Collector
             $this->registerPromotedPropertyWrites($node, $scope);
         }
 
-        return $this->emitUsages($scope);
+        return $this->tryFlushBuffer($node, $scope);
     }
 
     private function registerInstancePropertyAccess(

--- a/src/Collector/ProvidedUsagesCollector.php
+++ b/src/Collector/ProvidedUsagesCollector.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ReflectionProvider;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
 use ShipMonk\PHPStan\DeadCode\Excluder\MemberUsageExcluder;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
@@ -27,11 +28,13 @@ final class ProvidedUsagesCollector implements Collector
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
+        UsageCacheStorage $usageCacheStorage,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly array $memberUsageProviders,
         private readonly array $memberUsageExcluders,
     )
     {
+        $this->usageCacheStorage = $usageCacheStorage;
     }
 
     public function getNodeType(): string
@@ -58,7 +61,7 @@ final class ProvidedUsagesCollector implements Collector
             }
         }
 
-        return $this->emitUsages($scope);
+        return $this->tryFlushBuffer($node, $scope);
     }
 
     private function validateUsage(

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\TrinaryLogic;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Collector\ClassDefinitionCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\ConstantFetchCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector;
@@ -76,6 +77,8 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         '__debugInfo' => null,
     ];
 
+    private UsageCacheStorage $usageCacheStorage;
+
     /**
      * typename => data
      *
@@ -129,6 +132,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
     public function __construct(
         private readonly DebugUsagePrinter $debugUsagePrinter,
+        UsageCacheStorage $usageCacheStorage,
         private readonly ClassHierarchy $classHierarchy,
         private readonly bool $detectDeadMethods,
         private readonly bool $detectDeadConstants,
@@ -139,6 +143,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         BackwardCompatibilityChecker $checker,
     )
     {
+        $this->usageCacheStorage = $usageCacheStorage;
         $checker->check();
     }
 
@@ -174,23 +179,26 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         unset($methodCallData, $providedUsagesData, $constFetchData, $propertyAccessData);
 
         foreach ($memberUseData as $file => $usesPerFile) {
-            foreach ($usesPerFile as $useStrings) {
-                foreach ($useStrings as $useString) {
-                    $collectedUsage = CollectedUsage::deserialize($useString, $file);
-                    $memberUsage = $collectedUsage->getUsage();
-                    $className = $memberUsage->getMemberRef()->getClassName();
-                    $memberName = $memberUsage->getMemberRef()->getMemberName();
+            foreach ($usesPerFile as $hashes) {
+                foreach ($hashes as $hash) {
+                    foreach ($this->usageCacheStorage->read($hash, $file) as $collectedUsage) {
+                        $memberUsage = $collectedUsage->getUsage();
+                        $className = $memberUsage->getMemberRef()->getClassName();
+                        $memberName = $memberUsage->getMemberRef()->getMemberName();
 
-                    if ($className === null) {
-                        $memberNameString = $memberName ?? DebugUsagePrinter::ANY_MEMBER;
-                        $this->mixedClassNameUsages[$memberUsage->getMemberType()->value][$memberNameString][] = $collectedUsage;
-                        continue;
+                        if ($className === null) {
+                            $memberNameString = $memberName ?? DebugUsagePrinter::ANY_MEMBER;
+                            $this->mixedClassNameUsages[$memberUsage->getMemberType()->value][$memberNameString][] = $collectedUsage;
+                            continue;
+                        }
+
+                        $knownCollectedUsages[] = $collectedUsage;
                     }
-
-                    $knownCollectedUsages[] = $collectedUsage;
                 }
             }
         }
+
+        $this->usageCacheStorage->gc();
 
         foreach ($classDefinitionData as $file => $data) {
             foreach ($data as $typeData) {

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -181,7 +181,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         foreach ($memberUseData as $file => $usesPerFile) {
             foreach ($usesPerFile as $hashes) {
                 foreach ($hashes as $hash) {
-                    foreach ($this->usageCacheStorage->read($hash, $file) as $collectedUsage) {
+                    foreach ($this->usageCacheStorage->unpack($hash, $file) as $collectedUsage) {
                         $memberUsage = $collectedUsage->getUsage();
                         $className = $memberUsage->getMemberRef()->getClassName();
                         $memberName = $memberUsage->getMemberRef()->getMemberName();

--- a/tests/Cache/UsageCacheStorageTest.php
+++ b/tests/Cache/UsageCacheStorageTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Cache;
+
+use LogicException;
+use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\TestCase;
+use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
+use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function getmypid;
+use function sys_get_temp_dir;
+
+final class UsageCacheStorageTest extends TestCase
+{
+
+    public function testWriteAndReadRoundTrip(): void
+    {
+        $cache = new UsageCacheStorage(sys_get_temp_dir() . '/dcd-test', offloadCollectorData: true);
+
+        $scopeFile = '/app/index.php';
+        $usages = $this->createSampleUsages();
+
+        $hashes = $cache->write($usages, $scopeFile);
+
+        self::assertCount(1, $hashes);
+
+        $restored = $cache->read($hashes[0], $scopeFile);
+
+        self::assertCount(2, $restored);
+        self::assertEquals($usages[0], $restored[0]);
+        self::assertEquals($usages[1], $restored[1]);
+    }
+
+    public function testWriteReturnsSameHashForSameData(): void
+    {
+        $cache = new UsageCacheStorage(sys_get_temp_dir() . '/dcd-test', offloadCollectorData: true);
+
+        $scopeFile = '/app/index.php';
+        $usages = $this->createSampleUsages();
+
+        $hashes1 = $cache->write($usages, $scopeFile);
+        $hashes2 = $cache->write($usages, $scopeFile);
+
+        self::assertSame($hashes1, $hashes2);
+    }
+
+    public function testReadMissingHashThrows(): void
+    {
+        $cache = new UsageCacheStorage(sys_get_temp_dir() . '/dcd-test-missing', offloadCollectorData: true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('DCD cache file not found');
+
+        $cache->read('nonexistenthash', '/app/index.php');
+    }
+
+    public function testDisabledCachePassesDataThrough(): void
+    {
+        $cache = new UsageCacheStorage(sys_get_temp_dir() . '/dcd-test-disabled', offloadCollectorData: false);
+
+        $scopeFile = '/app/index.php';
+        $usages = $this->createSampleUsages();
+
+        $strings = $cache->write($usages, $scopeFile);
+
+        self::assertCount(2, $strings);
+
+        $restored = [];
+
+        foreach ($strings as $string) {
+            foreach ($cache->read($string, $scopeFile) as $usage) {
+                $restored[] = $usage;
+            }
+        }
+
+        self::assertCount(2, $restored);
+        self::assertEquals($usages[0], $restored[0]);
+        self::assertEquals($usages[1], $restored[1]);
+    }
+
+    public function testSerializedUsageContainsNoNewline(): void
+    {
+        $scopeFile = '/app/index.php';
+
+        foreach ($this->createSampleUsages() as $usage) {
+            $serialized = $usage->serialize($scopeFile);
+            self::assertStringNotContainsString("\n", $serialized, 'Serialized usage must not contain newlines (used as separator in cache files)');
+        }
+    }
+
+    public function testGcRemovesUnreadFiles(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/dcd-test-gc-' . getmypid();
+        $cache = new UsageCacheStorage($tmpDir, offloadCollectorData: true);
+
+        $scopeFile = '/app/index.php';
+        $usages = $this->createSampleUsages();
+
+        $hash1 = $cache->write([$usages[0]], $scopeFile);
+        $hash2 = $cache->write([$usages[1]], $scopeFile);
+
+        // Only read hash1, so hash2 should be cleaned up
+        $cache->read($hash1[0], $scopeFile);
+        $cache->gc();
+
+        // hash1 should still be readable by a fresh instance
+        $freshCache = new UsageCacheStorage($tmpDir, offloadCollectorData: true);
+        $restored = $freshCache->read($hash1[0], $scopeFile);
+        self::assertCount(1, $restored);
+
+        // hash2 should be gone
+        $this->expectException(LogicException::class);
+        $freshCache->read($hash2[0], $scopeFile);
+    }
+
+    /**
+     * @return array{CollectedUsage, CollectedUsage}
+     */
+    private function createSampleUsages(): array
+    {
+        return [
+            new CollectedUsage(
+                new ClassMethodUsage(
+                    new UsageOrigin(className: 'App\Foo', memberName: 'bar', memberType: MemberType::METHOD, accessType: AccessType::READ, fileName: '/app/index.php', line: 10, provider: null, note: null),
+                    new ClassMethodRef('App\Baz', 'qux', possibleDescendant: false),
+                ),
+                null,
+            ),
+            new CollectedUsage(
+                new ClassConstantUsage(
+                    new UsageOrigin(className: 'App\Foo', memberName: 'bar', memberType: MemberType::METHOD, accessType: AccessType::READ, fileName: '/app/index.php', line: 15, provider: null, note: null),
+                    new ClassConstantRef('App\Config', 'VERSION', possibleDescendant: false, isEnumCase: TrinaryLogic::createNo()),
+                ),
+                null,
+            ),
+        ];
+    }
+
+}

--- a/tests/Cache/UsageCacheStorageTest.php
+++ b/tests/Cache/UsageCacheStorageTest.php
@@ -26,11 +26,11 @@ final class UsageCacheStorageTest extends TestCase
         $scopeFile = '/app/index.php';
         $usages = $this->createSampleUsages();
 
-        $hashes = $cache->write($usages, $scopeFile);
+        $hashes = $cache->pack($usages, $scopeFile);
 
         self::assertCount(1, $hashes);
 
-        $restored = $cache->read($hashes[0], $scopeFile);
+        $restored = $cache->unpack($hashes[0], $scopeFile);
 
         self::assertCount(2, $restored);
         self::assertEquals($usages[0], $restored[0]);
@@ -44,8 +44,8 @@ final class UsageCacheStorageTest extends TestCase
         $scopeFile = '/app/index.php';
         $usages = $this->createSampleUsages();
 
-        $hashes1 = $cache->write($usages, $scopeFile);
-        $hashes2 = $cache->write($usages, $scopeFile);
+        $hashes1 = $cache->pack($usages, $scopeFile);
+        $hashes2 = $cache->pack($usages, $scopeFile);
 
         self::assertSame($hashes1, $hashes2);
     }
@@ -57,7 +57,7 @@ final class UsageCacheStorageTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('DCD cache file not found');
 
-        $cache->read('nonexistenthash', '/app/index.php');
+        $cache->unpack('nonexistenthash', '/app/index.php');
     }
 
     public function testDisabledCachePassesDataThrough(): void
@@ -67,14 +67,14 @@ final class UsageCacheStorageTest extends TestCase
         $scopeFile = '/app/index.php';
         $usages = $this->createSampleUsages();
 
-        $strings = $cache->write($usages, $scopeFile);
+        $strings = $cache->pack($usages, $scopeFile);
 
         self::assertCount(2, $strings);
 
         $restored = [];
 
         foreach ($strings as $string) {
-            foreach ($cache->read($string, $scopeFile) as $usage) {
+            foreach ($cache->unpack($string, $scopeFile) as $usage) {
                 $restored[] = $usage;
             }
         }
@@ -102,21 +102,21 @@ final class UsageCacheStorageTest extends TestCase
         $scopeFile = '/app/index.php';
         $usages = $this->createSampleUsages();
 
-        $hash1 = $cache->write([$usages[0]], $scopeFile);
-        $hash2 = $cache->write([$usages[1]], $scopeFile);
+        $hash1 = $cache->pack([$usages[0]], $scopeFile);
+        $hash2 = $cache->pack([$usages[1]], $scopeFile);
 
         // Only read hash1, so hash2 should be cleaned up
-        $cache->read($hash1[0], $scopeFile);
+        $cache->unpack($hash1[0], $scopeFile);
         $cache->gc();
 
         // hash1 should still be readable by a fresh instance
         $freshCache = new UsageCacheStorage($tmpDir, offloadCollectorData: true);
-        $restored = $freshCache->read($hash1[0], $scopeFile);
+        $restored = $freshCache->unpack($hash1[0], $scopeFile);
         self::assertCount(1, $restored);
 
         // hash2 should be gone
         $this->expectException(LogicException::class);
-        $freshCache->read($hash2[0], $scopeFile);
+        $freshCache->unpack($hash2[0], $scopeFile);
     }
 
     /**

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -28,6 +28,7 @@ use ReflectionClassConstant;
 use ReflectionEnumUnitCase;
 use ReflectionMethod;
 use ReflectionProperty;
+use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Collector\ClassDefinitionCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\ConstantFetchCollector;
 use ShipMonk\PHPStan\DeadCode\Collector\MethodCallCollector;
@@ -115,6 +116,8 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
     private ?DeadCodeRule $rule = null;
 
+    private ?UsageCacheStorage $usageCacheStorage = null;
+
     private ?string $editorUrl = null;
 
     protected function getRule(): DeadCodeRule
@@ -131,6 +134,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                     $this->createOutputEnhancer(),
                     self::createReflectionProvider(),
                 ),
+                $this->getUsageCacheStorage(),
                 new ClassHierarchy(),
                 $this->detectDeadMethods,
                 $this->detectDeadConstants,
@@ -152,17 +156,29 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
     {
         $reflectionProvider = self::createReflectionProvider();
 
+        $usageCacheStorage = $this->getUsageCacheStorage();
+
         return [
             new ProvidedUsagesCollector(
+                $usageCacheStorage,
                 $reflectionProvider,
                 $this->getMemberUsageProviders(),
                 $this->getMemberUsageExcluders(),
             ),
             new ClassDefinitionCollector($reflectionProvider),
-            new MethodCallCollector($this->getMemberUsageExcluders()),
-            new ConstantFetchCollector($reflectionProvider, $this->getMemberUsageExcluders()),
-            new PropertyAccessCollector($this->getMemberUsageExcluders()),
+            new MethodCallCollector($usageCacheStorage, $this->getMemberUsageExcluders()),
+            new ConstantFetchCollector($usageCacheStorage, $reflectionProvider, $this->getMemberUsageExcluders()),
+            new PropertyAccessCollector($usageCacheStorage, $this->getMemberUsageExcluders()),
         ];
+    }
+
+    private function getUsageCacheStorage(): UsageCacheStorage
+    {
+        if ($this->usageCacheStorage === null) {
+            $this->usageCacheStorage = new UsageCacheStorage(__DIR__ . '/../../cache');
+        }
+
+        return $this->usageCacheStorage;
     }
 
     /**

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -175,7 +175,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
     private function getUsageCacheStorage(): UsageCacheStorage
     {
         if ($this->usageCacheStorage === null) {
-            $this->usageCacheStorage = new UsageCacheStorage(__DIR__ . '/../../cache');
+            $this->usageCacheStorage = new UsageCacheStorage(__DIR__ . '/../../cache', true);
         }
 
         return $this->usageCacheStorage;

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -175,7 +175,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
     private function getUsageCacheStorage(): UsageCacheStorage
     {
         if ($this->usageCacheStorage === null) {
-            $this->usageCacheStorage = new UsageCacheStorage(__DIR__ . '/../../cache', true);
+            $this->usageCacheStorage = new UsageCacheStorage(__DIR__ . '/../../cache', offloadCollectorData: true);
         }
 
         return $this->usageCacheStorage;


### PR DESCRIPTION
PHPStan's result cache becomes huge (up to 1GB for huge projects) because DCD collectors emit many JSON-serialized usage strings.

Introduce `UsageCacheStorage` that stores full collector data in `%tmpDir%/dcd/` using content-addressable files. Collectors now emit only md5 hashes through PHPStan's mechanism, dramatically shrinking the result cache. Re-introduce class-boundary batching (flush at `ClassMethodsNode`) to further reduce the number of emits. GC of orphaned cache files runs automatically after each full analysis.

Inspired by my idea in https://github.com/phpstan/phpstan/issues/14074#issuecomment-4045915933
