### PR TITLE
Detect property reads via (array) cast, get_object_vars, json_encode, serialize

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -184,6 +184,7 @@ services:
         tags:
             - phpstan.collector
         arguments:
+            analysedPaths: %analysedPaths%
             memberUsageExcluders: tagged(shipmonk.deadCode.memberUsageExcluder)
 
     -

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\InClassMethodNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -30,6 +31,7 @@ use ShipMonk\PHPStan\DeadCode\Visitor\PropertyWriteVisitor;
 use function array_map;
 use function current;
 use function in_array;
+use function str_starts_with;
 
 /**
  * @implements Collector<Node, list<string>>
@@ -40,10 +42,13 @@ final class PropertyAccessCollector implements Collector
     use BufferedUsageCollector;
 
     /**
+     * @param list<string> $analysedPaths
      * @param list<MemberUsageExcluder> $memberUsageExcluders
      */
     public function __construct(
         UsageCacheStorage $usageCacheStorage,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly array $analysedPaths,
         private readonly array $memberUsageExcluders,
     )
     {
@@ -392,7 +397,8 @@ final class PropertyAccessCollector implements Collector
     }
 
     /**
-     * json_encode() reads only public properties of non-JsonSerializable objects
+     * json_encode() reads public properties of non-JsonSerializable objects,
+     * recursively for nested object properties.
      */
     private function registerJsonEncodePropertyReads(
         Type $type,
@@ -400,29 +406,71 @@ final class PropertyAccessCollector implements Collector
         Scope $scope,
     ): void
     {
-        foreach ($this->getObjectClassReflections($type) as $classReflection) {
-            if ($classReflection->implementsInterface(JsonSerializable::class)) {
-                continue;
-            }
+        $visited = [];
 
-            $this->registerUsage(
-                new ClassPropertyUsage(
-                    UsageOrigin::createRegular($node, $scope),
-                    new ClassPropertyRef(
-                        $classReflection->getName(),
-                        null,
-                        possibleDescendant: !$classReflection->isFinalByKeyword(),
-                    ),
-                    AccessType::READ,
-                ),
-                $node,
-                $scope,
-            );
+        foreach ($this->getObjectClassReflections($type) as $classReflection) {
+            $this->registerJsonEncodePropertyReadsRecursive($classReflection, $node, $scope, $visited);
         }
     }
 
     /**
-     * serialize() reads all properties when no __serialize() or Serializable or __sleep() exists.
+     * @param array<string, true> $visited
+     */
+    private function registerJsonEncodePropertyReadsRecursive(
+        ClassReflection $classReflection,
+        Node $node,
+        Scope $scope,
+        array &$visited,
+    ): void
+    {
+        if ($classReflection->implementsInterface(JsonSerializable::class)) {
+            return;
+        }
+
+        $className = $classReflection->getName();
+
+        if (isset($visited[$className])) {
+            return;
+        }
+
+        $visited[$className] = true;
+
+        $this->registerUsage(
+            new ClassPropertyUsage(
+                UsageOrigin::createRegular($node, $scope),
+                new ClassPropertyRef(
+                    $className,
+                    null,
+                    possibleDescendant: !$classReflection->isFinalByKeyword(),
+                ),
+                AccessType::READ,
+            ),
+            $node,
+            $scope,
+        );
+
+        foreach ($classReflection->getNativeReflection()->getProperties() as $property) {
+            if (!$property->isPublic() || $property->isStatic()) {
+                continue;
+            }
+
+            $propertyReflection = $classReflection->getNativeProperty($property->getName());
+
+            foreach ($propertyReflection->getReadableType()->getReferencedClasses() as $nestedClassName) {
+                $nestedClassReflection = $this->resolveClassForRecursion($nestedClassName);
+
+                if ($nestedClassReflection === null) {
+                    continue;
+                }
+
+                $this->registerJsonEncodePropertyReadsRecursive($nestedClassReflection, $node, $scope, $visited);
+            }
+        }
+    }
+
+    /**
+     * serialize() reads all properties when no __serialize() or Serializable exists,
+     * recursively for nested object properties.
      * When __sleep() exists, we conservatively mark all properties as read since we cannot
      * determine the return value statically.
      */
@@ -432,24 +480,65 @@ final class PropertyAccessCollector implements Collector
         Scope $scope,
     ): void
     {
+        $visited = [];
+
         foreach ($this->getObjectClassReflections($type) as $classReflection) {
-            if ($this->hasCustomSerializationLogic($classReflection)) {
+            $this->registerSerializePropertyReadsRecursive($classReflection, $node, $scope, $visited);
+        }
+    }
+
+    /**
+     * @param array<string, true> $visited
+     */
+    private function registerSerializePropertyReadsRecursive(
+        ClassReflection $classReflection,
+        Node $node,
+        Scope $scope,
+        array &$visited,
+    ): void
+    {
+        if ($this->hasCustomSerializationLogic($classReflection)) {
+            return;
+        }
+
+        $className = $classReflection->getName();
+
+        if (isset($visited[$className])) {
+            return;
+        }
+
+        $visited[$className] = true;
+
+        $this->registerUsage(
+            new ClassPropertyUsage(
+                UsageOrigin::createRegular($node, $scope),
+                new ClassPropertyRef(
+                    $className,
+                    null,
+                    possibleDescendant: !$classReflection->isFinalByKeyword(),
+                ),
+                AccessType::READ,
+            ),
+            $node,
+            $scope,
+        );
+
+        foreach ($classReflection->getNativeReflection()->getProperties() as $property) {
+            if ($property->isStatic()) {
                 continue;
             }
 
-            $this->registerUsage(
-                new ClassPropertyUsage(
-                    UsageOrigin::createRegular($node, $scope),
-                    new ClassPropertyRef(
-                        $classReflection->getName(),
-                        null,
-                        possibleDescendant: !$classReflection->isFinalByKeyword(),
-                    ),
-                    AccessType::READ,
-                ),
-                $node,
-                $scope,
-            );
+            $propertyReflection = $classReflection->getNativeProperty($property->getName());
+
+            foreach ($propertyReflection->getReadableType()->getReferencedClasses() as $nestedClassName) {
+                $nestedClassReflection = $this->resolveClassForRecursion($nestedClassName);
+
+                if ($nestedClassReflection === null) {
+                    continue;
+                }
+
+                $this->registerSerializePropertyReadsRecursive($nestedClassReflection, $node, $scope, $visited);
+            }
         }
     }
 
@@ -464,6 +553,29 @@ final class PropertyAccessCollector implements Collector
         }
 
         return false;
