### PR TITLE
API Platform: Add support for resource attributes, filters and operation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ parameters:
 - `!php/const` and `!php/enum` references in `config` yamls
 - Symfony UX: `#[AsTwigComponent]`/`#[AsLiveComponent]` (constructor, `mount()`), `#[LiveProp]`, `#[LiveAction]`, `#[LiveListener]`, lifecycle hooks
 
+#### API Platform:
+- Resource classes — properties (serialized/deserialized), constructor, and PropertyAccessor-style accessors on classes with `#[ApiResource]` or any operation attribute (`#[Get]`, `#[GetCollection]`, `#[Post]`, `#[Put]`, `#[Patch]`, `#[Delete]`, GraphQL `#[Query]`/`#[Mutation]`/…)
+- `provider:`, `processor:`, `controller:` class-string references in operation attributes (supports `Class::method` syntax)
+- Filter classes referenced via `#[ApiFilter]` (class and property level)
+
 #### Doctrine:
 - `#[AsEntityListener]`, `#[AsDoctrineListener]` attribute
 - `Doctrine\ORM\Events::*` events, `Doctrine\Common\EventSubscriber` methods

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",
+        "api-platform/core": "^3.0 || ^4.0",
         "behat/behat": "^3.14",
         "composer/semver": "^3.4",
         "doctrine/orm": "^2.19 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a24b57f996c94a3df027eade4f9ee0c1",
