### PR TITLE
Symfony: Add support for AsTwigComponent(template: new FromMethod(...))

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -36,6 +36,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use SimpleXMLElement;
 use SplFileInfo;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
 use UnexpectedValueException;
 use function array_filter;
 use function array_key_first;
@@ -414,6 +415,21 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
             if (is_string($defaultAction) && $classReflection->hasNativeMethod($defaultAction)) {
                 $usages[] = $this->createUsage($classReflection->getNativeMethod($defaultAction), 'Default action method via #[AsLiveComponent(defaultAction)] attribute');
+            }
+        }
+
+        foreach (['Symfony\UX\TwigComponent\Attribute\AsTwigComponent', 'Symfony\UX\LiveComponent\Attribute\AsLiveComponent'] as $twigComponentAttributeClass) {
+            foreach ($nativeReflection->getAttributes($twigComponentAttributeClass) as $twigComponentAttribute) {
+                $twigComponentArguments = $twigComponentAttribute->getArguments();
+                $template = $twigComponentArguments['template'] ?? $twigComponentArguments[1] ?? null;
+
+                if ($template instanceof FromMethod) {
+                    $templateMethodName = $template->method;
+
+                    if ($classReflection->hasNativeMethod($templateMethodName)) {
+                        $usages[] = $this->createUsage($classReflection->getNativeMethod($templateMethodName), 'Twig component template method via FromMethod');
+                    }
+                }
             }
         }
 

--- a/tests/Rule/data/providers/symfony-ux.php
+++ b/tests/Rule/data/providers/symfony-ux.php
@@ -107,3 +107,18 @@ class CustomActionComponent
 
     public function deadMethod(): void {} // error: Unused SymfonyUx\CustomActionComponent::deadMethod
 }
+
+#[AsTwigComponent(template: new \Symfony\UX\TwigComponent\Attribute\FromMethod('getTemplatePath'))]
+class DynamicTemplateComponent
+{
+    public function __construct() {}
+
+    public function mount(): void {}
+
+    public function getTemplatePath(): string
+    {
+        return 'components/dynamic.html.twig';
+    }
+
+    public function deadMethod(): void {} // error: Unused SymfonyUx\DynamicTemplateComponent::deadMethod
+}


### PR DESCRIPTION
## Problem

When `#[AsTwigComponent(template: new FromMethod('getTemplatePath'))]` is used, the framework dynamically calls `$component->getTemplatePath()` at render time to resolve the template path (in `PreRenderEvent::__construct()`). The detector already handles `#[AsTwigComponent]` for constructors and `mount()`, but does not extract the `FromMethod` method reference from the `template` parameter, causing the referenced method to be falsely reported as dead.

## Changes

- After processing `#[AsLiveComponent(defaultAction)]`, iterate `#[AsTwigComponent]` and `#[AsLiveComponent]` attributes to check for `FromMethod` in the `template` argument
- `ReflectionAttribute::getArguments()` returns the evaluated `FromMethod` object, allowing direct access to its `method` property
- Avoided `IS_INSTANCEOF` flag (causes reflection errors in test fixtures where `AsMessageHandler` is not loaded)
- Add test with `#[AsTwigComponent(template: new FromMethod('getTemplatePath'))]`

Co-Authored-By: Claude Code