### PR TITLE
Symfony: Mark BackedEnum cases as used in invokable command parameters

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -30,6 +30,8 @@ use PHPStan\Type\Type;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionAttribute;
+use ReflectionEnum;
+use ReflectionNamedType;
 use Reflector;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
@@ -152,6 +154,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 ...$this->getMethodUsagesFromReflection($node),
                 ...$this->getPropertyUsagesFromReflection($node),
                 ...$this->getConstantUsages($node->getClassReflection()),
+                ...$this->getInvokableCommandEnumUsages($node),
             ];
         }
 
@@ -665,6 +668,10 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
         if ($this->isConstructorWithAsCommandAttribute($method)) {
             return 'Class has #[AsCommand] attribute';
+        }
+
+        if ($this->isInvokeOnAsCommandClass($method)) {
+            return 'Invokable command method via #[AsCommand] attribute';
         }
 
         if ($this->isConstructorWithAsControllerAttribute($method)) {
@@ -1194,6 +1201,12 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         return $method->isConstructor() && $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand');
     }
 
+    private function isInvokeOnAsCommandClass(ReflectionMethod $method): bool
+    {
+        $class = $method->getDeclaringClass();
+        return $method->getName() === '__invoke' && $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand');
+    }
+
     private function isConstructorWithAsControllerAttribute(ReflectionMethod $method): bool
     {
         $class = $method->getDeclaringClass();
@@ -1481,6 +1494,78 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                     isEnumCase: TrinaryLogic::createYes(),
                 ),
             );
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @return list<ClassConstantUsage>
+     */
+    private function getInvokableCommandEnumUsages(InClassNode $node): array
+    {
+        $classReflection = $node->getClassReflection();
+        $nativeReflection = $classReflection->getNativeReflection();
+
+        if ($nativeReflection instanceof ReflectionEnum) {
+            return [];
+        }
+
+        if (!$this->hasAttribute($nativeReflection, 'Symfony\Component\Console\Attribute\AsCommand')) {
+            return [];
+        }
+
+        $invokeMethod = null;
+
+        foreach ($nativeReflection->getMethods() as $method) {
+            if ($method->getName() === '__invoke') {
+                $invokeMethod = $method;
+                break;
+            }
+        }
+
+        if ($invokeMethod === null) {
+            return [];
+        }
+
+        $usages = [];
+
+        foreach ($invokeMethod->getParameters() as $parameter) {
+            $type = $parameter->getType();
+
+            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+                continue;
+            }
+
+            $typeName = $type->getName();
+
+            if (!$this->reflectionProvider->hasClass($typeName)) {
+                continue;
+            }
+
+            $enumReflection = $this->reflectionProvider->getClass($typeName);
+
+            if (!$enumReflection->isBackedEnum()) {
+                continue;
+            }
+
+            $nativeEnumReflection = $enumReflection->getNativeReflection();
+
+            if (!$nativeEnumReflection instanceof ReflectionEnum) {
+                continue;
+            }
+
+            foreach ($nativeEnumReflection->getCases() as $case) {
+                $usages[] = new ClassConstantUsage(
+                    UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Invokable command parameter in ' . $nativeReflection->getShortName())),
+                    new ClassConstantRef(
+                        $typeName,
+                        $case->getName(),
+                        possibleDescendant: false,
+                        isEnumCase: TrinaryLogic::createYes(),
+                    ),
+                );
+            }
         }
 
         return $usages;

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -670,10 +670,6 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return 'Class has #[AsCommand] attribute';
         }
 
-        if ($this->isInvokeOnAsCommandClass($method)) {
-            return 'Invokable command method via #[AsCommand] attribute';
-        }
-
         if ($this->isConstructorWithAsControllerAttribute($method)) {
             return 'Class has #[AsController] attribute';
         }
@@ -1201,12 +1197,6 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         return $method->isConstructor() && $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand');
     }
 
-    private function isInvokeOnAsCommandClass(ReflectionMethod $method): bool
-    {
-        $class = $method->getDeclaringClass();
-        return $method->getName() === '__invoke' && $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand');
-    }
-
     private function isConstructorWithAsControllerAttribute(ReflectionMethod $method): bool
     {
         $class = $method->getDeclaringClass();
@@ -1511,7 +1501,10 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return [];
         }
 
-        if (!$this->hasAttribute($nativeReflection, 'Symfony\Component\Console\Attribute\AsCommand')) {
+        $isCommand = $this->hasAttribute($nativeReflection, 'Symfony\Component\Console\Attribute\AsCommand')
+            || $nativeReflection->isSubclassOf('Symfony\Component\Console\Command\Command');
+
+        if (!$isCommand) {
             return [];
         }
 

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -111,12 +111,25 @@ enum InvokableCommandUnused: string {
     case B = 'b'; // error: Unused Symfony\InvokableCommandUnused::B
 }
 
+enum InvokableCommandModeViaExtend: string {
+    case Fast = 'fast';
+    case Slow = 'slow';
+}
+
 #[AsCommand('app:invokable')]
 class InvokableCommand
 {
     public function __invoke(InvokableCommandMode $mode): int
     {
         InvokableCommandUnused::A;
+        return 0;
+    }
+}
+
+class InvokableCommandViaExtend extends Command
+{
+    public function __invoke(InvokableCommandModeViaExtend $mode): int
+    {
         return 0;
     }
 }

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -101,6 +101,26 @@ class HelloCommand
     public function __construct() {}
 }
 
+enum InvokableCommandMode: string {
+    case Dry = 'dry';
+    case Wet = 'wet';
+}
+
+enum InvokableCommandUnused: string {
+    case A = 'a';
+    case B = 'b'; // error: Unused Symfony\InvokableCommandUnused::B
+}
+
+#[AsCommand('app:invokable')]
+class InvokableCommand
+{
+    public function __invoke(InvokableCommandMode $mode): int
+    {
+        InvokableCommandUnused::A;
+        return 0;
+    }
+}
+
 class DicClassParent { // not present in DIC, but ctor is not dead
     public function __construct() {}
 }


### PR DESCRIPTION
## Summary
- When a Symfony command uses the invokable pattern (`#[AsCommand]` + `__invoke` method), `BackedEnum`-typed parameters are resolved at runtime via `::tryFrom()`, meaning any case could be provided via CLI input
- Marks all cases of such enums as used
- Also marks the `__invoke` method itself as used on `#[AsCommand]` classes

Co-Authored-By: Claude Code