### PR TITLE
Doctrine: Fix missing #[PostRemove] lifecycle callback detection

### DIFF
--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -210,6 +210,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
     {
         return $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PostLoad')
             || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PostPersist')
+            || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PostRemove')
             || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PostUpdate')
             || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PreFlush')
             || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PrePersist')

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -24,6 +24,9 @@ class MyEntity
     #[\Doctrine\ORM\Mapping\PreUpdate]
     public function onUpdate(PreUpdateEventArgs $args): void {}
 
+    #[\Doctrine\ORM\Mapping\PostRemove]
+    public function onRemove(): void {}
+
 }
 
 #[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postUpdate', method: 'afterUpdate')]


### PR DESCRIPTION
## Problem

`DoctrineUsageProvider::isLifecycleEventMethod()` checks 7 of the 8 Doctrine ORM lifecycle callback attributes but omits `Doctrine\ORM\Mapping\PostRemove`. This means any entity method annotated with `#[PostRemove]` is falsely reported as dead code.

Doctrine's `AttributeDriver::getMethodCallbacks()` handles all 8 lifecycle callbacks: `PrePersist`, `PostPersist`, `PreUpdate`, `PostUpdate`, `PreRemove`, `PostRemove`, `PostLoad`, `PreFlush`. We were missing exactly one: `PostRemove`.

## Changes

- Add `Doctrine\ORM\Mapping\PostRemove` to the lifecycle callback check
- Add test with `#[PostRemove]` annotated method

Co-Authored-By: Claude Code