### PR TITLE
Doctrine: Add ToolEvents to listener heuristic

### DIFF
--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -220,7 +220,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
 
     /**
      * Ideally, we would need to parse DIC xml to know this for sure just like phpstan-symfony does.
-     * - see Doctrine\ORM\Events::*
+     * - see Doctrine\ORM\Events::* and Doctrine\ORM\Tools\ToolEvents::*
      */
     private function isProbablyDoctrineListener(string $methodName): bool
     {
@@ -236,7 +236,9 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             || $methodName === 'preFlush'
             || $methodName === 'onFlush'
             || $methodName === 'postFlush'
-            || $methodName === 'onClear';
+            || $methodName === 'onClear'
+            || $methodName === 'postGenerateSchemaTable'
+            || $methodName === 'postGenerateSchema';
     }
 
     private function hasAttribute(

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -56,6 +56,10 @@ class OldListenerHeuristics {
 
     public function postPersist(): void {}
 
+    public function postGenerateSchemaTable(): void {}
+
+    public function postGenerateSchema(): void {}
+
     public function deadCode(): void // error: Unused Doctrine\OldListenerHeuristics::deadCode
     {
 


### PR DESCRIPTION
## Problem

The `isProbablyDoctrineListener()` heuristic method covers all 13 event names from `Doctrine\ORM\Events` but is missing 2 events from `Doctrine\ORM\Tools\ToolEvents`:
- `postGenerateSchemaTable`
- `postGenerateSchema`

These events are dispatched by `SchemaTool::getSchemaFromMetadata()` during schema generation. A plain Doctrine `EventManager` listener with methods matching these names would be falsely reported as dead.

Note: This only affects listeners registered via plain `EventManager::addEventListener()` without `#[AsDoctrineListener]` or `#[AutoconfigureTag]` attributes, which resolve event names dynamically and already work correctly.

## Changes

- Add `postGenerateSchemaTable` and `postGenerateSchema` to the heuristic
- Update comment to reference both `Events::*` and `ToolEvents::*`
- Add test methods to `OldListenerHeuristics` fixture

Co-Authored-By: Claude Code