### PR TITLE
Compatibility fixes for PHPStan 2.1.52

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.46",
+            "version": "2.1.52",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
-                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/08a34f8db7ca4daabff74a474fe13c0e56e2b4e5",
+                "reference": "08a34f8db7ca4daabff74a474fe13c0e56e2b4e5",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-01T09:25:14+00:00"
+            "time": "2026-04-28T12:17:53+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/Cache/UsageCacheStorageTest.php
+++ b/tests/Cache/UsageCacheStorageTest.php
@@ -79,6 +79,7 @@ final class UsageCacheStorageTest extends TestCase
             }
         }
 
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (https://github.com/phpstan/phpstan/issues/14543)
         self::assertCount(2, $restored);
         self::assertEquals($usages[0], $restored[0]);
         self::assertEquals($usages[1], $restored[1]);

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1366,10 +1366,9 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         foreach ($errors as $error) {
             $result[] = $error;
 
+            /** @var list<array{blackMember: BlackMember, transitive: bool}> $metadata */
             $metadata = $error->getMetadata();
 
-            /** @var BlackMember $blackMember */
-            /** @var bool $transitive */
             foreach ($metadata as ['blackMember' => $blackMember, 'transitive' => $transitive]) {
                 if (!$transitive) {
                     continue;


### PR DESCRIPTION
## Summary

Two errors surface on PHPStan 2.1.52 (CI uses `composer update`, so any new PR pulls the latest):

- `tests/Cache/UsageCacheStorageTest.php:82` — `staticMethod.alreadyNarrowedType` on `assertCount(2, $restored)`. The narrowing is a regression in 2.1.52: nested `foreach` over a `non-empty-list<T>` collapses to an exact-count tuple instead of `non-empty-list<T>`. Bisected to 2.1.51 → 2.1.52. Reported upstream: phpstan/phpstan#14543. Suppressed locally with `@phpstan-ignore` referencing the issue.
- `tests/Rule/DeadCodeRuleTest.php:1373` — `offsetAccess.nonArray` for destructuring `$error->getMetadata()`. The previous floating `/** @var BlackMember */` / `/** @var bool */` tags don't help with destructuring; replaced with a `@var` on `$metadata` declaring the shape the rule actually emits.

Lockfile bumped to 2.1.52 to match what CI runs.