+    }
+
+    private function resolveClassForRecursion(string $className): ?ClassReflection
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $fileName = $classReflection->getFileName();
+
+        if ($fileName === null) {
+            return null;
+        }
+
+        foreach ($this->analysedPaths as $path) {
+            if (str_starts_with($fileName, $path)) {
+                return $classReflection;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -2,16 +2,23 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Collector;
 
+use JsonSerializable;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Cast\Array_ as ArrayCast;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\InClassMethodNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use Serializable;
 use ShipMonk\PHPStan\DeadCode\Cache\UsageCacheStorage;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Excluder\MemberUsageExcluder;
@@ -20,6 +27,9 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use ShipMonk\PHPStan\DeadCode\Visitor\PropertyWriteVisitor;
+use function array_map;
+use function current;
+use function in_array;
 
 /**
  * @implements Collector<Node, list<string>>
@@ -67,6 +77,14 @@ final class PropertyAccessCollector implements Collector
 
         if ($node instanceof InClassMethodNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
             $this->registerPromotedPropertyWrites($node, $scope);
+        }
+
+        if ($node instanceof ArrayCast) {
+            $this->registerArrayCastPropertyRead($node, $scope);
+        }
+
+        if ($node instanceof FuncCall) {
+            $this->registerNativeFunctionPropertyRead($node, $scope);
         }
 
         return $this->tryFlushBuffer($node, $scope);
@@ -277,6 +295,187 @@ final class PropertyAccessCollector implements Collector
                 $scope,
             );
         }
+    }
+
+    private function registerArrayCastPropertyRead(
+        ArrayCast $node,
+        Scope $scope,
+    ): void
+    {
+        $exprType = $scope->getType($node->expr);
+        $this->registerAllPropertyReadsForType($exprType, $node, $scope);
+    }
+
+    private function registerNativeFunctionPropertyRead(
+        FuncCall $node,
+        Scope $scope,
+    ): void
+    {
+        $args = $node->getArgs();
+
+        if ($args === []) {
+            return;
+        }
+
+        $functionNames = $this->getFunctionNames($node, $scope);
+        $firstArgType = $scope->getType(current($args)->value);
+
+        foreach ($functionNames as $functionName) {
+            if (in_array($functionName, ['get_object_vars', 'get_mangled_object_vars'], true)) {
+                $this->registerAllPropertyReadsForType($firstArgType, $node, $scope);
+            }
+
+            if ($functionName === 'json_encode') {
+                $this->registerJsonEncodePropertyReads($firstArgType, $node, $scope);
+            }
+
+            if ($functionName === 'serialize') {
+                $this->registerSerializePropertyReads($firstArgType, $node, $scope);
+            }
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getFunctionNames(
+        FuncCall $node,
+        Scope $scope,
+    ): array
+    {
+        if ($node->name instanceof Name) {
+            return [$node->name->toString()];
+        }
+
+        return array_map(
+            static fn (ConstantStringType $string): string => $string->getValue(),
+            $scope->getType($node->name)->getConstantStrings(),
+        );
+    }
+
+    /**
+     * (array) cast, get_object_vars(), get_mangled_object_vars() — reads all properties
+     */
+    private function registerAllPropertyReadsForType(
+        Type $type,
+        Node $node,
+        Scope $scope,
+    ): void
+    {
+        foreach ($this->getObjectClassReflections($type) as $classReflection) {
+            $this->registerUsage(
+                new ClassPropertyUsage(
+                    UsageOrigin::createRegular($node, $scope),
+                    new ClassPropertyRef(
+                        $classReflection->getName(),
+                        null,
+                        possibleDescendant: !$classReflection->isFinalByKeyword(),
+                    ),
+                    AccessType::READ,
+                ),
+                $node,
+                $scope,
+            );
+        }
+
+        if ($this->getObjectClassReflections($type) === []) {
+            $this->registerUsage(
+                new ClassPropertyUsage(
+                    UsageOrigin::createRegular($node, $scope),
+                    new ClassPropertyRef(null, null, possibleDescendant: true),
+                    AccessType::READ,
+                ),
+                $node,
+                $scope,
+            );
+        }
+    }
+
+    /**
+     * json_encode() reads only public properties of non-JsonSerializable objects
+     */
+    private function registerJsonEncodePropertyReads(
+        Type $type,
+        Node $node,
+        Scope $scope,
+    ): void
+    {
+        foreach ($this->getObjectClassReflections($type) as $classReflection) {
+            if ($classReflection->implementsInterface(JsonSerializable::class)) {
+                continue;
+            }
+
+            $this->registerUsage(
+                new ClassPropertyUsage(
+                    UsageOrigin::createRegular($node, $scope),
+                    new ClassPropertyRef(
+                        $classReflection->getName(),
+                        null,
+                        possibleDescendant: !$classReflection->isFinalByKeyword(),
+                    ),
+                    AccessType::READ,
+                ),
+                $node,
+                $scope,
+            );
+        }
+    }
+
+    /**
+     * serialize() reads all properties when no __serialize() or Serializable or __sleep() exists.
+     * When __sleep() exists, we conservatively mark all properties as read since we cannot
+     * determine the return value statically.
+     */
+    private function registerSerializePropertyReads(
+        Type $type,
+        Node $node,
+        Scope $scope,
+    ): void
+    {
+        foreach ($this->getObjectClassReflections($type) as $classReflection) {
+            if ($this->hasCustomSerializationLogic($classReflection)) {
+                continue;
+            }
+
+            $this->registerUsage(
+                new ClassPropertyUsage(
+                    UsageOrigin::createRegular($node, $scope),
+                    new ClassPropertyRef(
+                        $classReflection->getName(),
+                        null,
+                        possibleDescendant: !$classReflection->isFinalByKeyword(),
+                    ),
+                    AccessType::READ,
+                ),
+                $node,
+                $scope,
+            );
+        }
+    }
+
+    private function hasCustomSerializationLogic(ClassReflection $classReflection): bool
+    {
+        if ($classReflection->hasNativeMethod('__serialize')) {
+            return true;
+        }
+
+        if ($classReflection->implementsInterface(Serializable::class)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<ClassReflection>
+     */
+    private function getObjectClassReflections(Type $type): array
+    {
+        $typeNoNull = TypeUtils::toBenevolentUnion(
+            TypeCombinator::removeNull($type),
+        );
+
+        return $typeNoNull->getObjectTypeOrClassStringObjectType()->getObjectClassReflections();
     }
 
 }

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -323,6 +323,18 @@ final class PropertyAccessCollector implements Collector
         foreach ($functionNames as $functionName) {
             if (in_array($functionName, ['get_object_vars', 'get_mangled_object_vars'], true)) {
                 $this->registerAllPropertyReadsForType($firstArgType, $node, $scope);
+
+                if ($this->getObjectClassReflections($firstArgType) === []) {
+                    $this->registerUsage(
+                        new ClassPropertyUsage(
+                            UsageOrigin::createRegular($node, $scope),
+                            new ClassPropertyRef(null, null, possibleDescendant: true),
+                            AccessType::READ,
+                        ),
+                        $node,
+                        $scope,
+                    );
+                }
             }
 
             if ($functionName === 'json_encode') {
@@ -371,18 +383,6 @@ final class PropertyAccessCollector implements Collector
                         null,
                         possibleDescendant: !$classReflection->isFinalByKeyword(),
                     ),
-                    AccessType::READ,
-                ),
-                $node,
-                $scope,
-            );
-        }
-
-        if ($this->getObjectClassReflections($type) === []) {
-            $this->registerUsage(
-                new ClassPropertyUsage(
-                    UsageOrigin::createRegular($node, $scope),
-                    new ClassPropertyRef(null, null, possibleDescendant: true),
                     AccessType::READ,
                 ),
                 $node,

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1067,6 +1067,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-write-multi' => [__DIR__ . '/data/properties/write-multi.php'];
         yield 'property-write-coalesce' => [__DIR__ . '/data/properties/write-coalesce.php'];
         yield 'property-write-inc-dec' => [__DIR__ . '/data/properties/write-inc-dec.php'];
+        yield 'property-native-reads' => [__DIR__ . '/data/properties/native-reads.php'];
         yield 'property-mixed' => [__DIR__ . '/data/properties/mixed/tracked.php'];
 
         // mixed member

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -168,7 +168,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             new ClassDefinitionCollector($reflectionProvider),
             new MethodCallCollector($usageCacheStorage, $this->getMemberUsageExcluders()),
             new ConstantFetchCollector($usageCacheStorage, $reflectionProvider, $this->getMemberUsageExcluders()),
-            new PropertyAccessCollector($usageCacheStorage, $this->getMemberUsageExcluders()),
+            new PropertyAccessCollector($usageCacheStorage, $reflectionProvider, [__DIR__ . '/data/'], $this->getMemberUsageExcluders()),
         ];
     }
 

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -183,6 +183,12 @@ function testArrayCastUnknownType($unknown): void
     (array) $unknown;
 }
 
