### PR TITLE
Blade: skip view data members declared in vendor

### DIFF
--- a/src/Provider/TemplateViewDataTraverser.php
+++ b/src/Provider/TemplateViewDataTraverser.php
@@ -121,6 +121,13 @@ final class TemplateViewDataTraverser
                 continue;
             }
 
+            // Skip methods declared outside analysed paths (vendor base classes/traits)
+            $declaringFile = $method->getDeclaringClass()->getFileName();
+
+            if (!$this->isFileAnalysed($declaringFile === false ? null : $declaringFile)) {
+                continue;
+            }
+
             // Mark method as used
             $usages[] = new ClassMethodUsage(
                 UsageOrigin::createVirtual($provider, VirtualUsageData::withNote($context)),
@@ -152,6 +159,13 @@ final class TemplateViewDataTraverser
                 continue;
             }
 
+            // Skip properties declared outside analysed paths (vendor base classes/traits)
+            $declaringFile = $property->getDeclaringClass()->getFileName();
+
+            if (!$this->isFileAnalysed($declaringFile === false ? null : $declaringFile)) {
+                continue;
+            }
+
             $usages[] = new ClassPropertyUsage(
                 UsageOrigin::createVirtual($provider, VirtualUsageData::withNote($context)),
                 new ClassPropertyRef($className, $property->getName(), possibleDescendant: false),
@@ -179,19 +193,22 @@ final class TemplateViewDataTraverser
 
     private function shouldSkipClass(ClassReflection $classReflection): bool
     {
-        $fileName = $classReflection->getFileName();
+        return !$this->isFileAnalysed($classReflection->getFileName());
+    }
 
+    private function isFileAnalysed(?string $fileName): bool
+    {
         if ($fileName === null) {
-            return true;
+            return false;
         }
 
         foreach ($this->analysedPaths as $path) {
             if (str_starts_with($fileName, $path)) {
-                return false; // do not traverse non-analyzed classes (e.g. vendor)
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
 }


### PR DESCRIPTION
## Summary

The Blade view data traverser walked all public methods/properties of every class passed to views, including those inherited from vendor base classes and traits — e.g. Eloquent's `Model` plus its many traits emit ~200+ inherited methods on every concrete model. Combined with the per-call retraversal of the model graph, projects with many `view()` calls passing models could see millions of emitted usages — enough to OOM during the unpack loop in `DeadCodeRule` (#349).

This change filters out methods/properties whose declaring class lives outside `analysedPaths`, matching the filter `EloquentUsageProvider::getMethodUsagesFromReflection` already applies. User-land parent classes and traits are still covered because `getMethods()`/`getProperties()` returns inherited members and the file-of-declaring-class check naturally keeps user-land ones.

Refs #349. 