### PR TITLE
Symfony: skip services not instantiated by the DIC

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -1143,6 +1143,11 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         foreach ($xml->services->service as $serviceDefinition) {
             /** @var SimpleXMLElement $serviceAttributes */
             $serviceAttributes = $serviceDefinition->attributes();
+
+            if ($this->isServiceNotInstantiatedByContainer($serviceDefinition, $serviceAttributes)) {
+                continue;
+            }
+
             $class = isset($serviceAttributes->class) ? (string) $serviceAttributes->class : null;
             $constructor = isset($serviceAttributes->constructor) ? (string) $serviceAttributes->constructor : '__construct';
 
@@ -1189,6 +1194,32 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 }
             }
         }
+    }
+
+    private function isServiceNotInstantiatedByContainer(
+        SimpleXMLElement $serviceDefinition,
+        SimpleXMLElement $serviceAttributes,
+    ): bool
+    {
+        if (isset($serviceAttributes->abstract) && (string) $serviceAttributes->abstract === 'true') {
+            return true;
+        }
+
+        if (isset($serviceAttributes->synthetic) && (string) $serviceAttributes->synthetic === 'true') {
+            return true;
+        }
+
+        foreach ($serviceDefinition->tag ?? [] as $tagDefinition) {
+            /** @var SimpleXMLElement $tagAttributes */
+            $tagAttributes = $tagDefinition->attributes();
+            $tagName = $tagAttributes->name !== null ? (string) $tagAttributes->name : null;
+
+            if ($tagName === 'container.error' || $tagName === 'container.excluded') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Provider/SymfonyUsageProviderTest.php
+++ b/tests/Provider/SymfonyUsageProviderTest.php
@@ -50,6 +50,11 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
         self::assertArrayHasKey('Symfony\DicClass1', $dicCalls);
         self::assertArrayHasKey('__construct', $dicCalls['Symfony\DicClass1']);
         self::assertArrayHasKey('calledViaDic', $dicCalls['Symfony\DicClass1']);
+
+        self::assertArrayNotHasKey('Symfony\DicErroredService', $dicCalls);
+        self::assertArrayNotHasKey('Symfony\DicExcludedService', $dicCalls);
+        self::assertArrayNotHasKey('Symfony\DicSyntheticService', $dicCalls);
+        self::assertArrayNotHasKey('Symfony\DicAbstractService', $dicCalls);
     }
 
     public function testExplicitContainerXmlPathsTakesPrecedenceOverContainer(): void

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -160,6 +160,22 @@ class DicClass4 {
     public function __construct() {}
 }
 
+class DicErroredService {
+    public function __construct(string $name) {} // error: Unused Symfony\DicErroredService::__construct
+}
+
+class DicExcludedService {
+    public function __construct() {} // error: Unused Symfony\DicExcludedService::__construct
+}
+
+class DicSyntheticService {
+    public function __construct() {} // error: Unused Symfony\DicSyntheticService::__construct
+}
+
+class DicAbstractService {
+    public function __construct() {} // error: Unused Symfony\DicAbstractService::__construct
+}
+
 class Sftp {
     const RETRY_LIMIT = 3; // used in yaml via !php/const
 }

--- a/tests/Rule/data/providers/symfony/services.xml
+++ b/tests/Rule/data/providers/symfony/services.xml
@@ -24,5 +24,13 @@
         <service id="Symfony\TaggedServiceB" class="Symfony\TaggedServiceB" public="true" autowire="true" autoconfigure="true">
             <tag name="app.tagged_handler"/>
         </service>
+        <service id="Symfony\DicErroredService" class="Symfony\DicErroredService" autowire="true" autoconfigure="true">
+            <tag name="container.error" message="Cannot autowire service &quot;Symfony\DicErroredService&quot;: argument &quot;$name&quot; of method &quot;__construct()&quot; is type-hinted &quot;string&quot;, you should configure its value explicitly."/>
+        </service>
+        <service id="Symfony\DicExcludedService" class="Symfony\DicExcludedService" abstract="true">
+            <tag name="container.excluded" source="because it's a Doctrine entity"/>
+        </service>
+        <service id="Symfony\DicSyntheticService" class="Symfony\DicSyntheticService" synthetic="true" public="true"/>
+        <service id="Symfony\DicAbstractService" class="Symfony\DicAbstractService" abstract="true"/>
     </services>
 </container>


### PR DESCRIPTION
## Summary

- Services tagged `container.error` or `container.excluded`, or marked `abstract="true"` / `synthetic="true"` in the dumped container XML are never constructed by the container. Skip them in `SymfonyUsageProvider::fillDicClasses()` so their constructors, `<call>` methods, `<factory>` methods, and tag memberships are not registered as DIC usage.
- Verified against `vendor/symfony/dependency-injection`:
  - `ContainerBuilder::doGet()` throws `RuntimeException` before `createService()` when `hasErrors()` is true (container.error) or `isSynthetic()` is true.
  - `FileLoader::addContainerExcludedTag()` marks `container.excluded` services abstract → `findDefinition`/autowiring excludes them; `AutowirePass.php:493` confirms.
  - Abstract definitions cannot be instantiated; by the time the XML is dumped `ResolveChildDefinitionsPass` has already resolved ChildDefinitions into concrete entries.
- **Not skipped:** `deprecated` (still instantiated, just emits notice), `lazy` (still instantiated via proxy), `public="false"` (private services still instantiated when referenced).

Co-Authored-By: Claude Code