+/** @param object $unknown */
+function testGetObjectVarsUnknownType($unknown): void
+{
+    get_object_vars($unknown);
+}
+
 function testGetObjectVars(): void
 {
     $obj = new GetObjectVarsClass();

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -12,14 +12,12 @@ class ArrayCastClass
     public string $pub;
     protected string $prot;
     private string $priv;
-    public string $notUsedOtherwise;
 
     public function __construct()
     {
         $this->pub = 'a';
         $this->prot = 'b';
         $this->priv = 'c';
-        $this->notUsedOtherwise = 'd';
     }
 }
 
@@ -42,11 +40,6 @@ class ArrayCastChild extends ArrayCastParent
         parent::__construct();
         $this->childProp = 'b';
     }
-}
-
-class ArrayCastUnused
-{
-    public string $notUsed; // error: Property NativePropertyReads\ArrayCastUnused::$notUsed is never read // error: Property NativePropertyReads\ArrayCastUnused::$notUsed is never written
 }
 
 // --- get_object_vars ---
@@ -83,19 +76,7 @@ class GetMangledClass
 
 // --- json_encode ---
 
-final class JsonEncodePublicOnly
-{
-    public string $pub;
-    private string $priv;
-
-    public function __construct()
-    {
-        $this->pub = 'a';
-        $this->priv = 'b';
-    }
-}
-
-class JsonEncodeNonFinal
+final class JsonEncodeClass
 {
     public string $pub;
     private string $priv;
@@ -187,7 +168,7 @@ final class SerializableInterfaceClass implements Serializable
 function testArrayCast(): void
 {
     $obj = new ArrayCastClass();
-    $arr = (array) $obj;
+    (array) $obj;
 
     $parent = new ArrayCastParent();
     (array) $parent;
@@ -216,11 +197,8 @@ function testGetMangledObjectVars(): void
 
 function testJsonEncode(): void
 {
-    $obj = new JsonEncodePublicOnly();
+    $obj = new JsonEncodeClass();
     json_encode($obj);
-
-    $nonFinal = new JsonEncodeNonFinal();
-    json_encode($nonFinal);
 
     $serializable = new JsonSerializableClass();
     json_encode($serializable);

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -165,6 +165,100 @@ final class SerializableInterfaceClass implements Serializable
     }
 }
 
+// --- json_encode transitive ---
+
+final class JsonEncodeNested
+{
+    public string $name;
+
+    public function __construct()
+    {
+        $this->name = 'nested';
+    }
+}
+
+final class JsonEncodeOuter
+{
+    public JsonEncodeNested $nested;
+    public \DateTimeInterface $date;
+
+    public function __construct()
+    {
+        $this->nested = new JsonEncodeNested();
+        $this->date = new \DateTimeImmutable();
+    }
+}
+
+final class JsonEncodeNestedJsonSerializable implements JsonSerializable
+{
+    public string $ignoredProp; // error: Property NativePropertyReads\JsonEncodeNestedJsonSerializable::$ignoredProp is never read // error: Property NativePropertyReads\JsonEncodeNestedJsonSerializable::$ignoredProp is never written
+
+    public function jsonSerialize(): mixed
+    {
+        return ['custom' => 'data'];
+    }
+}
+
+final class JsonEncodeOuterWithJsonSerializableNested
+{
+    public JsonEncodeNestedJsonSerializable $nested;
+
+    public function __construct()
+    {
+        $this->nested = new JsonEncodeNestedJsonSerializable();
+    }
+}
+
+// --- serialize transitive ---
+
+final class SerializeNested
+{
+    public string $name;
+    private int $id;
+
+    public function __construct()
+    {
+        $this->name = 'nested';
+        $this->id = 1;
+    }
+}
+
+final class SerializeOuter
+{
+    public SerializeNested $nested;
+
+    public function __construct()
+    {
+        $this->nested = new SerializeNested();
+    }
+}
+
+final class SerializeNestedWithMagic
+{
+    public string $ignoredProp; // error: Property NativePropertyReads\SerializeNestedWithMagic::$ignoredProp is never read // error: Property NativePropertyReads\SerializeNestedWithMagic::$ignoredProp is never written
+
+    /** @return array<string, mixed> */
+    public function __serialize(): array
+    {
+        return [];
+    }
+
+    /** @param array<string, mixed> $data */
+    public function __unserialize(array $data): void
+    {
+    }
+}
+
+final class SerializeOuterWithMagicNested
+{
+    public SerializeNestedWithMagic $nested;
+
+    public function __construct()
+    {
+        $this->nested = new SerializeNestedWithMagic();
+    }
+}
+
 function testArrayCast(): void
 {
     $obj = new ArrayCastClass();
@@ -208,6 +302,12 @@ function testJsonEncode(): void
 
     $serializable = new JsonSerializableClass();
     json_encode($serializable);
+
+    $outer = new JsonEncodeOuter();
+    json_encode($outer);
+
+    $outerWithJsonSerializable = new JsonEncodeOuterWithJsonSerializableNested();
+    json_encode($outerWithJsonSerializable);
 }
 
 function testSerialize(): void
@@ -223,4 +323,10 @@ function testSerialize(): void
 
     $iface = new SerializableInterfaceClass();
     serialize($iface);
+
+    $outer = new SerializeOuter();
+    serialize($outer);
+
+    $outerWithMagic = new SerializeOuterWithMagicNested();
+    serialize($outerWithMagic);
 }

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -1,0 +1,242 @@
+<?php declare(strict_types = 1);
+
+namespace NativePropertyReads;
+
+use JsonSerializable;
+use Serializable;
+
+// --- (array) cast ---
+
+class ArrayCastClass
+{
+    public string $pub;
+    protected string $prot;
+    private string $priv;
+    public string $notUsedOtherwise;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->prot = 'b';
+        $this->priv = 'c';
+        $this->notUsedOtherwise = 'd';
+    }
+}
+
+class ArrayCastParent
+{
+    public string $parentProp;
+
+    public function __construct()
+    {
+        $this->parentProp = 'a';
+    }
+}
+
+class ArrayCastChild extends ArrayCastParent
+{
+    public string $childProp;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->childProp = 'b';
+    }
+}
+
+class ArrayCastUnused
+{
+    public string $notUsed; // error: Property NativePropertyReads\ArrayCastUnused::$notUsed is never read // error: Property NativePropertyReads\ArrayCastUnused::$notUsed is never written
+}
+
+// --- get_object_vars ---
+
+class GetObjectVarsClass
+{
+    public string $pub;
+    protected string $prot;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->prot = 'b';
+        $this->priv = 'c';
+    }
+}
+
+// --- get_mangled_object_vars ---
+
+class GetMangledClass
+{
+    public string $pub;
+    protected string $prot;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->prot = 'b';
+        $this->priv = 'c';
+    }
+}
+
+// --- json_encode ---
+
+final class JsonEncodePublicOnly
+{
+    public string $pub;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->priv = 'b';
+    }
+}
+
+class JsonEncodeNonFinal
+{
+    public string $pub;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->priv = 'b';
+    }
+}
+
+final class JsonSerializableClass implements JsonSerializable
+{
+    public string $pub; // error: Property NativePropertyReads\JsonSerializableClass::$pub is never read // error: Property NativePropertyReads\JsonSerializableClass::$pub is never written
+    private string $priv; // error: Property NativePropertyReads\JsonSerializableClass::$priv is never read // error: Property NativePropertyReads\JsonSerializableClass::$priv is never written
+
+    public function jsonSerialize(): mixed
+    {
+        return ['custom' => 'data'];
+    }
+}
+
+// --- serialize ---
+
+final class SerializeDefault
+{
+    public string $pub;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->priv = 'b';
+    }
+}
+
+final class SerializeWithMagic
+{
+    public string $pub; // error: Property NativePropertyReads\SerializeWithMagic::$pub is never read // error: Property NativePropertyReads\SerializeWithMagic::$pub is never written
+    private string $priv; // error: Property NativePropertyReads\SerializeWithMagic::$priv is never read // error: Property NativePropertyReads\SerializeWithMagic::$priv is never written
+
+    /** @return array<string, mixed> */
+    public function __serialize(): array
+    {
+        return ['custom' => 'data'];
+    }
+
+    /** @param array<string, mixed> $data */
+    public function __unserialize(array $data): void
+    {
+    }
+}
+
+final class SerializeWithSleep
+{
+    public string $pub;
+    private string $priv;
+
+    public function __construct()
+    {
+        $this->pub = 'a';
+        $this->priv = 'b';
+    }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        return ['pub'];
+    }
+}
+
+/**
+ * @implements Serializable<string>
+ */
+final class SerializableInterfaceClass implements Serializable
+{
+    public string $pub; // error: Property NativePropertyReads\SerializableInterfaceClass::$pub is never read // error: Property NativePropertyReads\SerializableInterfaceClass::$pub is never written
+
+    public function serialize(): string
+    {
+        return '';
+    }
+
+    public function unserialize(string $data): void
+    {
+    }
+}
+
+function testArrayCast(): void
+{
+    $obj = new ArrayCastClass();
+    $arr = (array) $obj;
+
+    $parent = new ArrayCastParent();
+    (array) $parent;
+
+    $child = new ArrayCastChild();
+    (array) $child;
+}
+
+/** @param mixed $unknown */
+function testArrayCastUnknownType($unknown): void
+{
+    (array) $unknown;
+}
+
+function testGetObjectVars(): void
+{
+    $obj = new GetObjectVarsClass();
+    get_object_vars($obj);
+}
+
+function testGetMangledObjectVars(): void
+{
+    $obj = new GetMangledClass();
+    get_mangled_object_vars($obj);
+}
+
+function testJsonEncode(): void
+{
+    $obj = new JsonEncodePublicOnly();
+    json_encode($obj);
+
+    $nonFinal = new JsonEncodeNonFinal();
+    json_encode($nonFinal);
+
+    $serializable = new JsonSerializableClass();
+    json_encode($serializable);
+}
+
+function testSerialize(): void
+{
+    $default = new SerializeDefault();
+    serialize($default);
+
+    $magic = new SerializeWithMagic();
+    serialize($magic);
+
+    $sleep = new SerializeWithSleep();
+    serialize($sleep);
+
+    $iface = new SerializableInterfaceClass();
+    serialize($iface);
+}


### PR DESCRIPTION
## Summary

- Detect properties read by `(array) $object` cast, `get_object_vars()`, `get_mangled_object_vars()`, `json_encode()`, and `serialize()` so they are no longer falsely reported as dead
- `json_encode()` skips `JsonSerializable` objects (calls `jsonSerialize()` instead of reading properties)
- `serialize()` skips objects with `__serialize()` or `Serializable` interface (custom serialization, no direct property reads)

Closes #331

Co-Authored-By: Claude Code