### PR TITLE
Add support for Symfony UX Twig Component and Live Component attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ parameters:
 - `EventSubscriberInterface::getSubscribedEvents`
 - `onKernelResponse`, `onKernelRequest`, etc
 - `!php/const` and `!php/enum` references in `config` yamls
+- Symfony UX: `#[AsTwigComponent]`/`#[AsLiveComponent]` (constructor, `mount()`), `#[LiveProp]`, `#[LiveAction]`, `#[LiveListener]`, lifecycle hooks
 
 #### Doctrine:
 - `#[AsEntityListener]`, `#[AsDoctrineListener]` attribute

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,8 @@
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/routing": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/scheduler": "^6.3 || ^7.0 || ^8.0",
+        "symfony/ux-live-component": "^2.34",
+        "symfony/ux-twig-component": "^2.34",
         "symfony/validator": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "twig/twig": "^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f77642a5b3037bbed8c2249b9a0b5f9a",
+    "content-hash": "400e8f45c21487e113a1b6cba7078f36",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -10573,6 +10573,173 @@
             "time": "2026-01-26T15:07:59+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/property-info": "^7.4.4|^8.0.4"
+            },
+            "require-dev": {
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v7.4.6",
             "source": {
@@ -10741,6 +10908,79 @@
                 }
             ],
             "time": "2026-01-23T11:07:10+00:00"
+        },
+        {
+            "name": "symfony/stimulus-bundle",
+            "version": "v2.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stimulus-bundle.git",
+                "reference": "d610a2e021cf63f955838b4bfe40da7e4cafe850"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stimulus-bundle/zipball/d610a2e021cf63f955838b4bfe40da7e4cafe850",
+                "reference": "d610a2e021cf63f955838b4bfe40da7e4cafe850",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/config": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.0|^3.0",
+                "symfony/finder": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0|^8.0",
+                "twig/twig": "^2.15.3|^3.8"
+            },
+            "require-dev": {
+                "symfony/asset-mapper": "^6.3|^7.0|^8.0",
+                "symfony/framework-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "zenstruck/browser": "^1.4"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\StimulusBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Integration with your Symfony app & Stimulus!",
+            "keywords": [
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/stimulus-bundle/tree/v2.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T22:29:11+00:00"
         },
         {
             "name": "symfony/string",
@@ -10933,6 +11173,88 @@
             "time": "2026-02-17T07:53:42+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "622d81551770029d44d16be68969712eb47892f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/622d81551770029d44d16be68969712eb47892f1",
+                "reference": "622d81551770029d44d16be68969712eb47892f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v7.4.4",
             "source": {
@@ -11009,6 +11331,196 @@
                 }
             ],
             "time": "2026-01-03T23:30:35+00:00"
+        },
+        {
+            "name": "symfony/ux-live-component",
+            "version": "v2.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-live-component.git",
+                "reference": "f246c189192121781c267e26a64ff6942ef61ab6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-live-component/zipball/f246c189192121781c267e26a64ff6942ef61ab6",
+                "reference": "f246c189192121781c267e26a64ff6942ef61ab6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/property-access": "^5.4.5|^6.0|^7.0|^8.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/stimulus-bundle": "^2.9",
+                "symfony/ux-twig-component": "^2.33.0",
+                "twig/twig": "^3.10.3"
+            },
+            "conflict": {
+                "symfony/config": "<5.4.0",
+                "symfony/property-info": "~7.0.0",
+                "symfony/type-info": "<7.2"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.0|^2.0",
+                "doctrine/collections": "^1.6.8|^2.0",
+                "doctrine/doctrine-bundle": "^2.4.3|^3.0|^4.0",
+                "doctrine/orm": "^2.9.4|^3.0",
+                "doctrine/persistence": "^2.5.2|^3.0|^4.0",
+                "phpdocumentor/reflection-docblock": "^5.6.2",
+                "symfony/config": "^6.3|^7.0|^8.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/form": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/framework-bundle": "^5.4|^6.1|^7.0|^8.0",
+                "symfony/http-kernel": "^6.1|^7.0|^8.0",
+                "symfony/options-resolver": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^6.1|^7.0|^8.0",
+                "symfony/security-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/uid": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/validator": "^5.4|^6.0|^7.0|^8.0",
+                "zenstruck/browser": "^1.2.0",
+                "zenstruck/foundry": "^2.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\LiveComponent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Live components for Symfony",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "components",
+                "symfony-ux",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-live-component/tree/v2.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T22:29:11+00:00"
+        },
+        {
+            "name": "symfony/ux-twig-component",
+            "version": "v2.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-twig-component.git",
+                "reference": "f9942e32246fe3fa9d31f60cffc1ada4d274830a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-twig-component/zipball/f9942e32246fe3fa9d31f60cffc1ada4d274830a",
+                "reference": "f9942e32246fe3fa9d31f60cffc1ada4d274830a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.2|^3.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0|^8.0",
+                "twig/twig": "^3.10.3"
+            },
+            "conflict": {
+                "symfony/config": "<5.4.0"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/css-selector": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/dom-crawler": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/framework-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^6.0|^7.0|^8.0",
+                "symfony/stimulus-bundle": "^2.9.1",
+                "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/webpack-encore-bundle": "^1.15|^2.3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\TwigComponent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Twig components for Symfony",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "components",
+                "symfony-ux",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-twig-component/tree/v2.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-15T18:48:53+00:00"
         },
         {
             "name": "symfony/validator",

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -921,9 +921,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return false;
         }
 
