### PR TITLE
Bump phpstan to 2.1.54, drop fixed `staticMethod.alreadyNarrowedType` ignore

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.52",
+            "version": "2.1.54",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/08a34f8db7ca4daabff74a474fe13c0e56e2b4e5",
-                "reference": "08a34f8db7ca4daabff74a474fe13c0e56e2b4e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-28T12:17:53+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/Cache/UsageCacheStorageTest.php
+++ b/tests/Cache/UsageCacheStorageTest.php
@@ -79,7 +79,6 @@ final class UsageCacheStorageTest extends TestCase
             }
         }
 
-        // @phpstan-ignore staticMethod.alreadyNarrowedType (https://github.com/phpstan/phpstan/issues/14543)
         self::assertCount(2, $restored);
         self::assertEquals($usages[0], $restored[0]);
         self::assertEquals($usages[1], $restored[1]);


### PR DESCRIPTION
Upstream phpstan/phpstan#14543 was fixed in 2.1.53, so the workaround ignore in UsageCacheStorageTest is now reported as unmatched.