### PR TITLE
Blade: deduplicate view-data usages across call sites

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -24,6 +24,8 @@ services:
 
     -
         class: ShipMonk\PHPStan\DeadCode\Debug\DebugUsagePrinter
+        arguments:
+            bladeOptions: %shipmonkDeadCode.usageProviders.blade%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider
@@ -285,7 +287,7 @@ parameters:
                 enabled: null
             blade:
                 enabled: null
-                deduplicateAcrossViews: false
+                deduplicateAcrossViews: true
             nette:
                 enabled: null
             netteTester:

--- a/rules.neon
+++ b/rules.neon
@@ -137,6 +137,7 @@ services:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.blade.enabled%
+            deduplicateAcrossViews: %shipmonkDeadCode.usageProviders.blade.deduplicateAcrossViews%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\NetteUsageProvider
@@ -284,6 +285,7 @@ parameters:
                 enabled: null
             blade:
                 enabled: null
+                deduplicateAcrossViews: false
             nette:
                 enabled: null
             netteTester:
@@ -375,6 +377,7 @@ parametersSchema:
             ])
             blade: structure([
                 enabled: schema(bool(), nullable())
+                deduplicateAcrossViews: bool()
             ])
             nette: structure([
                 enabled: schema(bool(), nullable())

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\DeadCode\Debug;
 
+use Composer\InstalledVersions;
 use LogicException;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\Container;
@@ -40,6 +41,8 @@ final class DebugUsagePrinter
 
     private readonly ReflectionProvider $reflectionProvider;
 
+    private readonly bool $bladeDedupActive;
+
     /**
      * memberKey => usage info
      *
@@ -47,10 +50,14 @@ final class DebugUsagePrinter
      */
     private array $debugMembers;
 
+    /**
+     * @param array{enabled: bool|null, deduplicateAcrossViews: bool} $bladeOptions
+     */
     public function __construct(
         Container $container,
         OutputEnhancer $outputEnhancer,
         ReflectionProvider $reflectionProvider,
+        array $bladeOptions,
     )
     {
         $this->outputEnhancer = $outputEnhancer;
@@ -59,6 +66,8 @@ final class DebugUsagePrinter
             // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible, missingType.checkedException, argument.type
             $container->getParameter('shipmonkDeadCode')['debug']['usagesOf'], // prevents https://github.com/phpstan/phpstan/issues/12740
         );
+        $bladeEnabled = $bladeOptions['enabled'] ?? InstalledVersions::isInstalled('laravel/framework');
+        $this->bladeDedupActive = $bladeEnabled && $bladeOptions['deduplicateAcrossViews'];
     }
 
     /**
@@ -222,6 +231,14 @@ final class DebugUsagePrinter
     {
         if ($this->debugMembers === [] || !$output->isDebug()) {
             return;
+        }
+
+        if ($this->bladeDedupActive) {
+            $output->writeLineFormatted('');
+            $output->writeLineFormatted('<fg=yellow>Warning: Blade view-data usages are deduplicated across call sites</>');
+            $output->writeLineFormatted('<fg=yellow>The report below may show fewer usages than actually exist — only the first encountered call site per class is recorded for Blade views.</>');
+            $output->writeLineFormatted('<fg=yellow>To see all usages, opt out by setting deduplicateAcrossViews: false.</>');
+            $output->writeLineFormatted('<fg=yellow>Opt-out may significantly increase RAM usage, see https://github.com/shipmonk-rnd/dead-code-detector/issues/349</>');
         }
 
         $output->writeLineFormatted("\n<fg=red>Usage debugging information:</>");

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -36,15 +36,19 @@ final class BladeUsageProvider implements MemberUsageProvider
 
     private readonly bool $enabled;
 
+    private readonly bool $deduplicateAcrossViews;
+
     public function __construct(
         ReflectionProvider $reflectionProvider,
         TemplateViewDataTraverser $traverser,
         ?bool $enabled,
+        bool $deduplicateAcrossViews,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->traverser = $traverser;
         $this->enabled = $enabled ?? InstalledVersions::isInstalled('laravel/framework');
+        $this->deduplicateAcrossViews = $deduplicateAcrossViews;
     }
 
     public function getUsages(
@@ -300,7 +304,7 @@ final class BladeUsageProvider implements MemberUsageProvider
         $referencedClassNames = $scope->getType($dataExpr)->getReferencedClasses();
         $rootContext = $this->getRootContext($node, $scope);
 
-        return $this->traverser->getUsages($referencedClassNames, $rootContext, $this);
+        return $this->traverser->getUsages($referencedClassNames, $rootContext, $this, $this->deduplicateAcrossViews);
     }
 
     /**

--- a/src/Provider/TemplateViewDataTraverser.php
+++ b/src/Provider/TemplateViewDataTraverser.php
@@ -24,6 +24,13 @@ final class TemplateViewDataTraverser
     private readonly array $analysedPaths;
 
     /**
+     * Classes whose members have already been emitted at least once in deduplication mode.
+     *
+     * @var array<string, true>
+     */
+    private array $seenClasses = [];
+
+    /**
      * @param list<string> $analysedPaths
      */
     public function __construct(
@@ -39,6 +46,9 @@ final class TemplateViewDataTraverser
      * Traverses referenced class names recursively, marking all public methods and properties as used.
      * Used by template engine providers (Twig, Blade) to handle data passed to views.
      *
+     * When $deduplicateAcrossViews is true, each class is emitted at most once across the whole analysis run
+     * (correct for dead-code detection but loses per-call-site diagnostic precision).
+     *
      * @param list<string> $referencedClassNames
      * @param non-empty-string $rootContext
      * @return list<ClassMemberUsage>
@@ -47,6 +57,7 @@ final class TemplateViewDataTraverser
         array $referencedClassNames,
         string $rootContext,
         MemberUsageProvider $provider,
+        bool $deduplicateAcrossViews = false,
     ): array
     {
         $usages = [];
@@ -55,7 +66,7 @@ final class TemplateViewDataTraverser
         foreach ($referencedClassNames as $className) {
             $usages = [
                 ...$usages,
-                ...$this->traverseClassNameRecursively($className, $visited, $rootContext, $provider),
+                ...$this->traverseClassNameRecursively($className, $visited, $rootContext, $provider, $deduplicateAcrossViews),
             ];
         }
 
@@ -72,6 +83,7 @@ final class TemplateViewDataTraverser
         array &$visited,
         string $context,
         MemberUsageProvider $provider,
+        bool $deduplicateAcrossViews,
     ): array
     {
         if (isset($visited[$className])) {
@@ -79,6 +91,10 @@ final class TemplateViewDataTraverser
         }
 
         $visited[$className] = true;
+
+        if ($deduplicateAcrossViews && isset($this->seenClasses[$className])) {
+            return [];
+        }
 
         if (!$this->reflectionProvider->hasClass($className)) {
             return [];
@@ -90,7 +106,11 @@ final class TemplateViewDataTraverser
             return [];
         }
 
-        return $this->getPublicMembersUsages($classReflection, $visited, $context, $provider);
+        if ($deduplicateAcrossViews) {
+            $this->seenClasses[$className] = true;
+        }
+
+        return $this->getPublicMembersUsages($classReflection, $visited, $context, $provider, $deduplicateAcrossViews);
     }
 
     /**
@@ -103,6 +123,7 @@ final class TemplateViewDataTraverser
         array &$visited,
         string $context,
         MemberUsageProvider $provider,
+        bool $deduplicateAcrossViews,
     ): array
     {
         $usages = [];
@@ -147,6 +168,7 @@ final class TemplateViewDataTraverser
                             $visited,
                             $newContext,
                             $provider,
+                            $deduplicateAcrossViews,
                         ),
                     ];
                 }
@@ -183,6 +205,7 @@ final class TemplateViewDataTraverser
                         $visited,
                         $newContext,
                         $provider,
+                        $deduplicateAcrossViews,
                     ),
                 ];
             }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -135,6 +135,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                     $container,
                     $this->createOutputEnhancer(),
                     self::createReflectionProvider(),
+                    ['enabled' => false, 'deduplicateAcrossViews' => false],
                 ),
                 $this->getUsageCacheStorage(),
                 new ClassHierarchy(),

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1214,6 +1214,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 self::createReflectionProvider(),
                 $templateViewDataTraverser,
                 $this->providersEnabled,
+                false,
             ),
             new NetteTesterUsageProvider(
                 $this->providersEnabled,


### PR DESCRIPTION
## Summary

- Adds `usageProviders.blade.deduplicateAcrossViews` flag, **enabled by default**.
- When enabled, each class reachable through Blade view data emits its member usages at most once across the whole analysis run, instead of once per `view()` call site. This collapses emitted usages from `O(call_sites × subtree_size)` down to `O(subtree_size)` and resolves the RAM/usage explosion reported in #349.
- Users can opt out by setting `deduplicateAcrossViews: false` if they prefer full per-call-site reporting and can afford the memory cost.
- When `debug.usagesOf` is used and the dedup is active, `DebugUsagePrinter` emits a warning explaining that the report may show fewer usages than actually exist, and pointing at the opt-out (with a RAM caveat referencing #349).

## Tradeoff

Default-on because Laravel codebases were OOM'ing without it. The cost: a dead view-bound method now reports only one example call site (whichever Blade visited first), rather than every site. Dead-code detection itself stays correct — a member with ≥1 emission is alive.

Twig is unaffected: the shared `TemplateViewDataTraverser` takes the flag per-call, and Twig's two call sites pass nothing (default `false`).