-        $isInstanceOf = 2; // ReflectionAttribute::IS_INSTANCEOF, since PHP 8.0
-
-        return $this->hasAttribute($method->getDeclaringClass(), 'Symfony\UX\TwigComponent\Attribute\AsTwigComponent', $isInstanceOf);
+        return $this->hasAttribute($method->getDeclaringClass(), 'Symfony\UX\TwigComponent\Attribute\AsTwigComponent', ReflectionAttribute::IS_INSTANCEOF);
     }
 
     private function isTwigComponentHookMethod(ReflectionMethod $method): bool
@@ -939,9 +937,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
     private function isLiveComponentActionMethod(ReflectionMethod $method): bool
     {
-        $isInstanceOf = 2; // ReflectionAttribute::IS_INSTANCEOF, since PHP 8.0
-
-        return $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\LiveAction', $isInstanceOf);
+        return $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\LiveAction', ReflectionAttribute::IS_INSTANCEOF);
     }
 
     private function isLiveComponentLifecycleMethod(ReflectionMethod $method): bool

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -51,7 +51,9 @@ use function preg_match_all;
 use function reset;
 use function simplexml_load_string;
 use function sprintf;
+use function str_ends_with;
 use function str_starts_with;
+use function trim;
 
 final class SymfonyUsageProvider implements MemberUsageProvider
 {
@@ -331,6 +333,82 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             }
         }
 
