### PR TITLE
Resolve string tags in AutowireIterator/AutowireLocator via DIC XML

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -21,6 +21,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantStringType;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionAttribute;
@@ -68,6 +69,13 @@ final class SymfonyUsageProvider implements MemberUsageProvider
      * @var array<string, array<string, true>>
      */
     private array $dicCalls = [];
+
+    /**
+     * tag => list of class names
+     *
+     * @var array<string, list<string>>
+     */
+    private array $dicTaggedClasses = [];
 
     /**
      * class => [constant => config file]
@@ -480,12 +488,16 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                     }
 
                     if ($arguments['services']->isArray()->yes()) {
-                        $classNames = $arguments['services']->getIterableValueType()->getConstantStrings();
+                        $resolvedClassNames = [];
+
+                        foreach ($arguments['services']->getIterableValueType()->getConstantStrings() as $className) {
+                            $resolvedClassNames[] = $className->getValue();
+                        }
                     } else {
-                        $classNames = $arguments['services']->getConstantStrings();
+                        $resolvedClassNames = $this->resolveTaggedClassNames($arguments['services']->getConstantStrings());
                     }
 
-                    if ($classNames === []) {
+                    if ($resolvedClassNames === []) {
                         continue;
                     }
 
@@ -500,11 +512,11 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                             continue;
                         }
 
-                        foreach ($classNames as $className) {
+                        foreach ($resolvedClassNames as $className) {
                             $usages[] = new ClassMethodUsage(
                                 $usageOrigin,
                                 new ClassMethodRef(
-                                    $className->getValue(),
+                                    $className,
                                     $method[0]->getValue(),
                                     possibleDescendant: true,
                                 ),
@@ -522,7 +534,13 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                         continue;
                     }
 
-                    $classNames = $arguments['tag']->getConstantStrings();
+                    $tagValues = $arguments['tag']->getConstantStrings();
+
+                    if ($tagValues === []) {
+                        continue;
+                    }
+
+                    $classNames = $this->resolveTaggedClassNames($tagValues);
 
                     if ($classNames === []) {
                         continue;
@@ -543,7 +561,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                             $usages[] = new ClassMethodUsage(
                                 $usageOrigin,
                                 new ClassMethodRef(
-                                    $className->getValue(),
+                                    $className,
                                     $method[0]->getValue(),
                                     possibleDescendant: true,
                                 ),
@@ -711,6 +729,16 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
                     $this->dicCalls[$class][$method] = true;
                 }
+
+                foreach ($serviceDefinition->tag ?? [] as $tagDefinition) {
+                    /** @var SimpleXMLElement $tagAttributes */
+                    $tagAttributes = $tagDefinition->attributes();
+                    $tagName = $tagAttributes->name !== null ? (string) $tagAttributes->name : null;
+
+                    if ($tagName !== null) {
+                        $this->dicTaggedClasses[$tagName][] = $class;
+                    }
+                }
             }
 
             foreach ($serviceDefinition->factory ?? [] as $factoryDefinition) {
@@ -753,6 +781,29 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         return $serviceMap;
+    }
+
+    /**
+     * @param list<ConstantStringType> $tagValues
+     * @return list<string>
+     */
+    private function resolveTaggedClassNames(array $tagValues): array
+    {
+        $classNames = [];
+
+        foreach ($tagValues as $tagValue) {
+            $value = $tagValue->getValue();
+
+            if (isset($this->dicTaggedClasses[$value])) {
+                foreach ($this->dicTaggedClasses[$value] as $class) {
+                    $classNames[] = $class;
+                }
+            } else {
+                $classNames[] = $value;
+            }
+        }
+
+        return $classNames;
     }
 
     private function isBundleConstructor(ReflectionMethod $method): bool

--- a/tests/Rule/data/providers/symfony-gte71.php
+++ b/tests/Rule/data/providers/symfony-gte71.php
@@ -195,6 +195,36 @@ class MessageHandlerWithMethodLevelNamedRedirect
     }
 }
 
+class TaggedServiceA {
+    public function getIndex(): string { return 'a'; }
+    public function getPriority(): int { return 1; }
+    public function dead(): void {} // error: Unused Symfony\TaggedServiceA::dead
+}
+
+class TaggedServiceB {
+    public function getIndex(): string { return 'b'; }
+    public function getPriority(): int { return 2; }
+    public function dead(): void {} // error: Unused Symfony\TaggedServiceB::dead
+}
+
+class TaggedIteratorController {
+
+    #[Route('/tagged-string', name: 'tagged-string')]
+    public function iteratorAction(
+        #[AutowireIterator('app.tagged_handler', defaultIndexMethod: 'getIndex', defaultPriorityMethod: 'getPriority')]
+        $iterator,
+    ): void {
+    }
+
+    #[Route('/locator-string', name: 'locator-string')]
+    public function locatorAction(
+        #[AutowireLocator('app.tagged_handler', defaultIndexMethod: 'getIndex', defaultPriorityMethod: 'getPriority')]
+        $locator,
+    ): void {
+    }
+
+}
+
 class AutowireCallableConsumer {
 
     #[Route('/callable', name: 'callable')]

--- a/tests/Rule/data/providers/symfony/services.xml
+++ b/tests/Rule/data/providers/symfony/services.xml
@@ -18,5 +18,11 @@
         <service id="Symfony\DicClass4" class="Symfony\DicClass4" public="true" autowire="true" autoconfigure="true">
             <argument type="service" id=".4_TokenConfig~abc123"/>
         </service>
+        <service id="Symfony\TaggedServiceA" class="Symfony\TaggedServiceA" public="true" autowire="true" autoconfigure="true">
+            <tag name="app.tagged_handler"/>
+        </service>
+        <service id="Symfony\TaggedServiceB" class="Symfony\TaggedServiceB" public="true" autowire="true" autoconfigure="true">
+            <tag name="app.tagged_handler"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
## Summary
- When `#[AutowireIterator]`, `#[TaggedIterator]`, `#[TaggedLocator]` or `#[AutowireLocator]` used a **string tag** (e.g. `'app.handler'`) instead of a class FQCN, the `defaultIndexMethod`/`defaultPriorityMethod` targets were falsely reported as dead
- Now we build a tag-to-classes map from `<tag>` elements in the DIC XML and use it to resolve string tags to concrete service classes
- Also fixes `#[AutowireLocator]` when its `$services` parameter is a string (tag name) rather than an array of class references

### Note

String tag resolution requires the container XML to be configured (same as other DIC-based features). This is done via either:
- [`phpstan/phpstan-symfony`](https://github.com/phpstan/phpstan-symfony) with `containerXmlPath`
- `shipmonkDeadCode.usageProviders.symfony.containerXmlPaths` configured directly:

```neon
parameters:
    shipmonkDeadCode:
        usageProviders:
            symfony:
                containerXmlPaths:
                    - %rootDir%/../../../var/cache/dev/App_KernelDevDebugContainer.xml
```

When a class FQCN is used as the tag (e.g. `#[AutowireIterator(SomeInterface::class, defaultIndexMethod: 'method')]`), it continues to work without any XML configuration.

Fixes #335

Co-Authored-By: Claude Code