### PR TITLE
Symfony: mark constructor of #[AsEventListener] host class as used

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -772,6 +772,10 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return 'Event listener method via #[AsEventListener] attribute';
         }
 
+        if ($this->isConstructorOfAnEventListenerClass($method)) {
+            return 'Constructor of an event listener class (required by DIC to invoke the listener)';
+        }
+
         if ($this->isMessageHandlerMethodWithAsMessageHandlerAttribute($method)) {
             return 'Message handler method via #[AsMessageHandler] attribute';
         }
@@ -1284,6 +1288,27 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
         return $this->hasAttribute($class, 'Symfony\Component\EventDispatcher\Attribute\AsEventListener')
             || $this->hasAttribute($method, 'Symfony\Component\EventDispatcher\Attribute\AsEventListener');
+    }
+
+    private function isConstructorOfAnEventListenerClass(ReflectionMethod $method): bool
+    {
+        if (!$method->isConstructor()) {
+            return false;
+        }
+
+        $class = $method->getDeclaringClass();
+
+        if ($this->hasAttribute($class, 'Symfony\Component\EventDispatcher\Attribute\AsEventListener')) {
+            return true;
+        }
+
+        foreach ($class->getMethods() as $classMethod) {
+            if ($this->hasAttribute($classMethod, 'Symfony\Component\EventDispatcher\Attribute\AsEventListener')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isMessageHandlerMethodWithAsMessageHandlerAttribute(ReflectionMethod $method): bool

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -314,4 +315,20 @@ class WrappedImportCommand extends Command {
         echo $input->filters->tag;
         return 0;
     }
+}
+
+class EventListenerOnMethodNotInDic
+{
+    public function __construct() {} // ctor required to invoke the #[AsEventListener] method below
+
+    #[AsEventListener]
+    public function __invoke(object $event): void {}
+}
+
+#[AsEventListener]
+class EventListenerOnClassNotInDic
+{
+    public function __construct() {} // ctor required to invoke the listener
+
+    public function __invoke(object $event): void {}
 }

--- a/tests/Rule/data/providers/symfony/services.xml
+++ b/tests/Rule/data/providers/symfony/services.xml
@@ -32,5 +32,11 @@
         </service>
         <service id="Symfony\DicSyntheticService" class="Symfony\DicSyntheticService" synthetic="true" public="true"/>
         <service id="Symfony\DicAbstractService" class="Symfony\DicAbstractService" abstract="true"/>
+        <service id="Symfony\EventListenerOnMethodNotInDic" class="Symfony\EventListenerOnMethodNotInDic" abstract="true">
+            <tag name="container.excluded" source="conditionally registered (e.g. via #[When])"/>
+        </service>
+        <service id="Symfony\EventListenerOnClassNotInDic" class="Symfony\EventListenerOnClassNotInDic" abstract="true">
+            <tag name="container.excluded" source="conditionally registered (e.g. via #[When])"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
`shouldMarkAsUsed` already marks the listener method via the existing `isEventListenerMethodWithAsEventListenerAttribute` helper, but the host class's `__construct` gets no usage when the service is excluded from the dumped container XML (`#[AsEventListener]` paired with `#[When]`, `#[Exclude]`, etc.). At runtime Symfony cannot invoke `__invoke` without first constructing the object

Mirrors the existing `isConstructorWithAsCommandAttribute` and `isConstructorWithAsControllerAttribute` helpers; additionally scans sibling methods because `#[AsEventListener]` usually lives on the listener method rather than the class.