+        foreach ($nativeReflection->getProperties() as $property) {
+            if ($property->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
+                continue;
+            }
+
+            foreach ($property->getAttributes('Symfony\UX\LiveComponent\Attribute\LiveProp') as $livePropAttribute) {
+                $livePropArguments = $livePropAttribute->getArguments();
+
+                $hydrateWith = $livePropArguments['hydrateWith'] ?? null;
+
+                if (is_string($hydrateWith)) {
+                    $hydrateMethodName = trim($hydrateWith, '()');
+
+                    if ($classReflection->hasNativeMethod($hydrateMethodName)) {
+                        $usages[] = $this->createUsage($classReflection->getNativeMethod($hydrateMethodName), 'Called via #[LiveProp(hydrateWith)] attribute');
+                    }
+                }
+
+                $dehydrateWith = $livePropArguments['dehydrateWith'] ?? null;
+
+                if (is_string($dehydrateWith)) {
+                    $dehydrateMethodName = trim($dehydrateWith, '()');
+
+                    if ($classReflection->hasNativeMethod($dehydrateMethodName)) {
+                        $usages[] = $this->createUsage($classReflection->getNativeMethod($dehydrateMethodName), 'Called via #[LiveProp(dehydrateWith)] attribute');
+                    }
+                }
+
+                $onUpdated = $livePropArguments['onUpdated'] ?? null;
+
+                if (is_string($onUpdated) && $classReflection->hasNativeMethod($onUpdated)) {
+                    $usages[] = $this->createUsage($classReflection->getNativeMethod($onUpdated), 'Called via #[LiveProp(onUpdated)] attribute');
+                } elseif (is_array($onUpdated)) {
+                    foreach ($onUpdated as $onUpdatedMethod) {
+                        if (is_string($onUpdatedMethod) && $classReflection->hasNativeMethod($onUpdatedMethod)) {
+                            $usages[] = $this->createUsage($classReflection->getNativeMethod($onUpdatedMethod), 'Called via #[LiveProp(onUpdated)] attribute');
+                        }
+                    }
+                }
+
+                $modifier = $livePropArguments['modifier'] ?? null;
+
+                if (is_string($modifier) && $classReflection->hasNativeMethod($modifier)) {
+                    $usages[] = $this->createUsage($classReflection->getNativeMethod($modifier), 'Called via #[LiveProp(modifier)] attribute');
+                }
+
+                $fieldName = $livePropArguments['fieldName'] ?? null;
+
+                if (is_string($fieldName) && str_ends_with($fieldName, '()')) {
+                    $fieldMethodName = trim($fieldName, '()');
+
+                    if ($classReflection->hasNativeMethod($fieldMethodName)) {
+                        $usages[] = $this->createUsage($classReflection->getNativeMethod($fieldMethodName), 'Called via #[LiveProp(fieldName)] attribute');
+                    }
+                }
+            }
+
+            foreach ($property->getAttributes('Symfony\UX\TwigComponent\Attribute\ExposeInTemplate') as $exposeAttribute) {
+                $exposeArguments = $exposeAttribute->getArguments();
+                $getter = $exposeArguments['getter'] ?? $exposeArguments[1] ?? null;
+
+                if (is_string($getter) && $classReflection->hasNativeMethod($getter)) {
+                    $usages[] = $this->createUsage($classReflection->getNativeMethod($getter), 'Called via #[ExposeInTemplate(getter)] attribute');
+                }
+            }
+        }
+
+        foreach ($nativeReflection->getAttributes('Symfony\UX\LiveComponent\Attribute\AsLiveComponent') as $liveComponentAttribute) {
+            $liveComponentArguments = $liveComponentAttribute->getArguments();
+            $defaultAction = $liveComponentArguments['defaultAction'] ?? null;
+
+            if (is_string($defaultAction) && $classReflection->hasNativeMethod($defaultAction)) {
+                $usages[] = $this->createUsage($classReflection->getNativeMethod($defaultAction), 'Default action method via #[AsLiveComponent(defaultAction)] attribute');
+            }
+        }
+
         return $usages;
     }
 
@@ -349,6 +427,15 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
             if ($this->hasAttribute($property, 'Symfony\Contracts\Service\Attribute\Required')) {
                 $usages[] = $this->createPropertyUsage($property, 'Autowired with #[Required] (set by DIC)', AccessType::WRITE);
+            }
+
+            if ($this->hasAttribute($property, 'Symfony\UX\LiveComponent\Attribute\LiveProp')) {
+                $usages[] = $this->createPropertyUsage($property, 'Stateful property via #[LiveProp] (hydrated/dehydrated by framework)', AccessType::READ);
+                $usages[] = $this->createPropertyUsage($property, 'Stateful property via #[LiveProp] (hydrated/dehydrated by framework)', AccessType::WRITE);
+            }
+
+            if ($this->hasAttribute($property, 'Symfony\UX\TwigComponent\Attribute\ExposeInTemplate')) {
+                $usages[] = $this->createPropertyUsage($property, 'Exposed in template via #[ExposeInTemplate]', AccessType::READ);
             }
         }
 