+    "content-hash": "eacbda73c05cabdcbf99c8ef907f63f3",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -61,6 +61,230 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "api-platform/core",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/api-platform/core.git",
+                "reference": "7cc01a69ab0974990a7a7d4ad2bc7914b710addb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/7cc01a69ab0974990a7a7d4ad2bc7914b710addb",
+                "reference": "7cc01a69ab0974990a7a7d4ad2bc7914b710addb",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.4",
+                "doctrine/inflector": "^2.0",
+                "php": ">=8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^3.1",
+                "symfony/http-foundation": "^6.4.14 || ^7.0 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
+                "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.1 || ^8.0",
+                "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
+                "symfony/translation-contracts": "^3.3",
+                "symfony/type-info": "^7.4 || ^8.0",
+                "symfony/validator": "^6.4.11 || ^7.1 || ^8.0",
+                "symfony/web-link": "^6.4 || ^7.1 || ^8.0",
+                "willdurand/negotiation": "^3.1"
+            },
+            "conflict": {
+                "doctrine/common": "<3.2.2",
+                "doctrine/dbal": "<2.10",
+                "doctrine/mongodb-odm": "<2.4",
+                "doctrine/orm": "<2.14.0 || 3.0.0",
+                "doctrine/persistence": "<1.3",
+                "phpspec/prophecy": "<1.15",
+                "phpunit/phpunit": "<9.5",
+                "symfony/framework-bundle": "6.4.6 || 7.0.6",
+                "symfony/object-mapper": "<7.3.4",
+                "symfony/var-exporter": "<6.1.1"
+            },
+            "replace": {
+                "api-platform/doctrine-common": "self.version",
+                "api-platform/doctrine-odm": "self.version",
+                "api-platform/doctrine-orm": "self.version",
+                "api-platform/documentation": "self.version",
+                "api-platform/elasticsearch": "self.version",
+                "api-platform/graphql": "self.version",
+                "api-platform/hal": "self.version",
+                "api-platform/http-cache": "self.version",
+                "api-platform/hydra": "self.version",
+                "api-platform/json-api": "self.version",
+                "api-platform/json-schema": "self.version",
+                "api-platform/jsonld": "self.version",
+                "api-platform/laravel": "self.version",
+                "api-platform/mcp": "self.version",
+                "api-platform/metadata": "self.version",
+                "api-platform/openapi": "self.version",
+                "api-platform/parameter-validator": "self.version",
+                "api-platform/ramsey-uuid": "self.version",
+                "api-platform/serializer": "self.version",
+                "api-platform/state": "self.version",
+                "api-platform/symfony": "self.version",
+                "api-platform/validator": "self.version"
+            },
+            "require-dev": {
+                "behat/behat": "^3.11",
+                "behat/mink": "^1.9",
+                "doctrine/common": "^3.2.2",
+                "doctrine/dbal": "^4.0",
+                "doctrine/doctrine-bundle": "^2.11 || ^3.1",
+                "doctrine/orm": "^2.17 || ^3.0",
+                "elasticsearch/elasticsearch": "^7.17 || ^8.4 || ^9.0",
+                "friends-of-behat/mink-browserkit-driver": "^1.3.1",
+                "friends-of-behat/mink-extension": "^2.2",
+                "friends-of-behat/symfony-extension": "^2.1",
+                "friendsofphp/php-cs-fixer": "^3.93",
+                "guzzlehttp/guzzle": "^6.0 || ^7.0",
+                "illuminate/config": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/http": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/pagination": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+                "jangregor/phpstan-prophecy": "^2.1.11",
+                "justinrainbow/json-schema": "^6.5.2",
+                "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+                "mcp/sdk": "^0.4.0",
+                "orchestra/testbench": "^10.9 || ^11.0",
+                "phpspec/prophecy-phpunit": "^2.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpdoc-parser": "^1.29 || ^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-doctrine": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^12.2",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "ramsey/uuid": "^4.7",
+                "ramsey/uuid-doctrine": "^2.0",
+                "soyuka/contexts": "^3.3.10",
+                "soyuka/pmu": "^0.2.0",
+                "soyuka/stubs-mongodb": "^1.0",
+                "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+                "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+                "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/doctrine-bridge": "^6.4.2 || ^7.1 || ^8.0",
+                "symfony/dom-crawler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/error-handler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+                "symfony/form": "^6.4 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+                "symfony/intl": "^6.4 || ^7.0 || ^8.0",
+                "symfony/json-streamer": "^7.4 || ^8.0",
+                "symfony/maker-bundle": "^1.24",
+                "symfony/mcp-bundle": "dev-main",
+                "symfony/mercure-bundle": "*",
+                "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+                "symfony/object-mapper": "^7.4 || ^8.0",
+                "symfony/routing": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-core": "^6.4 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+                "symfony/string": "^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/uid": "^6.4 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^7.4 || ^8.0",
+                "symfony/web-profiler-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
+                "twig/twig": "^1.42.3 || ^2.12 || ^3.0",
+                "webonyx/graphql-php": "^15.0"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",
+                "elasticsearch/elasticsearch": "To support Elasticsearch.",
+                "opensearch-project/opensearch-php": "To support OpenSearch (^2.5).",
+                "phpstan/phpdoc-parser": "To support extracting metadata from PHPDoc.",
+                "psr/cache-implementation": "To use metadata caching.",
+                "ramsey/uuid": "To support Ramsey's UUID identifiers.",
+                "symfony/cache": "To have metadata caching when using Symfony integration.",
+                "symfony/config": "To load XML configuration files.",
+                "symfony/expression-language": "To use authorization features.",
+                "symfony/http-client": "To use the HTTP cache invalidation system.",
+                "symfony/json-streamer": "To use the JSON Streamer component.",
+                "symfony/messenger": "To support messenger integration.",
+                "symfony/security": "To use authorization features.",
+                "symfony/twig-bundle": "To use the Swagger UI integration.",
+                "symfony/uid": "To support Symfony UUID/ULID identifiers.",
+                "symfony/web-profiler-bundle": "To use the data collector.",
+                "webonyx/graphql-php": "To support GraphQL."
+            },
+            "type": "library",
+            "extra": {
+                "pmu": {
+                    "projects": [
+                        "./src/*/composer.json",
+                        "src/Doctrine/*/composer.json"
+                    ]
+                },
+                "thanks": {
+                    "url": "https://github.com/api-platform/api-platform",
+                    "name": "api-platform/api-platform"
+                },
+                "symfony": {
+                    "require": "^6.4 || ^7.1 || ^8.0"
+                },
+                "branch-alias": {
+                    "dev-3.4": "3.4.x-dev",
+                    "dev-4.1": "4.1.x-dev",
+                    "dev-4.2": "4.2.x-dev",
+                    "dev-main": "4.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JsonLd/HydraContext.php"
+                ],
+                "psr-4": {
+                    "ApiPlatform\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "kevin@dunglas.fr",
+                    "homepage": "https://dunglas.fr"
+                }
+            ],
+            "description": "Build a fully-featured hypermedia or GraphQL API in minutes!",
+            "homepage": "https://api-platform.com",
+            "keywords": [
+                "Hydra",
+                "JSON-LD",
+                "api",
+                "graphql",
+                "hal",
+                "jsonapi",
+                "laravel",
+                "openapi",
+                "rest",
+                "swagger",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/api-platform/core/issues",
+                "source": "https://github.com/api-platform/core/tree/v4.3.3"
+            },
+            "time": "2026-03-29T10:10:54+00:00"
+        },
         {
             "name": "behat/behat",
             "version": "v3.29.0",
@@ -6275,6 +6499,62 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
+            "name": "psr/link",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link.git",
+                "reference": "84b159194ecfd7eaa472280213976e96415433f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link/zipball/84b159194ecfd7eaa472280213976e96415433f7",
+                "reference": "84b159194ecfd7eaa472280213976e96415433f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "suggest": {
+                "fig/link-util": "Provides some useful PSR-13 utilities"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for HTTP links",
+            "homepage": "https://github.com/php-fig/link",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/link/tree/2.0.1"
+            },
+            "time": "2021-03-11T23:00:27+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -11093,6 +11373,103 @@
             "time": "2026-01-23T11:07:10+00:00"
         },
         {
+            "name": "symfony/serializer",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "0e3169be25dbf0c23686c8089662cee9dd714932"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/0e3169be25dbf0c23686c8089662cee9dd714932",
+                "reference": "0e3169be25dbf0c23686c8089662cee9dd714932",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/property-info": "<7.4",
+                "symfony/type-info": "<7.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-31T07:15:36+00:00"
+        },
+        {
             "name": "symfony/stimulus-bundle",
             "version": "v2.34.0",
             "source": {
@@ -11968,6 +12345,90 @@
             "time": "2025-11-05T18:53:00+00:00"
         },
         {
+            "name": "symfony/web-link",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-link.git",
+                "reference": "f76065fd8d59284332c8beaf2d7e1449f8c532c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-link/zipball/f76065fd8d59284332c8beaf2d7e1449f8c532c3",
+                "reference": "f76065fd8d59284332c8beaf2d7e1449f8c532c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/link": "^1.1|^2.0"
+            },
+            "provide": {
+                "psr/link-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\WebLink\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Manages links between resources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dns-prefetch",
+                "http",
+                "http2",
+                "link",
+                "performance",
+                "prefetch",
+                "preload",
+                "prerender",
+                "psr13",
+                "push"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/web-link/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v7.4.6",
             "source": {
@@ -12434,6 +12895,62 @@
                 "source": "https://github.com/webmozarts/glob/tree/4.7.0"
             },
             "time": "2024-03-07T20:33:40+00:00"
+        },
+        {
+            "name": "willdurand/negotiation",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/Negotiation.git",
+                "reference": "68e9ea0553ef6e2ee8db5c1d98829f111e623ec2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/Negotiation/zipball/68e9ea0553ef6e2ee8db5c1d98829f111e623ec2",
+                "reference": "68e9ea0553ef6e2ee8db5c1d98829f111e623ec2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Negotiation\\": "src/Negotiation"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "will+git@drnd.me"
+                }
+            ],
+            "description": "Content Negotiation tools for PHP provided as a standalone library.",
+            "homepage": "http://williamdurand.fr/Negotiation/",
+            "keywords": [
+                "accept",
+                "content",
+                "format",
+                "header",
+                "negotiation"
+            ],
+            "support": {
+                "issues": "https://github.com/willdurand/Negotiation/issues",
+                "source": "https://github.com/willdurand/Negotiation/tree/3.1.0"
+            },
+            "time": "2022-01-30T20:08:53+00:00"
         }
     ],
     "aliases": [],

