### PR TITLE
Enable exceptions LSP check

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,6 +28,7 @@ parameters:
         check:
             missingCheckedExceptionInThrows: true
             tooWideThrowType: true
+            throwTypeCovariance: true
         implicitThrows: false
         uncheckedExceptionClasses:
             - LogicException


### PR DESCRIPTION
Enables PHPStan's `exceptions.check.throwTypeCovariance` check. No new errors surfaced in the codebase.