@@ -555,6 +642,26 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
         if ($this->isProbablySymfonyListener($method)) {
             return 'Probable listener method';
+        }
+
+        if ($this->isConstructorOrMountOnTwigComponent($method)) {
+            return 'Class has #[AsTwigComponent] or #[AsLiveComponent] attribute';
+        }
+
+        if ($this->isTwigComponentHookMethod($method)) {
+            return 'Twig component lifecycle hook';
+        }
+
+        if ($this->isExposedInTemplateMethod($method)) {
+            return 'Exposed in template via #[ExposeInTemplate] attribute';
+        }
+
+        if ($this->isLiveComponentActionMethod($method)) {
+            return 'Live component action/listener method via attribute';
+        }
+
+        if ($this->isLiveComponentLifecycleMethod($method)) {
+            return 'Live component lifecycle hook';
         }
 
         return null;
@@ -806,6 +913,42 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         return false;
+    }
+
+    private function isConstructorOrMountOnTwigComponent(ReflectionMethod $method): bool
+    {
+        if (!$method->isConstructor() && $method->getName() !== 'mount') {
+            return false;
+        }
+
+        $isInstanceOf = 2; // ReflectionAttribute::IS_INSTANCEOF, since PHP 8.0
+
+        return $this->hasAttribute($method->getDeclaringClass(), 'Symfony\UX\TwigComponent\Attribute\AsTwigComponent', $isInstanceOf);
+    }
+
+    private function isTwigComponentHookMethod(ReflectionMethod $method): bool
+    {
+        return $this->hasAttribute($method, 'Symfony\UX\TwigComponent\Attribute\PreMount')
+            || $this->hasAttribute($method, 'Symfony\UX\TwigComponent\Attribute\PostMount');
+    }
+
+    private function isExposedInTemplateMethod(ReflectionMethod $method): bool
+    {
+        return $this->hasAttribute($method, 'Symfony\UX\TwigComponent\Attribute\ExposeInTemplate');
+    }
+
+    private function isLiveComponentActionMethod(ReflectionMethod $method): bool
+    {
+        $isInstanceOf = 2; // ReflectionAttribute::IS_INSTANCEOF, since PHP 8.0
+
+        return $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\LiveAction', $isInstanceOf);
+    }
+
+    private function isLiveComponentLifecycleMethod(ReflectionMethod $method): bool
+    {
+        return $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\PostHydrate')
+            || $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\PreDehydrate')
+            || $this->hasAttribute($method, 'Symfony\UX\LiveComponent\Attribute\PreReRender');
     }
 
     private function isProbablySymfonyListener(ReflectionMethod $method): bool

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -984,6 +984,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-symfony' => [__DIR__ . '/data/providers/symfony.php'];
         yield 'provider-symfony-7.1' => [__DIR__ . '/data/providers/symfony-gte71.php', self::requiresPackage('symfony/dependency-injection', '>= 7.1')];
         yield 'provider-symfony-scheduler' => [__DIR__ . '/data/providers/symfony-scheduler.php', self::requiresPackage('symfony/scheduler', '>= 6.3')];
+        yield 'provider-symfony-ux' => [__DIR__ . '/data/providers/symfony-ux.php', self::requiresPackage('symfony/ux-live-component', '>= 2.0')];
         yield 'provider-twig' => [__DIR__ . '/data/providers/twig.php'];
         yield 'provider-twig-template' => [__DIR__ . '/data/providers/twig-template.php'];
         yield 'provider-phpunit' => [__DIR__ . '/data/providers/phpunit.php'];

