### PR TITLE
CI: drop coverage-guard removal from matrix jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,9 +51,7 @@ jobs:
                     ini-file: development
             -
                 name: Update dependencies
-                run: |
-                    composer remove --dev shipmonk/coverage-guard --no-update
-                    composer update --no-progress --prefer-dist --no-interaction
+                run: composer update --no-progress --prefer-dist --no-interaction
             -
                 name: Run dependency analyser
                 run: composer check:dependencies
@@ -76,9 +74,7 @@ jobs:
                     ini-file: development
             -
                 name: Update dependencies
-                run: |
-                    composer remove --dev shipmonk/coverage-guard --no-update
-                    composer update --no-progress --prefer-dist --no-interaction
+                run: composer update --no-progress --prefer-dist --no-interaction
             -
                 name: Run PHPStan
                 run: composer check:types
@@ -102,9 +98,7 @@ jobs:
                     ini-file: development
             -
                 name: Update dependencies
-                run: |
-                    composer remove --dev shipmonk/coverage-guard --no-update
-                    composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             -
                 name: Run tests
                 run: vendor/bin/phpunit --no-coverage


### PR DESCRIPTION
## Summary

The `composer remove --dev shipmonk/coverage-guard --no-update` step was introduced in #274 because `shipmonk/coverage-guard` requires PHP ^8.1, but at that time this project still supported PHP 7.4/8.0 and the CI matrix included PHP 7.4 (`cda`, `tests`) and 8.0 (`phpstan`). The workaround was needed to let composer resolve dependencies on those lower rows.

#296 dropped PHP 7.4/8.0 support; the matrix is now 8.1–8.5, all compatible with coverage-guard. The removal step is leftover and can go.

Draft so CI (especially `tests` with `--prefer-lowest`) can confirm nothing regresses.