### PR TITLE
Support Symfony forms data_class mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/form": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/routing": "^5.4 || ^6.0 || ^7.0 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "400e8f45c21487e113a1b6cba7078f36",
+    "content-hash": "a24b57f996c94a3df027eade4f9ee0c1",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -9094,6 +9094,101 @@
             "time": "2026-01-29T09:40:50+00:00"
         },
         {
+            "name": "symfony/form",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/form.git",
+                "reference": "c163f5db2f1ffecb3d5b33a2e662d13115323b20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/form/zipball/c163f5db2f1ffecb3d5b33a2e662d13115323b20",
+                "reference": "c163f5db2f1ffecb3d5b33a2e662d13115323b20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/options-resolver": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/intl": "<7.4",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/validator": "<7.4"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0|^2.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/html-sanitizer": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Form\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows to easily create, process and reuse HTML forms",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/form/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "symfony/framework-bundle",
             "version": "v8.0.7",
             "source": {
@@ -9842,6 +9937,94 @@
                 }
             ],
             "time": "2025-06-27T09:58:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c",
+                "reference": "bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-20T22:24:30+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -909,27 +909,20 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 continue;
             }
 
+            $propertyClassName = $property->getDeclaringClass()->getName();
+            $propertyName = $property->getName();
+
             $usages[] = new ClassPropertyUsage(
                 $origin,
-                new ClassPropertyRef(
-                    $property->getDeclaringClass()->getName(),
-                    $property->getName(),
-                    possibleDescendant: false,
-                ),
+                new ClassPropertyRef($propertyClassName, $propertyName, possibleDescendant: false),
                 AccessType::READ,
             );
 
-            if (!$property->isReadOnly()) {
-                $usages[] = new ClassPropertyUsage(
-                    $origin,
-                    new ClassPropertyRef(
-                        $property->getDeclaringClass()->getName(),
-                        $property->getName(),
-                        possibleDescendant: false,
-                    ),
-                    AccessType::WRITE,
-                );
-            }
+            $usages[] = new ClassPropertyUsage(
+                $origin,
+                new ClassPropertyRef($propertyClassName, $propertyName, possibleDescendant: false),
+                AccessType::WRITE,
+            );
         }
 
         if ($classReflection->hasNativeMethod('__construct')) {

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -883,17 +883,13 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 continue;
             }
 
