### PR TITLE
Use ReflectionAttribute::IS_INSTANCEOF constant directly

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -734,10 +734,8 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
     private function isMethodWithRouteAttribute(ReflectionMethod $method): bool
     {
-        $isInstanceOf = 2; // ReflectionAttribute::IS_INSTANCEOF, since PHP 8.0
-
-        return $this->hasAttribute($method, 'Symfony\Component\Routing\Attribute\Route', $isInstanceOf)
-            || $this->hasAttribute($method, 'Symfony\Component\Routing\Annotation\Route', $isInstanceOf);
+        return $this->hasAttribute($method, 'Symfony\Component\Routing\Attribute\Route', ReflectionAttribute::IS_INSTANCEOF)
+            || $this->hasAttribute($method, 'Symfony\Component\Routing\Annotation\Route', ReflectionAttribute::IS_INSTANCEOF);
     }
 
     private function isMethodWithInteractAttribute(ReflectionMethod $method): bool


### PR DESCRIPTION
## Summary
- Replace hardcoded magic number `2` with `ReflectionAttribute::IS_INSTANCEOF` constant in `SymfonyUsageProvider`
- The comment noted it was available since PHP 8.0, and our minimum is PHP 8.1

Co-Authored-By: Claude Code