### PR TITLE
PHPUnit: Fix cross-class @dataProvider annotation not being resolved

### DIFF
--- a/src/Provider/PhpUnitUsageProvider.php
+++ b/src/Provider/PhpUnitUsageProvider.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\TestCase;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function count;
+use function explode;
 use function is_string;
 use function ltrim;
 use function str_contains;
 use function str_starts_with;
-use function strpos;
-use function substr;
 
 final class PhpUnitUsageProvider implements MemberUsageProvider
 {
@@ -71,12 +71,11 @@ final class PhpUnitUsageProvider implements MemberUsageProvider
             }
 
             foreach ($annotationDataProviders as $dataProvider) {
-                $separatorPos = strpos($dataProvider, '::');
+                $parts = explode('::', $dataProvider, 2);
 
-                if ($separatorPos !== false) {
-                    $providerClassName = ltrim(substr($dataProvider, 0, $separatorPos), '\\');
-                    $providerMethodName = substr($dataProvider, $separatorPos + 2);
-                    $usages[] = $this->createUsage($providerClassName, $providerMethodName, "External data provider method (annotation), used by $className::$methodName");
+                if (count($parts) === 2) {
+                    $providerClassName = ltrim($parts[0], '\\');
+                    $usages[] = $this->createUsage($providerClassName, $parts[1], "External data provider method (annotation), used by $className::$methodName");
                 } else {
                     $usages[] = $this->createUsage($className, $dataProvider, "Data provider method, used by $methodName");
                 }

--- a/src/Provider/PhpUnitUsageProvider.php
+++ b/src/Provider/PhpUnitUsageProvider.php
@@ -14,10 +14,12 @@ use PHPUnit\Framework\TestCase;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
-use function array_merge;
 use function is_string;
+use function ltrim;
 use function str_contains;
 use function str_starts_with;
+use function strpos;
+use function substr;
 
 final class PhpUnitUsageProvider implements MemberUsageProvider
 {
@@ -61,13 +63,23 @@ final class PhpUnitUsageProvider implements MemberUsageProvider
             $methodName = $method->getName();
 
             $externalDataProviderMethods = $this->getExternalDataProvidersFromAttributes($method);
-            $localDataProviderMethods = array_merge(
-                $this->getDataProvidersFromAnnotations($method->getDocComment()),
-                $this->getDataProvidersFromAttributes($method),
-            );
+            $annotationDataProviders = $this->getDataProvidersFromAnnotations($method->getDocComment());
+            $localDataProviderMethods = $this->getDataProvidersFromAttributes($method);
 
             foreach ($externalDataProviderMethods as [$externalClassName, $externalMethodName]) {
                 $usages[] = $this->createUsage($externalClassName, $externalMethodName, "External data provider method, used by $className::$methodName");
+            }
+
+            foreach ($annotationDataProviders as $dataProvider) {
+                $separatorPos = strpos($dataProvider, '::');
+
+                if ($separatorPos !== false) {
+                    $providerClassName = ltrim(substr($dataProvider, 0, $separatorPos), '\\');
+                    $providerMethodName = substr($dataProvider, $separatorPos + 2);
+                    $usages[] = $this->createUsage($providerClassName, $providerMethodName, "External data provider method (annotation), used by $className::$methodName");
+                } else {
+                    $usages[] = $this->createUsage($className, $dataProvider, "Data provider method, used by $methodName");
+                }
             }
 
             foreach ($localDataProviderMethods as $dataProvider) {

--- a/tests/Rule/data/providers/phpunit.php
+++ b/tests/Rule/data/providers/phpunit.php
@@ -25,6 +25,11 @@ class ExternalProvider {
     {
         return [];
     }
+
+    public static function provideViaAnnotation(): array
+    {
+        return [];
+    }
 }
 
 class SomeTest extends TestCase
@@ -57,6 +62,13 @@ class SomeTest extends TestCase
      * @dataProvider provideFromPhpDoc
      */
     public function testBar(string $arg): void
+    {
+    }
+
+    /**
+     * @dataProvider \PhpUnit\ExternalProvider::provideViaAnnotation
+     */
+    public function testExternalViaAnnotation(string $arg): void
     {
     }
 


### PR DESCRIPTION
## Problem

PHPUnit supports cross-class data providers via the `@dataProvider ClassName::methodName` annotation syntax. The detector's `getDataProvidersFromAnnotations()` returns the raw tag value (e.g. `\App\ExternalProvider::provideData`) and feeds it into `createUsage($currentClassName, $rawValue, ...)` — treating the entire string including the class prefix as a method name on the current test class.

The `#[DataProviderExternal]` attribute path handles cross-class references correctly (separate class + method arguments), but the equivalent annotation path did not split on `::`.

PHPUnit's own `AnnotationParser` handles this by splitting on `::` (see `vendor/phpunit/phpunit/src/Metadata/Parser/AnnotationParser.php:245`).

## Changes

- Split annotation data provider values on `::` to extract external class name and method name
- Strip leading `\` from FQCN (PHPStan stores class names without it)
- Add test with `@dataProvider \PhpUnit\ExternalProvider::provideViaAnnotation`

Co-Authored-By: Claude Code