### PR TITLE
Symfony: Add support for #[MapInput] console command DTOs

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -54,3 +54,9 @@ parameters:
         # allow referencing any attribute classes
         - '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionClass\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
         - '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionMethod\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
+
+        # Symfony Console 7.x (which introduced MapInput/Argument/Option attributes) requires PHP 8.2+,
+        # so on PHP 8.1 those classes are unknown and the literal class-string is rejected
+        -
+            message: '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionProperty\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
+            reportUnmatched: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -51,12 +51,10 @@ parameters:
             message: "#but it's missing from the PHPDoc @throws tag\\.$#" # allow uncatched exceptions in tests
             path: tests/*
 
-        # allow referencing any attribute classes
+        # allow referencing any attribute classes (ReflectionProperty variant only triggers on PHP 8.1,
+        # where Symfony Console 6.x is installed and MapInput/Argument/Option attribute classes are unknown)
         - '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionClass\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
         - '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionMethod\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
-
-        # Symfony Console 7.x (which introduced MapInput/Argument/Option attributes) requires PHP 8.2+,
-        # so on PHP 8.1 those classes are unknown and the literal class-string is rejected
         -
             message: '#^Parameter \#1 \$name of method PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionProperty\:\:getAttributes\(\) expects class\-string\|null, string given\.$#'
             reportUnmatched: false

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -686,11 +686,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             }
 
             foreach ($parameterType->getObjectClassNames() as $dtoClassName) {
-                if (!$this->reflectionProvider->hasClass($dtoClassName)) {
-                    continue;
-                }
-
-                $this->collectMapInputDtoUsages($dtoClassName, $usages);
+                $usages = [...$usages, ...$this->collectMapInputDtoUsages($dtoClassName)];
             }
         }
 
@@ -698,51 +694,44 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * @param list<ClassMethodUsage|ClassPropertyUsage> $usages
      * @param array<string, true> $visited
+     * @return list<ClassMethodUsage|ClassPropertyUsage>
      */
     private function collectMapInputDtoUsages(
         string $dtoClassName,
-        array &$usages,
         array &$visited = [],
-    ): void
+    ): array
     {
         if (isset($visited[$dtoClassName])) {
-            return;
+            return [];
         }
 
         $visited[$dtoClassName] = true;
 
         if (!$this->reflectionProvider->hasClass($dtoClassName)) {
-            return;
+            return [];
         }
 
         $dtoReflection = $this->reflectionProvider->getClass($dtoClassName);
-        $origin = UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Console input DTO via #[MapInput]'));
+        $nativeReflection = $dtoReflection->getNativeReflection();
+        $note = 'Console input DTO via #[MapInput]';
+        $usages = [];
 
-        foreach ($dtoReflection->getNativeReflection()->getProperties() as $property) {
+        foreach ($nativeReflection->getProperties() as $property) {
             if ($property->getDeclaringClass()->getName() !== $dtoClassName) {
                 continue;
             }
 
-            $isInputProperty = $property->getAttributes('Symfony\Component\Console\Attribute\Argument') !== []
-                || $property->getAttributes('Symfony\Component\Console\Attribute\Option') !== [];
-            $nestedMapInput = $property->getAttributes('Symfony\Component\Console\Attribute\MapInput') !== [];
+            $isInputProperty = $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\Argument')
+                || $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\Option');
+            $nestedMapInput = $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\MapInput');
 
             if (!$isInputProperty && !$nestedMapInput) {
                 continue;
             }
 
-            $usages[] = new ClassPropertyUsage(
-                $origin,
-                new ClassPropertyRef($dtoClassName, $property->getName(), possibleDescendant: false),
-                AccessType::WRITE,
-            );
-            $usages[] = new ClassPropertyUsage(
-                $origin,
-                new ClassPropertyRef($dtoClassName, $property->getName(), possibleDescendant: false),
-                AccessType::READ,
-            );
+            $usages[] = $this->createPropertyUsage($property, $note, AccessType::WRITE);
+            $usages[] = $this->createPropertyUsage($property, $note, AccessType::READ);
 
             if (!$nestedMapInput) {
                 continue;
@@ -754,21 +743,23 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 continue;
             }
 
-            $this->collectMapInputDtoUsages($propertyType->getName(), $usages, $visited);
+            $usages = [...$usages, ...$this->collectMapInputDtoUsages($propertyType->getName(), $visited)];
         }
 
-        foreach ($dtoReflection->getNativeReflection()->getMethods() as $dtoMethod) {
+        foreach ($nativeReflection->getMethods() as $dtoMethod) {
             if ($dtoMethod->getDeclaringClass()->getName() !== $dtoClassName) {
                 continue;
             }
 
-            if ($dtoMethod->getAttributes('Symfony\Component\Console\Attribute\Interact') !== []) {
+            if ($this->hasAttribute($dtoMethod, 'Symfony\Component\Console\Attribute\Interact')) {
                 $usages[] = new ClassMethodUsage(
-                    $origin,
+                    UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
                     new ClassMethodRef($dtoClassName, $dtoMethod->getName(), possibleDescendant: false),
                 );
             }
         }
+
+        return $usages;
     }
 
     private function shouldMarkAsUsed(ReflectionMethod $method): ?string

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -686,12 +686,24 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
     /**
      * @param list<ClassMethodUsage|ClassPropertyUsage> $usages
+     * @param array<string, true> $visited
      */
     private function collectMapInputDtoUsages(
         string $dtoClassName,
         array &$usages,
+        array &$visited = [],
     ): void
     {
+        if (isset($visited[$dtoClassName])) {
+            return;
+        }
+
+        $visited[$dtoClassName] = true;
+
+        if (!$this->reflectionProvider->hasClass($dtoClassName)) {
+            return;
+        }
+
         $dtoReflection = $this->reflectionProvider->getClass($dtoClassName);
         $origin = UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Console input DTO via #[MapInput]'));
 
@@ -702,8 +714,9 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
             $isInputProperty = $property->getAttributes('Symfony\Component\Console\Attribute\Argument') !== []
                 || $property->getAttributes('Symfony\Component\Console\Attribute\Option') !== [];
+            $nestedMapInput = $property->getAttributes('Symfony\Component\Console\Attribute\MapInput') !== [];
 
-            if (!$isInputProperty) {
+            if (!$isInputProperty && !$nestedMapInput) {
                 continue;
             }
 
@@ -717,6 +730,18 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 new ClassPropertyRef($dtoClassName, $property->getName(), possibleDescendant: false),
                 AccessType::READ,
             );
+
+            if (!$nestedMapInput) {
+                continue;
+            }
+
+            $propertyType = $property->getType();
+
+            if (!$propertyType instanceof ReflectionNamedType || $propertyType->isBuiltin()) {
+                continue;
+            }
+
+            $this->collectMapInputDtoUsages($propertyType->getName(), $usages, $visited);
         }
 
         foreach ($dtoReflection->getNativeReflection()->getMethods() as $dtoMethod) {

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
@@ -30,7 +31,6 @@ use PHPStan\Type\Type;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionAttribute;
-use ReflectionEnum;
 use ReflectionNamedType;
 use Reflector;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
@@ -655,10 +655,6 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         $nativeReflection = $node->getClassReflection()->getNativeReflection();
-
-        if ($nativeReflection instanceof ReflectionEnum) {
-            return [];
-        }
 
         $isCommand = $this->hasAttribute($nativeReflection, 'Symfony\Component\Console\Attribute\AsCommand')
             || $nativeReflection->isSubclassOf('Symfony\Component\Console\Command\Command');
@@ -1456,7 +1452,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $classOrMethod
+     * @param ReflectionClass|ReflectionMethod|ReflectionProperty|ReflectionEnum $classOrMethod
      * @param ReflectionAttribute::IS_*|0 $flags
      */
     private function hasAttribute(

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -162,6 +162,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $usages = [
                 ...$usages,
                 ...$this->getMethodUsagesFromAttributeReflection($node, $scope),
+                ...$this->getMapInputUsages($node),
             ];
         }
 
@@ -642,6 +643,94 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         return $usages;
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function getMapInputUsages(InClassMethodNode $node): array
+    {
+        $usages = [];
+
+        foreach ($node->getMethodReflection()->getParameters() as $parameter) {
+            $isMapInput = false;
+
+            foreach ($parameter->getAttributes() as $attributeReflection) {
+                if ($attributeReflection->getName() === 'Symfony\Component\Console\Attribute\MapInput') {
+                    $isMapInput = true;
+                    break;
+                }
+            }
+
+            if (!$isMapInput) {
+                continue;
+            }
+
+            $parameterType = $parameter->getType();
+
+            if (!$parameterType->isObject()->yes()) {
+                continue;
+            }
+
+            foreach ($parameterType->getObjectClassNames() as $dtoClassName) {
+                if (!$this->reflectionProvider->hasClass($dtoClassName)) {
+                    continue;
+                }
+
+                $this->collectMapInputDtoUsages($dtoClassName, $usages);
+            }
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @param list<ClassMemberUsage> $usages
+     */
+    private function collectMapInputDtoUsages(
+        string $dtoClassName,
+        array &$usages,
+    ): void
+    {
+        $dtoReflection = $this->reflectionProvider->getClass($dtoClassName);
+        $origin = UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Console input DTO via #[MapInput]'));
+
+        foreach ($dtoReflection->getNativeReflection()->getProperties() as $property) {
+            if ($property->getDeclaringClass()->getName() !== $dtoClassName) {
+                continue;
+            }
+
+            $isInputProperty = $property->getAttributes('Symfony\Component\Console\Attribute\Argument') !== []
+                || $property->getAttributes('Symfony\Component\Console\Attribute\Option') !== [];
+
+            if (!$isInputProperty) {
+                continue;
+            }
+
+            $usages[] = new ClassPropertyUsage(
+                $origin,
+                new ClassPropertyRef($dtoClassName, $property->getName(), possibleDescendant: false),
+                AccessType::WRITE,
+            );
+            $usages[] = new ClassPropertyUsage(
+                $origin,
+                new ClassPropertyRef($dtoClassName, $property->getName(), possibleDescendant: false),
+                AccessType::READ,
+            );
+        }
+
+        foreach ($dtoReflection->getNativeReflection()->getMethods() as $dtoMethod) {
+            if ($dtoMethod->getDeclaringClass()->getName() !== $dtoClassName) {
+                continue;
+            }
+
+            if ($dtoMethod->getAttributes('Symfony\Component\Console\Attribute\Interact') !== []) {
+                $usages[] = new ClassMethodUsage(
+                    $origin,
+                    new ClassMethodRef($dtoClassName, $dtoMethod->getName(), possibleDescendant: false),
+                );
+            }
+        }
     }
 
     private function shouldMarkAsUsed(ReflectionMethod $method): ?string

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -646,7 +646,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * @return list<ClassMemberUsage>
+     * @return list<ClassMethodUsage|ClassPropertyUsage>
      */
     private function getMapInputUsages(InClassMethodNode $node): array
     {
@@ -685,7 +685,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * @param list<ClassMemberUsage> $usages
+     * @param list<ClassMethodUsage|ClassPropertyUsage> $usages
      */
     private function collectMapInputDtoUsages(
         string $dtoClassName,

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -650,6 +650,23 @@ final class SymfonyUsageProvider implements MemberUsageProvider
      */
     private function getMapInputUsages(InClassMethodNode $node): array
     {
+        if ($node->getMethodReflection()->getName() !== '__invoke') {
+            return [];
+        }
+
+        $nativeReflection = $node->getClassReflection()->getNativeReflection();
+
+        if ($nativeReflection instanceof ReflectionEnum) {
+            return [];
+        }
+
+        $isCommand = $this->hasAttribute($nativeReflection, 'Symfony\Component\Console\Attribute\AsCommand')
+            || $nativeReflection->isSubclassOf('Symfony\Component\Console\Command\Command');
+
+        if (!$isCommand) {
+            return [];
+        }
+
         $usages = [];
 
         foreach ($node->getMethodReflection()->getParameters() as $parameter) {

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -265,3 +265,37 @@ class OrphanedInput {
     #[Interact]
     public function askSomething(): void {} // error: Unused Symfony\OrphanedInput::askSomething
 }
+
+class NestedFiltersInput {
+    #[\Symfony\Component\Console\Attribute\Argument]
+    public string $tag;
+
+    #[\Symfony\Component\Console\Attribute\Option]
+    public bool $strict = false;
+
+    public string $notAnInput; // error: Property Symfony\NestedFiltersInput::$notAnInput is never read // error: Property Symfony\NestedFiltersInput::$notAnInput is never written
+
+    #[Interact]
+    public function askForTag(): void {}
+
+    public function deadOnNested(): void {} // error: Unused Symfony\NestedFiltersInput::deadOnNested
+}
+
+class WrappedImportInput {
+    #[\Symfony\Component\Console\Attribute\Argument]
+    public string $name;
+
+    #[\Symfony\Component\Console\Attribute\MapInput]
+    public NestedFiltersInput $filters;
+}
+
+#[AsCommand(name: 'app:import-wrapped')]
+class WrappedImportCommand extends Command {
+    public function __invoke(
+        #[\Symfony\Component\Console\Attribute\MapInput] WrappedImportInput $input,
+    ): int {
+        echo $input->name;
+        echo $input->filters->tag;
+        return 0;
+    }
+}

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -235,3 +235,33 @@ class RequiredPropertyService {
     public object $unused; // error: Property Symfony\RequiredPropertyService::$unused is never read // error: Property Symfony\RequiredPropertyService::$unused is never written
 }
 
+class ImportInput {
+    #[\Symfony\Component\Console\Attribute\Argument]
+    public string $file;
+
+    #[\Symfony\Component\Console\Attribute\Option]
+    public bool $force = false;
+
+    public string $notAnInput; // error: Property Symfony\ImportInput::$notAnInput is never read // error: Property Symfony\ImportInput::$notAnInput is never written
+
+    #[Interact]
+    public function askForConfirmation(): void {}
+}
+
+#[AsCommand(name: 'app:import')]
+class ImportCommand extends Command {
+    public function __invoke(
+        #[\Symfony\Component\Console\Attribute\MapInput] ImportInput $input,
+    ): int {
+        echo $input->file;
+        return 0;
+    }
+}
+
+class OrphanedInput {
+    #[\Symfony\Component\Console\Attribute\Argument]
+    public string $name; // error: Property Symfony\OrphanedInput::$name is never read // error: Property Symfony\OrphanedInput::$name is never written
+
+    #[Interact]
+    public function askSomething(): void {} // error: Unused Symfony\OrphanedInput::askSomething
+}


### PR DESCRIPTION
## Problem

When a Symfony console command uses `#[MapInput]` on a method parameter, the framework creates a DTO via `newInstanceWithoutConstructor()` and writes directly to public properties decorated with `#[Argument]` or `#[Option]`. It also reads those properties back in `setValue()`. Methods with `#[Interact]` on the DTO are called for interactive input. `#[MapInput]` can also be placed on a DTO property to nest another input DTO. All of this is invisible in user source code, causing false positives.

## Approach

Detection is **anchored at the `#[MapInput]` usage site** — we only mark DTO properties as used when the DTO class is actually referenced by a `#[MapInput]` parameter (directly or via nesting). A class with `#[Argument]`/`#[Option]` properties that is never referenced by `#[MapInput]` will still be reported as dead.

## Changes

- Detect `#[MapInput]` attribute on method parameters
- Resolve the parameter type to the DTO class
- Mark properties with `#[Argument]` or `#[Option]` as both read and written
- Mark methods with `#[Interact]` as used
- Recurse into nested `#[MapInput]` properties on the DTO (the host property is marked read+written, cycles prevented via visited set)
- Add positive test (referenced DTO), negative test (orphaned DTO not referenced by `#[MapInput]`), and nested-DTO test

Co-Authored-By: Claude Code