### PR TITLE
Add Blade view data support

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -92,11 +92,15 @@ services:
             containerXmlPaths: %shipmonkDeadCode.usageProviders.symfony.containerXmlPaths%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\TemplateViewDataTraverser
+        arguments:
+            analysedPaths: %analysedPaths%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\TwigUsageProvider
         tags:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
-            analysedPaths: %analysedPaths%
             enabled: %shipmonkDeadCode.usageProviders.twig.enabled%
 
     -
@@ -126,6 +130,13 @@ services:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.laravel.enabled%
+
+    -
+        class: ShipMonk\PHPStan\DeadCode\Provider\BladeUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.blade.enabled%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\NetteUsageProvider
@@ -271,6 +282,8 @@ parameters:
                 enabled: null
             laravel:
                 enabled: null
+            blade:
+                enabled: null
             nette:
                 enabled: null
             netteTester:
@@ -358,6 +371,9 @@ parametersSchema:
                 enabled: schema(bool(), nullable())
             ])
             laravel: structure([
+                enabled: schema(bool(), nullable())
+            ])
+            blade: structure([
                 enabled: schema(bool(), nullable())
             ])
             nette: structure([

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -13,9 +13,21 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function strpos;
+use function substr;
 
 final class BladeUsageProvider implements MemberUsageProvider
 {
+
+    private const VIEW_FACADE_METHODS = [
+        'make' => true,
+        'first' => true,
+        'composer' => true,
+        'creator' => true,
+    ];
 
     private readonly ReflectionProvider $reflectionProvider;
 
@@ -88,7 +100,7 @@ final class BladeUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * Handles View::make('template', $data) and View::first($views, $data)
+     * Handles View::make/first('template', $data) and View::composer/creator('view', Class::class)
      *
      * @return list<ClassMemberUsage>
      */
@@ -103,7 +115,7 @@ final class BladeUsageProvider implements MemberUsageProvider
 
         $methodName = $node->name->toString();
 
-        if ($methodName !== 'make' && $methodName !== 'first') {
+        if (!isset(self::VIEW_FACADE_METHODS[$methodName])) {
             return [];
         }
 
@@ -122,17 +134,67 @@ final class BladeUsageProvider implements MemberUsageProvider
                 $classReflection->is('Illuminate\Support\Facades\View')
                 || $classReflection->is('Illuminate\Contracts\View\Factory')
             ) {
-                $args = $node->getArgs();
+                if ($methodName === 'make' || $methodName === 'first') {
+                    $args = $node->getArgs();
 
-                if (!isset($args[1])) {
-                    return [];
+                    if (!isset($args[1])) {
+                        return [];
+                    }
+
+                    return $this->traverseDataArg($args[1]->value, $node, $scope);
                 }
 
-                return $this->traverseDataArg($args[1]->value, $node, $scope);
+                // View::composer('view', Class::class) / View::creator('view', Class::class)
+                return $this->getUsagesFromComposerOrCreator($node, $scope, $methodName);
             }
         }
 
         return [];
+    }
+
+    /**
+     * @return list<ClassMethodUsage>
+     */
+    private function getUsagesFromComposerOrCreator(
+        StaticCall $node,
+        Scope $scope,
+        string $methodName,
+    ): array
+    {
+        $args = $node->getArgs();
+
+        if (!isset($args[1])) {
+            return [];
+        }
+
+        $callbackType = $scope->getType($args[1]->value);
+        $usages = [];
+
+        /** @var string $methodName View::composer → compose, View::creator → create */
+        $calledMethod = $methodName === 'composer' ? 'compose' : 'create';
+
+        foreach ($callbackType->getConstantStrings() as $stringType) {
+            $value = $stringType->getValue();
+
+            // Support 'Class@method' syntax
+            $atPos = strpos($value, '@');
+
+            if ($atPos !== false) {
+                $callbackClassName = substr($value, 0, $atPos);
+                $calledMethod = substr($value, $atPos + 1);
+            } else {
+                $callbackClassName = $value;
+            }
+
+            foreach ([$calledMethod, '__construct'] as $method) {
+                $usages[] = new ClassMethodUsage(
+                    UsageOrigin::createRegular($node, $scope),
+                    new ClassMethodRef($callbackClassName, $method, possibleDescendant: false),
+                );
+            }
+        }
+
+        return $usages;
     }
 
     /**

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -1,0 +1,254 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use Composer\InstalledVersions;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+
+final class BladeUsageProvider implements MemberUsageProvider
+{
+
+    private readonly ReflectionProvider $reflectionProvider;
+
+    private readonly TemplateViewDataTraverser $traverser;
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        TemplateViewDataTraverser $traverser,
+        ?bool $enabled,
+    )
+    {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->traverser = $traverser;
+        $this->enabled = $enabled ?? InstalledVersions::isInstalled('laravel/framework');
+    }
+
+    public function getUsages(
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$this->enabled) {
+            return [];
+        }
+
+        $usages = [];
+
+        if ($node instanceof FuncCall) {
+            $usages = [...$usages, ...$this->getUsagesFromViewHelper($node, $scope)];
+        }
+
+        if ($node instanceof StaticCall) {
+            $usages = [...$usages, ...$this->getUsagesFromViewFacade($node, $scope)];
+        }
+
+        if ($node instanceof MethodCall) {
+            $usages = [...$usages, ...$this->getUsagesFromMethodCall($node, $scope)];
+        }
+
+        return $usages;
+    }
+
+    /**
+     * Handles view('template', ['key' => $model])
+     *
+     * @return list<ClassMemberUsage>
+     */
+    private function getUsagesFromViewHelper(
+        FuncCall $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$node->name instanceof Name) {
+            return [];
+        }
+
+        if ($node->name->toString() !== 'view') {
+            return [];
+        }
+
+        $args = $node->getArgs();
+
+        if (!isset($args[1])) {
+            return [];
+        }
+
+        return $this->traverseDataArg($args[1]->value, $node, $scope);
+    }
+
+    /**
+     * Handles View::make('template', $data) and View::first($views, $data)
+     *
+     * @return list<ClassMemberUsage>
+     */
+    private function getUsagesFromViewFacade(
+        StaticCall $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        if ($methodName !== 'make' && $methodName !== 'first') {
+            return [];
+        }
+
+        $callerType = $node->class instanceof Expr
+            ? $scope->getType($node->class)
+            : $scope->resolveTypeByName($node->class);
+
+        foreach ($callerType->getObjectClassNames() as $className) {
+            if (!$this->reflectionProvider->hasClass($className)) {
+                continue;
+            }
+
+            $classReflection = $this->reflectionProvider->getClass($className);
+
+            if (
+                $classReflection->is('Illuminate\Support\Facades\View')
+                || $classReflection->is('Illuminate\Contracts\View\Factory')
+            ) {
+                $args = $node->getArgs();
+
+                if (!isset($args[1])) {
+                    return [];
+                }
+
+                return $this->traverseDataArg($args[1]->value, $node, $scope);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Handles:
+     * - $factory->make('template', $data) / $factory->first($views, $data)
+     * - $response->view('template', $data)
+     * - $view->with('key', $value) / $view->with(['key' => $value])
+     *
+     * @return list<ClassMemberUsage>
+     */
+    private function getUsagesFromMethodCall(
+        MethodCall $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        $callerType = $scope->getType($node->var);
+
+        foreach ($callerType->getObjectClassNames() as $className) {
+            if (!$this->reflectionProvider->hasClass($className)) {
+                continue;
+            }
+
+            $classReflection = $this->reflectionProvider->getClass($className);
+
+            if ($classReflection->is('Illuminate\Contracts\View\Factory')) {
+                if ($methodName === 'make' || $methodName === 'first') {
+                    $args = $node->getArgs();
+
+                    if (!isset($args[1])) {
+                        return [];
+                    }
+
+                    return $this->traverseDataArg($args[1]->value, $node, $scope);
+                }
+            }
+
+            if ($classReflection->is('Illuminate\Contracts\Routing\ResponseFactory')) {
+                if ($methodName === 'view') {
+                    $args = $node->getArgs();
+
+                    if (!isset($args[1])) {
+                        return [];
+                    }
+
+                    return $this->traverseDataArg($args[1]->value, $node, $scope);
+                }
+            }
+
+            if ($classReflection->is('Illuminate\Contracts\View\View')) {
+                if ($methodName === 'with') {
+                    return $this->getUsagesFromWithCall($node, $scope);
+                }
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function getUsagesFromWithCall(
+        MethodCall $node,
+        Scope $scope,
+    ): array
+    {
+        $args = $node->getArgs();
+
+        // with('key', $value) — extract from value arg
+        if (isset($args[1])) {
+            return $this->traverseDataArg($args[1]->value, $node, $scope);
+        }
+
+        // with(['key' => $value]) — extract from array arg
+        if (isset($args[0])) {
+            return $this->traverseDataArg($args[0]->value, $node, $scope);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function traverseDataArg(
+        Expr $dataExpr,
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        $referencedClassNames = $scope->getType($dataExpr)->getReferencedClasses();
+        $rootContext = $this->getRootContext($node, $scope);
+
+        return $this->traverser->getUsages($referencedClassNames, $rootContext, $this);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function getRootContext(
+        Node $node,
+        Scope $scope,
+    ): string
+    {
+        $functionName = $scope->getFunctionName();
+
+        if (!$scope->isInClass() || $functionName === null) {
+            return 'unknown';
+        }
+
+        return "{$scope->getClassReflection()->getName()}::{$functionName}({$node->getStartLine()})";
+    }
+
+}

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -4,6 +4,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 
 use Composer\InstalledVersions;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -145,7 +146,7 @@ final class BladeUsageProvider implements MemberUsageProvider
                 }
 
                 // View::composer('view', Class::class) / View::creator('view', Class::class)
-                return $this->getUsagesFromComposerOrCreator($node, $scope, $methodName);
+                return $this->getUsagesFromComposerOrCreator($node, $node->getArgs(), $scope, $methodName);
             }
         }
 
@@ -153,16 +154,16 @@ final class BladeUsageProvider implements MemberUsageProvider
     }
 
     /**
+     * @param array<Arg> $args
      * @return list<ClassMethodUsage>
      */
     private function getUsagesFromComposerOrCreator(
-        StaticCall $node,
+        Node $node,
+        array $args,
         Scope $scope,
         string $methodName,
     ): array
     {
-        $args = $node->getArgs();
-
         if (!isset($args[1])) {
             return [];
         }
@@ -170,8 +171,8 @@ final class BladeUsageProvider implements MemberUsageProvider
         $callbackType = $scope->getType($args[1]->value);
         $usages = [];
 
-        /** @var string $methodName View::composer → compose, View::creator → create */
-        $calledMethod = $methodName === 'composer' ? 'compose' : 'create';
+        // View::composer → compose, View::creator → create (see Illuminate\View\Concerns\ManagesEvents::classEventMethodForPrefix)
+        $defaultMethod = $methodName === 'composer' ? 'compose' : 'create';
 
         foreach ($callbackType->getConstantStrings() as $stringType) {
             $value = $stringType->getValue();
@@ -184,6 +185,7 @@ final class BladeUsageProvider implements MemberUsageProvider
                 $calledMethod = substr($value, $atPos + 1);
             } else {
                 $callbackClassName = $value;
+                $calledMethod = $defaultMethod;
             }
 
             foreach ([$calledMethod, '__construct'] as $method) {
@@ -200,6 +202,7 @@ final class BladeUsageProvider implements MemberUsageProvider
     /**
      * Handles:
      * - $factory->make('template', $data) / $factory->first($views, $data)
+     * - $factory->composer('view', Class::class) / $factory->creator('view', Class::class)
      * - $response->view('template', $data)
      * - $view->with('key', $value) / $view->with(['key' => $value])
      *
@@ -233,6 +236,10 @@ final class BladeUsageProvider implements MemberUsageProvider
                     }
 
                     return $this->traverseDataArg($args[1]->value, $node, $scope);
+                }
+
+                if ($methodName === 'composer' || $methodName === 'creator') {
+                    return $this->getUsagesFromComposerOrCreator($node, $node->getArgs(), $scope, $methodName);
                 }
             }
 

--- a/src/Provider/TemplateViewDataTraverser.php
+++ b/src/Provider/TemplateViewDataTraverser.php
@@ -1,0 +1,197 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function str_starts_with;
+
+final class TemplateViewDataTraverser
+{
+
+    private readonly ReflectionProvider $reflectionProvider;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $analysedPaths;
+
+    /**
+     * @param list<string> $analysedPaths
+     */
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        array $analysedPaths,
+    )
+    {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->analysedPaths = $analysedPaths;
+    }
+
+    /**
+     * Traverses referenced class names recursively, marking all public methods and properties as used.
+     * Used by template engine providers (Twig, Blade) to handle data passed to views.
+     *
+     * @param list<string> $referencedClassNames
+     * @param non-empty-string $rootContext
+     * @return list<ClassMemberUsage>
+     */
+    public function getUsages(
+        array $referencedClassNames,
+        string $rootContext,
+        MemberUsageProvider $provider,
+    ): array
+    {
+        $usages = [];
+        $visited = [];
+
+        foreach ($referencedClassNames as $className) {
+            $usages = [
+                ...$usages,
+                ...$this->traverseClassNameRecursively($className, $visited, $rootContext, $provider),
+            ];
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @param non-empty-string $context
+     * @param array<string, true> $visited
+     * @return list<ClassMemberUsage>
+     */
+    private function traverseClassNameRecursively(
+        string $className,
+        array &$visited,
+        string $context,
+        MemberUsageProvider $provider,
+    ): array
+    {
+        if (isset($visited[$className])) {
+            return []; // Cycle detection
+        }
+
+        $visited[$className] = true;
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        if ($this->shouldSkipClass($classReflection)) {
+            return [];
+        }
+
+        return $this->getPublicMembersUsages($classReflection, $visited, $context, $provider);
+    }
+
+    /**
+     * @param array<string, true> $visited
+     * @param non-empty-string $context
+     * @return list<ClassMemberUsage>
+     */
+    private function getPublicMembersUsages(
+        ClassReflection $classReflection,
+        array &$visited,
+        string $context,
+        MemberUsageProvider $provider,
+    ): array
+    {
+        $usages = [];
+        $className = $classReflection->getName();
+        $nativeReflection = $classReflection->getNativeReflection();
+        $shortClassName = $nativeReflection->getShortName();
+
+        // Process public methods
+        foreach ($nativeReflection->getMethods() as $method) {
+            if (!$method->isPublic() || $method->isStatic()) {
+                continue;
+            }
+
+            // Skip magic methods
+            if (str_starts_with($method->getName(), '__')) {
+                continue;
+            }
+
+            // Mark method as used
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($provider, VirtualUsageData::withNote($context)),
+                new ClassMethodRef($className, $method->getName(), possibleDescendant: false),
+            );
+
+            // Traverse method return type
+            $extendedMethodReflection = $classReflection->getNativeMethod($method->getName());
+            $newContext = "{$context} -> {$shortClassName}::{$method->getName()}";
+
+            foreach ($extendedMethodReflection->getVariants() as $variant) {
+                foreach ($variant->getReturnType()->getReferencedClasses() as $returnClassName) {
+                    $usages = [
+                        ...$usages,
+                        ...$this->traverseClassNameRecursively(
+                            $returnClassName,
+                            $visited,
+                            $newContext,
+                            $provider,
+                        ),
+                    ];
+                }
+            }
+        }
+
+        // Process public properties
+        foreach ($nativeReflection->getProperties() as $property) {
+            if (!$property->isPublic() || $property->isStatic()) {
+                continue;
+            }
+
+            $usages[] = new ClassPropertyUsage(
+                UsageOrigin::createVirtual($provider, VirtualUsageData::withNote($context)),
+                new ClassPropertyRef($className, $property->getName(), possibleDescendant: false),
+                AccessType::READ,
+            );
+
+            $propertyReflection = $classReflection->getNativeProperty($property->getName());
+            $newContext = "{$context} -> {$shortClassName}::\${$property->getName()}";
+
+            foreach ($propertyReflection->getReadableType()->getReferencedClasses() as $propertyClassName) {
+                $usages = [
+                    ...$usages,
+                    ...$this->traverseClassNameRecursively(
+                        $propertyClassName,
+                        $visited,
+                        $newContext,
+                        $provider,
+                    ),
+                ];
+            }
+        }
+
+        return $usages;
+    }
+
+    private function shouldSkipClass(ClassReflection $classReflection): bool
+    {
+        $fileName = $classReflection->getFileName();
+
+        if ($fileName === null) {
+            return true;
+        }
+
+        foreach ($this->analysedPaths as $path) {
+            if (str_starts_with($fileName, $path)) {
+                return false; // do not traverse non-analyzed classes (e.g. vendor)
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/Provider/TwigUsageProvider.php
+++ b/src/Provider/TwigUsageProvider.php
@@ -14,49 +14,38 @@ use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
 use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\UnionType;
 use ReflectionException;
-use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
-use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
-use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use function array_map;
 use function count;
 use function explode;
 use function in_array;
-use function str_starts_with;
 
 final class TwigUsageProvider implements MemberUsageProvider
 {
 
     private readonly ReflectionProvider $reflectionProvider;
 
-    /**
-     * @var list<string>
-     */
-    private readonly array $analysedPaths;
+    private readonly TemplateViewDataTraverser $traverser;
 
     private readonly bool $enabled;
 
-    /**
-     * @param list<string> $analysedPaths
-     */
     public function __construct(
         ReflectionProvider $reflectionProvider,
-        array $analysedPaths,
+        TemplateViewDataTraverser $traverser,
         ?bool $enabled,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        $this->analysedPaths = $analysedPaths;
+        $this->traverser = $traverser;
         $this->enabled = $enabled ?? $this->isTwigInstalled();
     }
 
@@ -295,19 +284,9 @@ final class TwigUsageProvider implements MemberUsageProvider
         }
 
         $referencedClassNames = $scope->getType($node->expr)->getReferencedClasses();
-
-        $usages = [];
-        $visited = [];
         $rootContext = $this->getRootContext($node, $scope);
 
-        foreach ($referencedClassNames as $className) {
-            $usages = [
-                ...$usages,
-                ...$this->traverseClassNameRecursively($className, $visited, $rootContext),
-            ];
-        }
-
-        return $usages;
+        return $this->traverser->getUsages($referencedClassNames, $rootContext, $this);
     }
 
     /**
@@ -336,20 +315,10 @@ final class TwigUsageProvider implements MemberUsageProvider
         }
 
         $parametersArg = $args[$parametersArgIndex];
-        $objectTypes = $scope->getType($parametersArg->value)->getReferencedClasses();
-
-        $usages = [];
-        $visited = [];
+        $referencedClassNames = $scope->getType($parametersArg->value)->getReferencedClasses();
         $rootContext = $this->getRootContext($node, $scope);
 
-        foreach ($objectTypes as $className) {
-            $usages = [
-                ...$usages,
-                ...$this->traverseClassNameRecursively($className, $visited, $rootContext),
-            ];
-        }
-
-        return $usages;
+        return $this->traverser->getUsages($referencedClassNames, $rootContext, $this);
     }
 
     private function getParametersArgIndex(
@@ -452,165 +421,6 @@ final class TwigUsageProvider implements MemberUsageProvider
         }
 
         return false;
-    }
-
-    /**
-     * @param non-empty-string $context
-     * @param array<string, true> $visited
-     * @return list<ClassMemberUsage>
-     */
-    private function traverseClassNameRecursively(
-        string $className,
-        array &$visited,
-        string $context,
-    ): array
-    {
-        if (isset($visited[$className])) {
-            return []; // Cycle detection
-        }
-
-        $visited[$className] = true;
-
-        if (!$this->reflectionProvider->hasClass($className)) {
-            return [];
-        }
-
-        $classReflection = $this->reflectionProvider->getClass($className);
-
-        if ($this->shouldSkipClass($classReflection)) {
-            return [];
-        }
-
-        return $this->getPublicMembersUsages($classReflection, $visited, $context);
-    }
-
-    /**
-     * @param array<string, true> $visited
-     * @param non-empty-string $context
-     * @return list<ClassMemberUsage>
-     */
-    private function getPublicMembersUsages(
-        ClassReflection $classReflection,
-        array &$visited,
-        string $context,
-    ): array
-    {
-        $usages = [];
-        $className = $classReflection->getName();
-        $nativeReflection = $classReflection->getNativeReflection();
-        $shortClassName = $nativeReflection->getShortName();
-
-        // Process public methods
-        foreach ($nativeReflection->getMethods() as $method) {
-            if (!$method->isPublic() || $method->isStatic()) {
-                continue;
-            }
-
-            // Skip magic methods
-            if ($this->shouldSkipMethod($method->getName())) {
-                continue;
-            }
-
-            // Mark method as used
-            $usages[] = $this->createMethodUsage($className, $method->getName(), $context);
-
-            // Traverse method return type
-            $extendedMethodReflection = $classReflection->getNativeMethod($method->getName());
-            $variants = $extendedMethodReflection->getVariants();
-            $newContext = "{$context} -> {$shortClassName}::{$method->getName()}";
-
-            foreach ($variants as $variant) {
-                $returnType = $variant->getReturnType();
-
-                foreach ($returnType->getReferencedClasses() as $returnClassName) {
-                    $usages = [
-                        ...$usages,
-                        ...$this->traverseClassNameRecursively(
-                            $returnClassName,
-                            $visited,
-                            $newContext,
-                        ),
-                    ];
-                }
-            }
-        }
-
-        // Process public properties
-        foreach ($nativeReflection->getProperties() as $property) {
-            if (!$property->isPublic() || $property->isStatic()) {
-                continue;
-            }
-
-            $usages[] = $this->createPropertyUsage($className, $property->getName(), $context);
-
-            $propertyReflection = $classReflection->getNativeProperty($property->getName());
-            $newContext = "{$context} -> {$shortClassName}::\${$property->getName()}";
-
-            foreach ($propertyReflection->getReadableType()->getReferencedClasses() as $propertyClassName) {
-                $usages = [
-                    ...$usages,
-                    ...$this->traverseClassNameRecursively(
-                        $propertyClassName,
-                        $visited,
-                        $newContext,
-                    ),
-                ];
-            }
-        }
-
-        return $usages;
-    }
-
-    /**
-     * @param non-empty-string $context
-     */
-    private function createMethodUsage(
-        string $className,
-        string $methodName,
-        string $context,
-    ): ClassMethodUsage
-    {
-        return new ClassMethodUsage(
-            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($context)),
-            new ClassMethodRef($className, $methodName, possibleDescendant: false),
-        );
-    }
-
-    /**
-     * @param non-empty-string $context
-     */
-    private function createPropertyUsage(
-        string $className,
-        string $propertyName,
-        string $context,
-    ): ClassPropertyUsage
-    {
-        return new ClassPropertyUsage(
-            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($context)),
-            new ClassPropertyRef($className, $propertyName, possibleDescendant: false),
-            AccessType::READ,
-        );
-    }
-
-    private function shouldSkipMethod(string $methodName): bool
-    {
-        return str_starts_with($methodName, '__');
-    }
-
-    private function shouldSkipClass(ClassReflection $classReflection): bool
-    {
-        $fileName = $classReflection->getFileName();
-        if ($fileName === null) {
-            return true;
-        }
-
-        foreach ($this->analysedPaths as $path) {
-            if (str_starts_with($fileName, $path)) {
-                return false; // do not traverse non-analyzed classes (e.g. vendor)
-            }
-        }
-
-        return true;
     }
 
 }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -47,6 +47,7 @@ use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
 use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
 use ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BehatUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\BladeUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BuiltinUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EloquentUsageProvider;
@@ -62,6 +63,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\StreamWrapperUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\TemplateViewDataTraverser;
 use ShipMonk\PHPStan\DeadCode\Provider\TwigUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VendorUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
@@ -995,6 +997,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-phpstan' => [__DIR__ . '/data/providers/phpstan.php'];
         yield 'provider-eloquent' => [__DIR__ . '/data/providers/eloquent.php'];
         yield 'provider-laravel' => [__DIR__ . '/data/providers/laravel.php'];
+        yield 'provider-blade' => [__DIR__ . '/data/providers/blade.php'];
         yield 'provider-nette' => [__DIR__ . '/data/providers/nette.php'];
         yield 'provider-nette-tester' => [__DIR__ . '/data/providers/nette-tester.php'];
         yield 'provider-apiphpdoc' => [__DIR__ . '/data/providers/api-phpdoc.php'];
@@ -1162,6 +1165,14 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
      */
     private function getMemberUsageProviders(): array
     {
+        $templateViewDataTraverser = new TemplateViewDataTraverser(
+            self::createReflectionProvider(),
+            [
+                __DIR__ . '/data/providers/twig-template.php',
+                __DIR__ . '/data/providers/blade.php',
+            ],
+        );
+
         $provides = [
             new ReflectionUsageProvider(
                 $this->providersEnabled,
@@ -1199,6 +1210,11 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 self::getContainer()->getByType(ReflectionProvider::class),
                 $this->providersEnabled,
             ),
+            new BladeUsageProvider(
+                self::createReflectionProvider(),
+                $templateViewDataTraverser,
+                $this->providersEnabled,
+            ),
             new NetteTesterUsageProvider(
                 $this->providersEnabled,
             ),
@@ -1218,7 +1234,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             ),
             new TwigUsageProvider(
                 self::createReflectionProvider(),
-                [__DIR__ . '/data/providers/twig-template.php'],
+                $templateViewDataTraverser,
                 $this->providersEnabled,
             ),
             new ApiPhpDocUsageProvider(

--- a/tests/Rule/data/providers/blade.php
+++ b/tests/Rule/data/providers/blade.php
@@ -135,6 +135,19 @@ final class CustomMethodComposer
 
 }
 
+final class FactoryComposer
+{
+
+    public function __construct()
+    {
+    }
+
+    public function compose(\Illuminate\Contracts\View\View $view): void
+    {
+    }
+
+}
+
 // --- Unused model ---
 
 final class BladeUnusedModel
@@ -222,6 +235,11 @@ class BladeController extends Controller
         ]);
     }
 
+    public function factoryComposer(): void
+    {
+        $this->viewFactory->composer('layouts.main', FactoryComposer::class);
+    }
+
     public function viewMakeNoData(): View // error: Unused Blade\BladeController::viewMakeNoData
     {
         return ViewFacade::make('blade.no-data');
@@ -248,6 +266,7 @@ function registerBladeRoutes(): void
     Route::get('/with-key-value', [BladeController::class, 'withKeyValue']);
     Route::get('/with-array', [BladeController::class, 'withArray']);
     Route::get('/factory-make', [BladeController::class, 'factoryMake']);
+    Route::get('/factory-composer', [BladeController::class, 'factoryComposer']);
 
     ViewFacade::composer('layouts.app', BreadcrumbsViewComposer::class);
     ViewFacade::creator('partials.sidebar', SidebarViewCreator::class);

--- a/tests/Rule/data/providers/blade.php
+++ b/tests/Rule/data/providers/blade.php
@@ -94,6 +94,47 @@ final class FactoryMakeModel
     public function getName(): string { return 'factory'; }
 }
 
+// --- View Composer/Creator ---
+
+final class BreadcrumbsViewComposer
+{
+
+    public function __construct()
+    {
+    }
+
+    public function compose(\Illuminate\Contracts\View\View $view): void
+    {
+    }
+
+}
+
+final class SidebarViewCreator
+{
+
+    public function __construct()
+    {
+    }
+
+    public function create(\Illuminate\Contracts\View\View $view): void
+    {
+    }
+
+}
+
+final class CustomMethodComposer
+{
+
+    public function __construct()
+    {
+    }
+
+    public function customCompose(\Illuminate\Contracts\View\View $view): void
+    {
+    }
+
+}
+
 // --- Unused model ---
 
 final class BladeUnusedModel
@@ -193,7 +234,7 @@ class BladeController extends Controller
 
 }
 
-// --- Route registrations ---
+// --- Route and View registrations ---
 
 function registerBladeRoutes(): void
 {
@@ -207,4 +248,10 @@ function registerBladeRoutes(): void
     Route::get('/with-key-value', [BladeController::class, 'withKeyValue']);
     Route::get('/with-array', [BladeController::class, 'withArray']);
     Route::get('/factory-make', [BladeController::class, 'factoryMake']);
+
+    ViewFacade::composer('layouts.app', BreadcrumbsViewComposer::class);
+    ViewFacade::creator('partials.sidebar', SidebarViewCreator::class);
+
+    // Class@method syntax
+    ViewFacade::composer('layouts.admin', 'Blade\CustomMethodComposer@customCompose');
 }

--- a/tests/Rule/data/providers/blade.php
+++ b/tests/Rule/data/providers/blade.php
@@ -1,0 +1,210 @@
+<?php declare(strict_types = 1);
+
+namespace Blade;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View as ViewFacade;
+use Illuminate\View\Factory as ViewFactory;
+
+// --- Models for view() helper ---
+
+final class ViewHelperSimpleModel
+{
+    public function getName(): string { return 'name'; }
+}
+
+final class ViewHelperNestedModel
+{
+    public function getValue(): string { return 'nested'; }
+
+    public function getDeep(): ViewHelperDeepModel { return new ViewHelperDeepModel(); }
+}
+
+final class ViewHelperDeepModel
+{
+    public function getDeepValue(): string { return 'deep'; }
+}
+
+// --- Models for View::make() ---
+
+final class ViewMakeModel
+{
+    public function getName(): string { return 'make'; }
+}
+
+// --- Models for View::first() ---
+
+final class ViewFirstModel
+{
+    public function getName(): string { return 'first'; }
+}
+
+// --- Models for response()->view() ---
+
+final class ResponseViewModel
+{
+    public function getName(): string { return 'response'; }
+}
+
+// --- Models for ->with() chaining ---
+
+final class WithKeyValueModel
+{
+    public function getName(): string { return 'with-kv'; }
+}
+
+final class WithArrayModel
+{
+    public function getName(): string { return 'with-array'; }
+}
+
+// --- Circular reference models ---
+
+final class BladeCircularA
+{
+    public function getB(): BladeCircularB { return new BladeCircularB(); }
+}
+
+final class BladeCircularB
+{
+    public function getA(): BladeCircularA { return new BladeCircularA(); }
+}
+
+// --- Model with public properties ---
+
+final class BladePropertyModel
+{
+    public function __construct(
+        public string $publicValue,
+        public ViewHelperNestedModel $nestedData,
+    )
+    {
+    }
+
+    public function getMethod(): string { return 'value'; }
+}
+
+// --- Models for factory->make() ---
+
+final class FactoryMakeModel
+{
+    public function getName(): string { return 'factory'; }
+}
+
+// --- Unused model ---
+
+final class BladeUnusedModel
+{
+    public function unusedMethod(): string { return 'unused'; } // error: Unused Blade\BladeUnusedModel::unusedMethod
+}
+
+// --- Controller ---
+
+class BladeController extends Controller
+{
+
+    public function __construct(
+        private readonly ResponseFactory $responseFactory,
+        private readonly ViewFactory $viewFactory,
+    )
+    {
+    }
+
+    public function viewHelper(): View
+    {
+        return view('blade.simple', [
+            'model' => new ViewHelperSimpleModel(),
+        ]);
+    }
+
+    public function viewHelperNested(): View
+    {
+        return view('blade.nested', [
+            'nested' => new ViewHelperNestedModel(),
+        ]);
+    }
+
+    public function viewHelperCircular(): View
+    {
+        return view('blade.circular', [
+            'data' => new BladeCircularA(),
+        ]);
+    }
+
+    public function viewHelperProperty(): View
+    {
+        return view('blade.property', [
+            'model' => new BladePropertyModel('test', new ViewHelperNestedModel()),
+        ]);
+    }
+
+    public function viewMake(): View
+    {
+        return ViewFacade::make('blade.make', [
+            'model' => new ViewMakeModel(),
+        ]);
+    }
+
+    public function viewFirst(): View
+    {
+        return ViewFacade::first(['blade.first1', 'blade.first2'], [
+            'model' => new ViewFirstModel(),
+        ]);
+    }
+
+    public function responseView(): \Illuminate\Http\Response
+    {
+        return $this->responseFactory->view('blade.response', [
+            'model' => new ResponseViewModel(),
+        ]);
+    }
+
+    public function withKeyValue(): View
+    {
+        return view('blade.with-kv')->with('model', new WithKeyValueModel());
+    }
+
+    public function withArray(): View
+    {
+        return view('blade.with-array')->with([
+            'model' => new WithArrayModel(),
+        ]);
+    }
+
+    public function factoryMake(): View
+    {
+        return $this->viewFactory->make('blade.factory', [
+            'model' => new FactoryMakeModel(),
+        ]);
+    }
+
+    public function viewMakeNoData(): View // error: Unused Blade\BladeController::viewMakeNoData
+    {
+        return ViewFacade::make('blade.no-data');
+    }
+
+    public function noView(): array // error: Unused Blade\BladeController::noView
+    {
+        return ['unused' => new BladeUnusedModel()];
+    }
+
+}
+
+// --- Route registrations ---
+
+function registerBladeRoutes(): void
+{
+    Route::get('/view-helper', [BladeController::class, 'viewHelper']);
+    Route::get('/view-helper-nested', [BladeController::class, 'viewHelperNested']);
+    Route::get('/view-helper-circular', [BladeController::class, 'viewHelperCircular']);
+    Route::get('/view-helper-property', [BladeController::class, 'viewHelperProperty']);
+    Route::get('/view-make', [BladeController::class, 'viewMake']);
+    Route::get('/view-first', [BladeController::class, 'viewFirst']);
+    Route::get('/response-view', [BladeController::class, 'responseView']);
+    Route::get('/with-key-value', [BladeController::class, 'withKeyValue']);
+    Route::get('/with-array', [BladeController::class, 'withArray']);
+    Route::get('/factory-make', [BladeController::class, 'factoryMake']);
+}


### PR DESCRIPTION
## Summary
- **Blade view data traversal**: Intercept `view()`, `View::make/first()`, `$factory->make/first()`, `response()->view()`, and `->with()` calls to mark public members of passed data objects as used via transitive walk
- **View composers/creators**: Intercept both `View::composer/creator()` (facade) and `$factory->composer/creator()` (injected factory) to mark `compose()`/`create()` + `__construct()` as used (supports `'Class@method'` syntax)
- **Shared traversal service**: Extract the transitive walk logic from `TwigUsageProvider` into a reusable `TemplateViewDataTraverser` service used by both Twig and Blade providers
- Auto-enables when `laravel/framework` is installed, configurable via `shipmonkDeadCode.usageProviders.blade.enabled`

## What is NOT covered
- View composers/creators data injection (the objects they `->with()` into views)
- Blade components (`<x-alert :message="$msg" />`) — data flows in `.blade.php` files which we don't parse
- `@include`/`@each` directives — inter-template data passing, invisible from PHP side
- Livewire component public properties — automatically available in views without explicit passing

## Real-world impact

| Project | Before | After | Errors eliminated |
|---------|--------|-------|--------------------------|
| Pinkary (level max, 10 models, Livewire) | 116 | 115 | **1** |
| BookStack (level 4, ~30 models, MVC) | 575 | 527 | **48** |

Co-Authored-By: Claude Code