-            if ($method->getDeclaringClass()->getName() !== $dataClassName) {
-                continue;
-            }
-
             $name = $method->getName();
 
             if ($this->isPropertyAccessorMethod($name)) {
                 $usages[] = new ClassMethodUsage(
                     $origin,
                     new ClassMethodRef(
-                        $dataClassName,
+                        $method->getDeclaringClass()->getName(),
                         $name,
                         possibleDescendant: false,
                     ),
@@ -906,10 +902,6 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 continue;
             }
 
-            if ($property->getDeclaringClass()->getName() !== $dataClassName) {
-                continue;
-            }
-
             if (!$property->isPublic()) {
                 continue;
             }
@@ -917,7 +909,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $usages[] = new ClassPropertyUsage(
                 $origin,
                 new ClassPropertyRef(
-                    $dataClassName,
+                    $property->getDeclaringClass()->getName(),
                     $property->getName(),
                     possibleDescendant: false,
                 ),
@@ -928,7 +920,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 $usages[] = new ClassPropertyUsage(
                     $origin,
                     new ClassPropertyRef(
-                        $dataClassName,
+                        $property->getDeclaringClass()->getName(),
                         $property->getName(),
                         possibleDescendant: false,
                     ),
@@ -938,10 +930,12 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         if ($classReflection->hasNativeMethod('__construct')) {
+            $constructorDeclaringClass = $classReflection->getNativeMethod('__construct')->getDeclaringClass()->getName();
+
             $usages[] = new ClassMethodUsage(
                 $origin,
                 new ClassMethodRef(
-                    $dataClassName,
+                    $constructorDeclaringClass,
                     '__construct',
                     possibleDescendant: false,
                 ),

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -813,7 +813,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         if ($methodName === 'createFormBuilder' && $this->isAbstractControllerType($callerType)) {
             $dataArgIndex = 0;
             $optionsArgIndex = 1;
-        } elseif (in_array($methodName, ['createForm'], true) && $this->isAbstractControllerType($callerType)) {
+        } elseif ($methodName === 'createForm' && $this->isAbstractControllerType($callerType)) {
             $dataArgIndex = 1;
             $optionsArgIndex = 2;
         } elseif (in_array($methodName, ['create', 'createBuilder'], true) && $this->isFormFactoryType($callerType)) {

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -886,6 +886,10 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 continue;
             }
 
+            if (!$method->isPublic()) {
+                continue;
+            }
+
             $name = $method->getName();
 
             if ($this->isPropertyAccessorMethod($name)) {

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -66,6 +66,8 @@ use function trim;
 final class SymfonyUsageProvider implements MemberUsageProvider
 {
 
+    private readonly ReflectionProvider $reflectionProvider;
+
     private readonly bool $enabled;
 
     private readonly ?string $configDir;
@@ -103,12 +105,13 @@ final class SymfonyUsageProvider implements MemberUsageProvider
      */
     public function __construct(
         Container $container,
-        private readonly ReflectionProvider $reflectionProvider,
+        ReflectionProvider $reflectionProvider,
         ?bool $enabled,
         ?string $configDir,
         array $containerXmlPaths,
     )
     {
+        $this->reflectionProvider = $reflectionProvider;
         $this->enabled = $enabled ?? $this->isSymfonyInstalled();
         $this->configDir = $configDir ?? $this->autodetectConfigDir();
 

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -7,6 +7,9 @@ use Composer\InstalledVersions;
 use FilesystemIterator;
 use LogicException;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
@@ -20,8 +23,10 @@ use PHPStan\Node\InClassNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Type;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionAttribute;
@@ -55,6 +60,7 @@ use function simplexml_load_string;
 use function sprintf;
 use function str_ends_with;
 use function str_starts_with;
+use function strlen;
 use function trim;
 
 final class SymfonyUsageProvider implements MemberUsageProvider
@@ -97,6 +103,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
      */
     public function __construct(
         Container $container,
+        private readonly ReflectionProvider $reflectionProvider,
         ?bool $enabled,
         ?string $configDir,
         array $containerXmlPaths,
@@ -149,6 +156,13 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $usages = [
                 ...$usages,
                 ...$this->getMethodUsagesFromAttributeReflection($node, $scope),
+            ];
+        }
+
+        if ($node instanceof MethodCall) {
+            $usages = [
+                ...$usages,
+                ...$this->getFormDataClassUsages($node, $scope),
             ];
         }
 
@@ -699,6 +713,292 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         return null;
+    }
+
+    /**
+     * @return list<ClassMethodUsage|ClassPropertyUsage>
+     */
+    private function getFormDataClassUsages(
+        MethodCall $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        $args = $node->getArgs();
+
+        $dataClassName = $this->extractFormDataClassFromOptionsResolver($methodName, $node, $args, $scope)
+            ?? $this->extractFormDataClassFromFormFactory($methodName, $node, $args, $scope);
+
+        if ($dataClassName === null || !$this->reflectionProvider->hasClass($dataClassName)) {
+            return [];
+        }
+
+        return $this->emitPropertyAccessorUsages($node, $scope, $dataClassName);
+    }
+
+    /**
+     * Detects data_class from OptionsResolver::setDefaults() and OptionsResolver::setDefault()
+     *
+     * @param array<int|string, Arg> $args
+     */
+    private function extractFormDataClassFromOptionsResolver(
+        string $methodName,
+        MethodCall $node,
+        array $args,
+        Scope $scope,
+    ): ?string
+    {
+        if ($methodName === 'setDefaults' && isset($args[0])) {
+            if (!$this->isOptionsResolverType($scope->getType($node->var))) {
+                return null;
+            }
+
+            return $this->extractDataClassFromArray($scope->getType($args[0]->value));
+        }
+
+        if ($methodName === 'setDefault' && isset($args[0], $args[1])) {
+            if (!$this->isOptionsResolverType($scope->getType($node->var))) {
+                return null;
+            }
+
+            foreach ($scope->getType($args[0]->value)->getConstantStrings() as $constantString) {
+                if ($constantString->getValue() === 'data_class') {
+                    foreach ($scope->getType($args[1]->value)->getConstantStrings() as $valueString) {
+                        return $valueString->getValue();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Detects data_class from FormFactory/Controller methods:
+     * - createForm($type, $data, ['data_class' => X]) or createForm($type, $data) where $data is typed
+     * - createNamed($name, $type, $data, ['data_class' => X]) or with typed $data
+     * - create($type, $data, ['data_class' => X]) or with typed $data
+     * - createFormBuilder($data, ['data_class' => X]) or with typed $data
+     * - createBuilder($type, $data, ['data_class' => X]) or with typed $data
+     * - createNamedBuilder($name, $type, $data, ['data_class' => X]) or with typed $data
+     *
+     * @param array<int|string, Arg> $args
+     */
+    private function extractFormDataClassFromFormFactory(
+        string $methodName,
+        MethodCall $node,
+        array $args,
+        Scope $scope,
+    ): ?string
+    {
+        $callerType = $scope->getType($node->var);
+
+        // AbstractController::createForm($type, $data, $options) — data at [1], options at [2]
+        // AbstractController::createFormBuilder($data, $options) — data at [0], options at [1]
+        // FormFactoryInterface::create($type, $data, $options) — data at [1], options at [2]
+        // FormFactoryInterface::createNamed($name, $type, $data, $options) — data at [2], options at [3]
+        // FormFactoryInterface::createBuilder($type, $data, $options) — data at [1], options at [2]
+        // FormFactoryInterface::createNamedBuilder($name, $type, $data, $options) — data at [2], options at [3]
+
+        $dataArgIndex = null;
+        $optionsArgIndex = null;
+
+        if ($methodName === 'createFormBuilder' && $this->isAbstractControllerType($callerType)) {
+            $dataArgIndex = 0;
+            $optionsArgIndex = 1;
+        } elseif (in_array($methodName, ['createForm'], true) && $this->isAbstractControllerType($callerType)) {
+            $dataArgIndex = 1;
+            $optionsArgIndex = 2;
+        } elseif (in_array($methodName, ['create', 'createBuilder'], true) && $this->isFormFactoryType($callerType)) {
+            $dataArgIndex = 1;
+            $optionsArgIndex = 2;
+        } elseif (in_array($methodName, ['createNamed', 'createNamedBuilder'], true) && $this->isFormFactoryType($callerType)) {
+            $dataArgIndex = 2;
+            $optionsArgIndex = 3;
+        } else {
+            return null;
+        }
+
+        // First, check explicit data_class in options array
+        if (isset($args[$optionsArgIndex])) {
+            $dataClassName = $this->extractDataClassFromArray($scope->getType($args[$optionsArgIndex]->value));
+
+            if ($dataClassName !== null) {
+                return $dataClassName;
+            }
+        }
+
+        // Then, infer from the data object type
+        if (isset($args[$dataArgIndex])) {
+            $dataType = $scope->getType($args[$dataArgIndex]->value);
+            $classNames = $dataType->getObjectClassNames();
+
+            if (count($classNames) === 1) {
+                return $classNames[0];
+            }
+        }
+
+        return null;
+    }
+
+    private function extractDataClassFromArray(Type $arrayType): ?string
+    {
+        foreach ($arrayType->getConstantArrays() as $constantArray) {
+            $keyTypes = $constantArray->getKeyTypes();
+            $valueTypes = $constantArray->getValueTypes();
+
+            foreach ($keyTypes as $index => $keyType) {
+                foreach ($keyType->getConstantStrings() as $keyString) {
+                    if ($keyString->getValue() === 'data_class') {
+                        foreach ($valueTypes[$index]->getConstantStrings() as $valueString) { // @phpstan-ignore offsetAccess.notFound
+                            return $valueString->getValue();
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<ClassMethodUsage|ClassPropertyUsage>
+     */
+    private function emitPropertyAccessorUsages(
+        Node $node,
+        Scope $scope,
+        string $dataClassName,
+    ): array
+    {
+        $classReflection = $this->reflectionProvider->getClass($dataClassName);
+        $usages = [];
+        $origin = UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Accessed by Symfony PropertyAccessor via form data_class'));
+
+        foreach ($classReflection->getNativeReflection()->getMethods() as $method) {
+            if ($method->isStatic()) {
+                continue;
+            }
+
+            if ($method->getDeclaringClass()->getName() !== $dataClassName) {
+                continue;
+            }
+
+            $name = $method->getName();
+
+            if ($this->isPropertyAccessorMethod($name)) {
+                $usages[] = new ClassMethodUsage(
+                    $origin,
+                    new ClassMethodRef(
+                        $dataClassName,
+                        $name,
+                        possibleDescendant: false,
+                    ),
+                );
+            }
+        }
+
+        foreach ($classReflection->getNativeReflection()->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($property->getDeclaringClass()->getName() !== $dataClassName) {
+                continue;
+            }
+
+            if (!$property->isPublic()) {
+                continue;
+            }
+
+            $usages[] = new ClassPropertyUsage(
+                $origin,
+                new ClassPropertyRef(
+                    $dataClassName,
+                    $property->getName(),
+                    possibleDescendant: false,
+                ),
+                AccessType::READ,
+            );
+
+            if (!$property->isReadOnly()) {
+                $usages[] = new ClassPropertyUsage(
+                    $origin,
+                    new ClassPropertyRef(
+                        $dataClassName,
+                        $property->getName(),
+                        possibleDescendant: false,
+                    ),
+                    AccessType::WRITE,
+                );
+            }
+        }
+
+        if ($classReflection->hasNativeMethod('__construct')) {
+            $usages[] = new ClassMethodUsage(
+                $origin,
+                new ClassMethodRef(
+                    $dataClassName,
+                    '__construct',
+                    possibleDescendant: false,
+                ),
+            );
+        }
+
+        return $usages;
+    }
+
+    private function isOptionsResolverType(Type $type): bool
+    {
+        foreach ($type->getObjectClassNames() as $className) {
+            if ($className === 'Symfony\Component\OptionsResolver\OptionsResolver') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isAbstractControllerType(Type $type): bool
+    {
+        foreach ($type->getObjectClassReflections() as $reflection) {
+            if (
+                $reflection->getName() === 'Symfony\Bundle\FrameworkBundle\Controller\AbstractController'
+                || $reflection->isSubclassOf('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isFormFactoryType(Type $type): bool
+    {
+        foreach ($type->getObjectClassReflections() as $reflection) {
+            if (
+                $reflection->getName() === 'Symfony\Component\Form\FormFactoryInterface'
+                || $reflection->implementsInterface('Symfony\Component\Form\FormFactoryInterface')
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPropertyAccessorMethod(string $methodName): bool
+    {
+        foreach (['get', 'set', 'is', 'has', 'can', 'add', 'remove'] as $prefix) {
+            if (str_starts_with($methodName, $prefix) && isset($methodName[strlen($prefix)]) && $methodName[strlen($prefix)] >= 'A' && $methodName[strlen($prefix)] <= 'Z') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function fillDicClasses(string $containerXmlPath): void

--- a/tests/Provider/SymfonyUsageProviderTest.php
+++ b/tests/Provider/SymfonyUsageProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Provider;
 
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use ReflectionClass;
 use function mkdir;
@@ -16,7 +17,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
         $configDir = __DIR__ . '/../../config';
         @mkdir($configDir);
 
-        $provider = new SymfonyUsageProvider(self::getContainer(), true, null, []);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, []);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $configDirPropertyReflection = $providerReflection->getProperty('configDir');
@@ -38,7 +39,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
     {
         $containerXmlPath = __DIR__ . '/../Rule/data/providers/symfony/services.xml';
 
-        $provider = new SymfonyUsageProvider(self::getContainer(), true, null, [$containerXmlPath]);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, [$containerXmlPath]);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');
@@ -56,7 +57,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
         $containerXmlPath = __DIR__ . '/../Rule/data/providers/symfony/services.xml';
 
         // Even though self::getContainer() has no symfony config, the explicit paths are used
-        $provider = new SymfonyUsageProvider(self::getContainer(), true, null, [$containerXmlPath]);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, [$containerXmlPath]);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');
@@ -71,7 +72,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
     {
         // When containerXmlPaths is empty, it falls back to getContainerXmlPath(container)
         // self::getContainer() has no symfony parameter, so no DIC classes are loaded
-        $provider = new SymfonyUsageProvider(self::getContainer(), true, null, []);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, []);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -985,6 +985,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-symfony-7.1' => [__DIR__ . '/data/providers/symfony-gte71.php', self::requiresPackage('symfony/dependency-injection', '>= 7.1')];
         yield 'provider-symfony-scheduler' => [__DIR__ . '/data/providers/symfony-scheduler.php', self::requiresPackage('symfony/scheduler', '>= 6.3')];
         yield 'provider-symfony-ux' => [__DIR__ . '/data/providers/symfony-ux.php', self::requiresPackage('symfony/ux-live-component', '>= 2.0')];
+        yield 'provider-symfony-form' => [__DIR__ . '/data/providers/symfony-form.php', self::requiresPackage('symfony/form', '>= 5.4')];
         yield 'provider-twig' => [__DIR__ . '/data/providers/twig.php'];
         yield 'provider-twig-template' => [__DIR__ . '/data/providers/twig-template.php'];
         yield 'provider-phpunit' => [__DIR__ . '/data/providers/phpunit.php'];
@@ -1210,6 +1211,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             ),
             new SymfonyUsageProvider(
                 $this->createContainerMockWithSymfonyConfig(),
+                self::getContainer()->getByType(ReflectionProvider::class),
                 $this->providersEnabled,
                 __DIR__ . '/data/providers/symfony/',
                 [],

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -14,7 +14,17 @@ use Symfony\Component\Routing\Attribute\Route;
 
 // Case 1: configureOptions with setDefaults
 
-class ProductData {
+class BaseProductData {
+
+    public function getInherited(): string {
+        return '';
+    }
+}
+
+class ProductData extends BaseProductData {
+
+    public function __construct() {
+    }
 
     public string $name;
 
@@ -58,6 +68,10 @@ class ProductData {
 
     public function hasExpired(): bool {
         return false;
+    }
+
+    public static function staticFactory(): self { // error: Unused SymfonyForm\ProductData::staticFactory
+        return new self();
     }
 
     public function dead(): void { // error: Unused SymfonyForm\ProductData::dead
@@ -125,41 +139,7 @@ class PublicPropertyFormType extends AbstractType {
     }
 }
 
-// Case 1d: data class with constructor, static and inherited methods
-
-class BaseData {
-
-    public function getInherited(): string {
-        return '';
-    }
-}
-
-class ConstructorData extends BaseData {
-
-    public function __construct(
-        private readonly string $name,
-    ) {
-    }
-
-    public function getName(): string {
-        return $this->name;
-    }
-
-    public static function staticFactory(): self { // error: Unused SymfonyForm\ConstructorData::staticFactory
-        return new self('');
-    }
-}
-
-class ConstructorFormType extends AbstractType {
-
-    public function configureOptions(OptionsResolver $resolver): void {
-        $resolver->setDefaults([
-            'data_class' => ConstructorData::class,
-        ]);
-    }
-}
-
-// Case 1e: form without data_class
+// Case 1d: form without data_class
 
 class NoDataClassType extends AbstractType {
 

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -129,7 +129,7 @@ class PublicPropertyFormType extends AbstractType {
 
 class BaseData {
 
-    public function getInherited(): string { // error: Unused SymfonyForm\BaseData::getInherited
+    public function getInherited(): string {
         return '';
     }
 }

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -1,0 +1,290 @@
+<?php declare(strict_types = 1);
+
+namespace SymfonyForm;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Attribute\Route;
+
+// Case 1: configureOptions with setDefaults
+
+class ProductData {
+
+    public string $name;
+
+    private string $description;
+
+    private int $price;
+
+    private bool $active;
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public function setName(string $name): void {
+        $this->name = $name;
+    }
+
+    public function getDescription(): string {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void {
+        $this->description = $description;
+    }
+
+    public function getPrice(): int {
+        return $this->price;
+    }
+
+    public function setPrice(int $price): void {
+        $this->price = $price;
+    }
+
+    public function isActive(): bool {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): void {
+        $this->active = $active;
+    }
+
+    public function hasExpired(): bool {
+        return false;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\ProductData::dead
+    }
+}
+
+class ProductType extends AbstractType {
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void {
+        $builder
+            ->add('name', TextType::class)
+            ->add('price', NumberType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void {
+        $resolver->setDefaults([
+            'data_class' => ProductData::class,
+        ]);
+    }
+}
+
+// Case 1b: configureOptions with setDefault
+
+class CategoryData {
+
+    private string $title;
+
+    public function getTitle(): string {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void {
+        $this->title = $title;
+    }
+
+    public function unused(): void { // error: Unused SymfonyForm\CategoryData::unused
+    }
+}
+
+class CategoryType extends AbstractType {
+
+    public function configureOptions(OptionsResolver $resolver): void {
+        $resolver->setDefault('data_class', CategoryData::class);
+    }
+}
+
+// Case 1c: public property data class
+
+class PublicPropertyData {
+
+    public string $label;
+
+    public readonly string $code; // error: Property SymfonyForm\PublicPropertyData::$code is never written
+
+    public function dead(): void { // error: Unused SymfonyForm\PublicPropertyData::dead
+    }
+}
+
+class PublicPropertyFormType extends AbstractType {
+
+    public function configureOptions(OptionsResolver $resolver): void {
+        $resolver->setDefaults([
+            'data_class' => PublicPropertyData::class,
+        ]);
+    }
+}
+
+// Case 1d: data class with constructor, static and inherited methods
+
+class BaseData {
+
+    public function getInherited(): string { // error: Unused SymfonyForm\BaseData::getInherited
+        return '';
+    }
+}
+
+class ConstructorData extends BaseData {
+
+    public function __construct(
+        private readonly string $name,
+    ) {
+    }
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public static function staticFactory(): self { // error: Unused SymfonyForm\ConstructorData::staticFactory
+        return new self('');
+    }
+}
+
+class ConstructorFormType extends AbstractType {
+
+    public function configureOptions(OptionsResolver $resolver): void {
+        $resolver->setDefaults([
+            'data_class' => ConstructorData::class,
+        ]);
+    }
+}
+
+// Case 1e: form without data_class
+
+class NoDataClassType extends AbstractType {
+
+    public function configureOptions(OptionsResolver $resolver): void {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+        ]);
+    }
+}
+
+// Case 2: createForm with explicit data_class in options
+
+class InlineData {
+
+    private string $value;
+
+    public function getValue(): string {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void {
+        $this->value = $value;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\InlineData::dead
+    }
+}
+
+class InlineDataController extends AbstractController {
+
+    #[Route('/inline')]
+    public function action(): Response {
+        $this->createForm(ProductType::class, null, [
+            'data_class' => InlineData::class,
+        ]);
+
+        return new Response();
+    }
+}
+
+// Case 3: createForm with typed data object
+
+class ImplicitData {
+
+    private string $label;
+
+    public function getLabel(): string {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): void {
+        $this->label = $label;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\ImplicitData::dead
+    }
+}
+
+class ImplicitDataController extends AbstractController {
+
+    #[Route('/implicit')]
+    public function action(): Response {
+        $data = new ImplicitData();
+        $this->createForm(ProductType::class, $data);
+
+        return new Response();
+    }
+}
+
+// Case 4: createFormBuilder with typed data object
+
+class BuilderData {
+
+    private string $name;
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public function setName(string $name): void {
+        $this->name = $name;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\BuilderData::dead
+    }
+}
+
+class BuilderDataController extends AbstractController {
+
+    #[Route('/builder')]
+    public function action(): Response {
+        $data = new BuilderData();
+        $this->createFormBuilder($data);
+
+        return new Response();
+    }
+}
+
+// Case 5: FormFactoryInterface::create with typed data object
+
+class FactoryData {
+
+    private string $title;
+
+    public function getTitle(): string {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void {
+        $this->title = $title;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\FactoryData::dead
+    }
+}
+
+class FactoryService {
+
+    public function __construct( // error: Unused SymfonyForm\FactoryService::__construct
+        private readonly FormFactoryInterface $formFactory, // error: Property SymfonyForm\FactoryService::$formFactory is never read // error: Property SymfonyForm\FactoryService::$formFactory is never written
+    ) {
+    }
+
+    public function doSomething(): void { // error: Unused SymfonyForm\FactoryService::doSomething
+        $data = new FactoryData();
+        $this->formFactory->create(ProductType::class, $data);
+    }
+}

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -124,8 +124,6 @@ class PublicPropertyData {
 
     public string $label;
 
-    public readonly string $code; // error: Property SymfonyForm\PublicPropertyData::$code is never written
-
     public function dead(): void { // error: Unused SymfonyForm\PublicPropertyData::dead
     }
 }

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -270,3 +270,96 @@ class FactoryService {
         $this->formFactory->create(ProductType::class, $data);
     }
 }
+
+// Case 6: FormFactoryInterface::createNamed with typed data object
+
+class NamedData {
+
+    private string $value;
+
+    public function getValue(): string {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void {
+        $this->value = $value;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\NamedData::dead
+    }
+}
+
+class NamedFormService {
+
+    public function __construct( // error: Unused SymfonyForm\NamedFormService::__construct
+        private readonly FormFactoryInterface $formFactory, // error: Property SymfonyForm\NamedFormService::$formFactory is never read // error: Property SymfonyForm\NamedFormService::$formFactory is never written
+    ) {
+    }
+
+    public function doSomething(): void { // error: Unused SymfonyForm\NamedFormService::doSomething
+        $data = new NamedData();
+        $this->formFactory->createNamed('my_form', ProductType::class, $data);
+    }
+}
+
+// Case 7: FormFactoryInterface::createBuilder with typed data object
+
+class BuilderFactoryData {
+
+    private string $value;
+
+    public function getValue(): string {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void {
+        $this->value = $value;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\BuilderFactoryData::dead
+    }
+}
+
+class BuilderFactoryService {
+
+    public function __construct( // error: Unused SymfonyForm\BuilderFactoryService::__construct
+        private readonly FormFactoryInterface $formFactory, // error: Property SymfonyForm\BuilderFactoryService::$formFactory is never read // error: Property SymfonyForm\BuilderFactoryService::$formFactory is never written
+    ) {
+    }
+
+    public function doSomething(): void { // error: Unused SymfonyForm\BuilderFactoryService::doSomething
+        $data = new BuilderFactoryData();
+        $this->formFactory->createBuilder(ProductType::class, $data);
+    }
+}
+
+// Case 8: FormFactoryInterface::createNamedBuilder with typed data object
+
+class NamedBuilderData {
+
+    private string $value;
+
+    public function getValue(): string {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void {
+        $this->value = $value;
+    }
+
+    public function dead(): void { // error: Unused SymfonyForm\NamedBuilderData::dead
+    }
+}
+
+class NamedBuilderService {
+
+    public function __construct( // error: Unused SymfonyForm\NamedBuilderService::__construct
+        private readonly FormFactoryInterface $formFactory, // error: Property SymfonyForm\NamedBuilderService::$formFactory is never read // error: Property SymfonyForm\NamedBuilderService::$formFactory is never written
+    ) {
+    }
+
+    public function doSomething(): void { // error: Unused SymfonyForm\NamedBuilderService::doSomething
+        $data = new NamedBuilderData();
+        $this->formFactory->createNamedBuilder('my_form', ProductType::class, $data);
+    }
+}

--- a/tests/Rule/data/providers/symfony-form.php
+++ b/tests/Rule/data/providers/symfony-form.php
@@ -70,6 +70,10 @@ class ProductData extends BaseProductData {
         return false;
     }
 
+    private function getSecret(): string { // error: Unused SymfonyForm\ProductData::getSecret
+        return '';
+    }
+
     public static function staticFactory(): self { // error: Unused SymfonyForm\ProductData::staticFactory
         return new self();
     }


### PR DESCRIPTION
## Summary

Closes #199

- Detects `data_class` from `OptionsResolver::setDefaults()`/`setDefault()`, `AbstractController::createForm()`/`createFormBuilder()`, and `FormFactoryInterface::create()`/`createNamed()`/`createBuilder()`/`createNamedBuilder()`
- Marks accessor-pattern methods (`get*`/`set*`/`is*`/`has*`/`can*`/`add*`/`remove*`), public properties, and `__construct` on the data class as used by Symfony's PropertyAccessor
- Uses PHPStan's type system (`$scope->getType()`) to resolve `data_class` values — handles `::class` constants, typed objects passed to form factory methods, and explicit `data_class` option arrays

Co-Authored-By: Claude Code