--- a/tests/Rule/data/providers/symfony-ux.php
+++ b/tests/Rule/data/providers/symfony-ux.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types = 1);
+
+namespace SymfonyUx;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveListener;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Attribute\PostHydrate;
+use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
+use Symfony\UX\TwigComponent\Attribute\PreMount;
+
+#[AsTwigComponent]
+class AlertComponent
+{
+    public function __construct() {}
+
+    public function mount(): void {}
+
+    #[PreMount]
+    public function preMount(): array { return []; }
+
+    #[PostMount]
+    public function postMount(): void {}
+
+    #[ExposeInTemplate]
+    public string $message = '';
+
+    #[ExposeInTemplate(getter: 'getFormattedMessage')]
+    public string $formatted = '';
+
+    public function getFormattedMessage(): string { return $this->message; }
+
+    #[ExposeInTemplate]
+    public function computedValue(): string { return ''; }
+
+    public string $notExposed = ''; // error: Property SymfonyUx\AlertComponent::$notExposed is never read
+
+    public function deadMethod(): void {} // error: Unused SymfonyUx\AlertComponent::deadMethod
+}
+
+#[AsLiveComponent]
+class CounterComponent
+{
+    public function __construct() {}
+
+    public function mount(): void {}
+
+    #[LiveProp]
+    public int $count = 0;
+
+    #[LiveProp]
+    public ?string $label = null;
+
+    #[LiveAction]
+    public function increment(): void {}
+
+    #[LiveListener('itemUpdated')]
+    public function onItemUpdated(): void {}
+
+    #[PostHydrate]
+    public function afterHydrate(): void {}
+
+    #[PreDehydrate]
+    public function beforeDehydrate(): void {}
+
+    #[PreReRender]
+    public function beforeReRender(): void {}
+
+    public int $notLiveProp = 0; // error: Property SymfonyUx\CounterComponent::$notLiveProp is never read
+
+    public function deadMethod(): void {} // error: Unused SymfonyUx\CounterComponent::deadMethod
+}
+
+#[AsLiveComponent(defaultAction: 'render')]
+class CustomActionComponent
+{
+    public function __construct() {}
+
+    public function render(): void {}
+
+    #[LiveProp(hydrateWith: 'hydrateDate', dehydrateWith: 'dehydrateDate')]
+    public string $date = '';
+
+    public function hydrateDate(string $data): string { return $data; }
+
+    public function dehydrateDate(string $date): string { return $date; }
+
+    #[LiveProp(onUpdated: 'onNameUpdated')]
+    public string $name = '';
+
+    public function onNameUpdated(string $oldValue): void {}
+
+    #[LiveProp(modifier: 'modifyStatus')]
+    public string $status = '';
+
+    public function modifyStatus(LiveProp $prop, string $propName): LiveProp { return $prop; }
+
+    #[LiveProp(fieldName: 'getFieldName()')]
+    public string $dynamicField = '';
+
+    public function getFieldName(): string { return 'field'; }
+
+    public function deadMethod(): void {} // error: Unused SymfonyUx\CustomActionComponent::deadMethod
+}


### PR DESCRIPTION
## Summary

Closes #328

Adds detection for `symfony/ux-twig-component` and `symfony/ux-live-component` attributes to prevent false positives on members used by the framework at runtime.

**Properties:**
- `#[LiveProp]` — marked as READ + WRITE (hydrated/dehydrated by framework)
- `#[ExposeInTemplate]` — marked as READ

**Methods:**
- Constructor and `mount()` on `#[AsTwigComponent]`/`#[AsLiveComponent]` classes
- `#[PreMount]`, `#[PostMount]` lifecycle hooks
- `#[ExposeInTemplate]` on methods
- `#[LiveAction]` (also covers `#[LiveListener]` via `IS_INSTANCEOF`)
- `#[PostHydrate]`, `#[PreDehydrate]`, `#[PreReRender]` lifecycle hooks

**Method references from attribute arguments:**
- `#[LiveProp(hydrateWith/dehydrateWith/onUpdated/modifier/fieldName)]`
- `#[ExposeInTemplate(getter)]`
- `#[AsLiveComponent(defaultAction)]`

All attribute handling was verified against the actual vendor source code in `symfony/ux-live-component` v2.34 and `symfony/ux-twig-component` v2.34.

Co-Authored-By: Claude Code