--- a/rules.neon
+++ b/rules.neon
@@ -92,6 +92,13 @@ services:
             containerXmlPaths: %shipmonkDeadCode.usageProviders.symfony.containerXmlPaths%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\ApiPlatformUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.apiPlatform.enabled%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\TemplateViewDataTraverser
         arguments:
             analysedPaths: %analysedPaths%
@@ -274,6 +281,8 @@ parameters:
                 enabled: null
                 configDir: null
                 containerXmlPaths: []
+            apiPlatform:
+                enabled: null
             twig:
                 enabled: null
             doctrine:
@@ -360,6 +369,9 @@ parametersSchema:
                 enabled: schema(bool(), nullable())
                 configDir: schema(string(), nullable())
                 containerXmlPaths: listOf(string())
+            ])
+            apiPlatform: structure([
+                enabled: schema(bool(), nullable())
             ])
             twig: structure([
                 enabled: schema(bool(), nullable())

--- a/src/Provider/ApiPlatformUsageProvider.php
+++ b/src/Provider/ApiPlatformUsageProvider.php
@@ -1,0 +1,355 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use Composer\InstalledVersions;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
+use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use ReflectionAttribute;
+use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function explode;
+use function is_string;
+use function str_contains;
+use function str_starts_with;
+use function strlen;
+
+final class ApiPlatformUsageProvider implements MemberUsageProvider
+{
+
+    private const RESOURCE_ATTRIBUTE = 'ApiPlatform\Metadata\ApiResource';
+
+    private const HTTP_OPERATION_ATTRIBUTE = 'ApiPlatform\Metadata\HttpOperation';
+
+    private const GRAPHQL_OPERATION_ATTRIBUTE = 'ApiPlatform\Metadata\GraphQl\Operation';
+
+    private const API_FILTER_ATTRIBUTE = 'ApiPlatform\Metadata\ApiFilter';
+
+    private readonly ReflectionProvider $reflectionProvider;
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        ?bool $enabled,
+    )
+    {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->enabled = $enabled ?? $this->isApiPlatformInstalled();
+    }
+
+    public function getUsages(
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$this->enabled) {
+            return [];
+        }
+
+        if (!$node instanceof InClassNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
+            return [];
+        }
+
+        $classReflection = $node->getClassReflection();
+        $nativeReflection = $classReflection->getNativeReflection();
+
+        $usages = [];
+
+        if ($this->isApiResource($nativeReflection)) {
+            $usages = [
+                ...$usages,
+                ...$this->emitResourceMemberUsages($classReflection),
+                ...$this->emitOperationTargetUsages($nativeReflection),
+            ];
+        }
+
+        $usages = [
+            ...$usages,
+            ...$this->emitApiFilterUsages($nativeReflection),
+        ];
+
+        return $usages;
+    }
+
+    /**
+     * @param ReflectionClass|ReflectionEnum $class
+     */
+    private function isApiResource(object $class): bool
+    {
+        if ($this->hasAttribute($class, self::RESOURCE_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF)) {
+            return true;
+        }
+
+        if ($this->hasAttribute($class, self::HTTP_OPERATION_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF)) {
+            return true;
+        }
+
+        return $this->hasAttribute($class, self::GRAPHQL_OPERATION_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF);
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function emitResourceMemberUsages(ClassReflection $classReflection): array
+    {
+        $nativeReflection = $classReflection->getNativeReflection();
+        $usages = [];
+        $note = 'API Platform resource — serialized/deserialized by framework';
+
+        if ($classReflection->hasNativeMethod('__construct')) {
+            $constructorDeclaringClass = $classReflection->getNativeMethod('__construct')->getDeclaringClass()->getName();
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+                new ClassMethodRef($constructorDeclaringClass, '__construct', possibleDescendant: false),
+            );
+        }
+
+        foreach ($nativeReflection->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($property->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
+                continue;
+            }
+
+            $usages[] = $this->createPropertyUsage($property, $note, AccessType::READ);
+            $usages[] = $this->createPropertyUsage($property, $note, AccessType::WRITE);
+        }
+
+        foreach ($nativeReflection->getMethods() as $method) {
+            if ($method->isStatic() || !$method->isPublic()) {
+                continue;
+            }
+
+            if ($method->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
+                continue;
+            }
+
+            if (!$this->isPropertyAccessorMethod($method->getName())) {
+                continue;
+            }
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+                new ClassMethodRef($nativeReflection->getName(), $method->getName(), possibleDescendant: false),
+            );
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @param ReflectionClass|ReflectionEnum $class
+     * @return list<ClassMemberUsage>
+     */
+    private function emitOperationTargetUsages(object $class): array
+    {
+        $usages = [];
+
+        $attributes = [
+            ...$class->getAttributes(self::RESOURCE_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF),
+            ...$class->getAttributes(self::HTTP_OPERATION_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF),
+            ...$class->getAttributes(self::GRAPHQL_OPERATION_ATTRIBUTE, ReflectionAttribute::IS_INSTANCEOF),
+        ];
+
+        foreach ($attributes as $attribute) {
+            $arguments = $attribute->getArguments();
+            $attributeName = $attribute->getName();
+
+            $provider = $arguments['provider'] ?? null;
+
+            if (is_string($provider)) {
+                foreach ($this->resolveTargetUsages($provider, 'provide', "Referenced as provider in #[$attributeName]") as $usage) {
+                    $usages[] = $usage;
+                }
+            }
+
+            $processor = $arguments['processor'] ?? null;
+
+            if (is_string($processor)) {
+                foreach ($this->resolveTargetUsages($processor, 'process', "Referenced as processor in #[$attributeName]") as $usage) {
+                    $usages[] = $usage;
+                }
+            }
+
+            $controller = $arguments['controller'] ?? null;
+
+            if (is_string($controller)) {
+                foreach ($this->resolveTargetUsages($controller, '__invoke', "Referenced as controller in #[$attributeName]") as $usage) {
+                    $usages[] = $usage;
+                }
+            }
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @param ReflectionClass|ReflectionEnum $class
+     * @return list<ClassMemberUsage>
+     */
+    private function emitApiFilterUsages(object $class): array
+    {
+        $usages = [];
+
+        $attributes = [...$class->getAttributes(self::API_FILTER_ATTRIBUTE)];
+
+        foreach ($class->getProperties() as $property) {
+            foreach ($property->getAttributes(self::API_FILTER_ATTRIBUTE) as $propertyAttribute) {
+                $attributes[] = $propertyAttribute;
+            }
+        }
+
+        foreach ($attributes as $attribute) {
+            $arguments = $attribute->getArguments();
+            $filterClass = $arguments['filterClass'] ?? $arguments[0] ?? null;
+
+            if (!is_string($filterClass) || !$this->reflectionProvider->hasClass($filterClass)) {
+                continue;
+            }
+
+            $filterReflection = $this->reflectionProvider->getClass($filterClass);
+
+            if (!$filterReflection->hasNativeMethod('__construct')) {
+                continue;
+            }
+
+            $constructorDeclaringClass = $filterReflection->getNativeMethod('__construct')->getDeclaringClass()->getName();
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote('API Platform filter (instantiated by DIC via #[ApiFilter])')),
+                new ClassMethodRef($constructorDeclaringClass, '__construct', possibleDescendant: false),
+            );
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function resolveTargetUsages(
+        string $target,
+        string $defaultMethod,
+        string $note,
+    ): array
+    {
+        $className = $target;
+        $methodName = $defaultMethod;
+
+        if (str_contains($target, '::')) {
+            [$className, $methodName] = explode('::', $target, 2); // @phpstan-ignore offsetAccess.notFound
+        }
+
+        if ($className === '' || !$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        if (!$classReflection->hasNativeMethod($methodName)) {
+            return [];
+        }
+
+        $usages = [
+            new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+                new ClassMethodRef($className, $methodName, possibleDescendant: true),
+            ),
+        ];
+
+        if ($classReflection->hasNativeMethod('__construct')) {
+            $constructorDeclaringClass = $classReflection->getNativeMethod('__construct')->getDeclaringClass()->getName();
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+                new ClassMethodRef($constructorDeclaringClass, '__construct', possibleDescendant: false),
+            );
+        }
+
+        return $usages;
+    }
+
+    private function createPropertyUsage(
+        ReflectionProperty $property,
+        string $note,
+        AccessType $accessType,
+    ): ClassPropertyUsage
+    {
+        return new ClassPropertyUsage(
+            UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+            new ClassPropertyRef(
+                $property->getDeclaringClass()->getName(),
+                $property->getName(),
+                possibleDescendant: false,
+            ),
+            $accessType,
+        );
+    }
+
+    private function isPropertyAccessorMethod(string $methodName): bool
+    {
+        foreach (['get', 'set', 'is', 'has', 'can', 'add', 'remove'] as $prefix) {
+            if (
+                str_starts_with($methodName, $prefix)
+                && isset($methodName[strlen($prefix)])
+                && $methodName[strlen($prefix)] >= 'A'
+                && $methodName[strlen($prefix)] <= 'Z'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass|ReflectionEnum|ReflectionMethod|ReflectionProperty $reflector
+     * @param ReflectionAttribute::IS_*|0 $flags
+     */
+    private function hasAttribute(
+        object $reflector,
+        string $attributeClass,
+        int $flags = 0,
+    ): bool
+    {
+        if ($reflector->getAttributes($attributeClass) !== []) {
+            return true;
+        }
+
+        if ($flags === 0) {
+            return false;
+        }
+
+        try {
+            /** @throws IdentifierNotFound */
+            return $reflector->getAttributes($attributeClass, $flags) !== [];
+        } catch (IdentifierNotFound $e) {
+            return false;
+        }
+    }
+
+    private function isApiPlatformInstalled(): bool
+    {
+        return InstalledVersions::isInstalled('api-platform/core')
+            || InstalledVersions::isInstalled('api-platform/metadata')
+            || InstalledVersions::isInstalled('api-platform/state')
+            || InstalledVersions::isInstalled('api-platform/symfony');
+    }
+
+}

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -46,6 +46,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Hierarchy\ClassHierarchy;
 use ShipMonk\PHPStan\DeadCode\Output\OutputEnhancer;
 use ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\ApiPlatformUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BehatUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BladeUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BuiltinUsageProvider;
@@ -1001,6 +1002,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-nette' => [__DIR__ . '/data/providers/nette.php'];
         yield 'provider-nette-tester' => [__DIR__ . '/data/providers/nette-tester.php'];
         yield 'provider-apiphpdoc' => [__DIR__ . '/data/providers/api-phpdoc.php'];
+        yield 'provider-api-platform' => [__DIR__ . '/data/providers/api-platform.php', self::requiresPackage('api-platform/core', '>= 3.0')];
         yield 'provider-enum' => [__DIR__ . '/data/providers/enum.php'];
         yield 'provider-enum-hooks' => [__DIR__ . '/data/providers/enum-hooks.php'];
         yield 'provider-builtin' => [__DIR__ . '/data/providers/builtin.php'];
@@ -1241,6 +1243,10 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 self::createReflectionProvider(),
                 $this->providersEnabled,
                 [__DIR__],
+            ),
+            new ApiPlatformUsageProvider(
+                self::getContainer()->getByType(ReflectionProvider::class),
+                $this->providersEnabled,
             ),
             new EnumUsageProvider(
                 $this->providersEnabled,

--- a/tests/Rule/data/providers/api-platform.php
+++ b/tests/Rule/data/providers/api-platform.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace ApiPlatformApp;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\FilterInterface;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\State\ProviderInterface;
+
+// Case 1: plain #[ApiResource] — properties are deserialized/serialized, ctor is invoked
+
+#[ApiResource]
+class Book
+{
+
+    public function __construct(
+        public string $title,
+    )
+    {
+    }
+
+    public int $pages;
+
+    private string $description;
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    public function deadHelper(): void // error: Unused ApiPlatformApp\Book::deadHelper
+    {
+    }
+
+}
+
+// Case 2: only operation attribute (no #[ApiResource]) still marks the class as resource
+
+#[Get]
+#[GetCollection]
+class Author
+{
+
+    public string $name;
+
+    private int $age;
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+
+    public function setAge(int $age): void
+    {
+        $this->age = $age;
+    }
+
+    public function privateDead(): void // error: Unused ApiPlatformApp\Author::privateDead
+    {
+    }
+
+}
+
+// Case 3: provider/processor/controller class-string references
+
+class BookProvider implements ProviderInterface
+{
+
+    public function __construct(private string $dsn)
+    {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        return $this->dsn === '' ? null : [];
+    }
+
+}
+
+class BookProcessor implements ProcessorInterface
+{
+
+    public function __construct(private string $bus)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        echo $this->bus;
+    }
+
+}
+
+class BookController
+{
+
+    public function __construct(private string $logger)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        echo $this->logger;
+    }
+
+}
+
+#[Get(provider: BookProvider::class, processor: BookProcessor::class, controller: BookController::class)]
+#[Post(processor: BookProcessor::class)]
+#[Delete(provider: 'ApiPlatformApp\BookProvider::provide')]
+class Review
+{
+
+    public int $rating;
+
+    public function getRating(): int
+    {
+        return $this->rating;
+    }
+
+}
+
+// Case 4: GraphQL operation marks class as resource too
+
+#[Query]
+class Tag
+{
+
+    public string $label;
+
+    public function dead(): void // error: Unused ApiPlatformApp\Tag::dead
+    {
+    }
+
+}
+
+// Case 5: ApiFilter references a filter class — its ctor is invoked by DIC
+
+class MyFilter implements FilterInterface
+{
+
+    public function __construct()
+    {
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [];
+    }
+
+}
+
+#[ApiResource]
+#[ApiFilter(MyFilter::class)]
+class Article
+{
+
+    public string $title;
+
+    #[ApiFilter(MyFilter::class)]
+    public string $slug;
+
+}
+
+// Case 6: a plain class without any API Platform attribute still reports dead members
+
+class NotAResource
+{
+
+    public string $neverUsedProp; // error: Property ApiPlatformApp\NotAResource::$neverUsedProp is never read // error: Property ApiPlatformApp\NotAResource::$neverUsedProp is never written
+
+    public function neverUsed(): void // error: Unused ApiPlatformApp\NotAResource::neverUsed
+    {
+    }
+
+}


### PR DESCRIPTION
## Summary
- New `ApiPlatformUsageProvider` marks `__construct`, non-static properties (READ+WRITE) and PropertyAccessor-style methods as used on classes carrying `#[ApiResource]` or any HTTP/GraphQL operation attribute — because API Platform instantiates and (de)serializes them at runtime
- Resolves `provider:`/`processor:`/`controller:` class-string references in operation attributes (including `Class::method` callable syntax) and filter classes referenced via `#[ApiFilter]` (class- and property-level)
- Auto-enabled when `api-platform/core`, `api-platform/metadata`, `api-platform/state`, or `api-platform/symfony` is installed; opt-in/opt-out via `shipmonkDeadCode.usageProviders.apiPlatform.enabled`

Resolves #344.

### Scope notes
Phase 1 — only flat-style operation attributes on the class (e.g. `#[Get(provider: X::class)]`) are scanned. The nested form `#[ApiResource(operations: [new Get(provider: X::class)])]` is not yet covered and can be added in a follow-up.

Co-Authored-By: Claude Code