### PR TITLE
Symfony: mark setClass target constructor as used

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -27,6 +27,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -170,6 +171,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $usages = [
                 ...$usages,
                 ...$this->getFormDataClassUsages($node, $scope),
+                ...$this->getDefinitionSetClassUsages($node, $scope),
             ];
         }
 
@@ -869,10 +871,58 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     }
 
     /**
-     * Detects data_class from OptionsResolver::setDefaults() and OptionsResolver::setDefault()
-     *
-     * @param array<int|string, Arg> $args
+     * @return list<ClassMethodUsage>
      */
+    private function getDefinitionSetClassUsages(
+        MethodCall $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->toString() !== 'setClass') {
+            return [];
+        }
+
+        $args = $node->getArgs();
+
+        if (!isset($args[0])) {
+            return [];
+        }
+
+        if (
+            !(new ObjectType('Symfony\Component\DependencyInjection\Definition'))
+                ->isSuperTypeOf($scope->getType($node->var))
+                ->yes()
+        ) {
+            return [];
+        }
+
+        $usages = [];
+
+        foreach ($scope->getType($args[0]->value)->getConstantStrings() as $constantString) {
+            $className = $constantString->getValue();
+
+            if (!$this->reflectionProvider->hasClass($className)) {
+                continue;
+            }
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createRegular($node, $scope),
+                new ClassMethodRef($className, '__construct', false),
+            );
+        }
+
+        return $usages;
+    }
+
+/**
+ * Detects data_class from OptionsResolver::setDefaults() and OptionsResolver::setDefault()
+ *
+ * @param array<int|string, Arg> $args
+ */
     private function extractFormDataClassFromOptionsResolver(
         string $methodName,
         MethodCall $node,

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -331,4 +333,17 @@ class EventListenerOnClassNotInDic
     public function __construct() {} // ctor required to invoke the listener
 
     public function __invoke(object $event): void {}
+}
+
+class SwappedServiceClassNotInDic
+{
+    public function __construct() {}
+}
+
+class SetClassCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getDefinition('some.service.id')->setClass(SwappedServiceClassNotInDic::class);
+    }
 }

--- a/tests/Rule/data/providers/symfony/services.xml
+++ b/tests/Rule/data/providers/symfony/services.xml
@@ -38,5 +38,8 @@
         <service id="Symfony\EventListenerOnClassNotInDic" class="Symfony\EventListenerOnClassNotInDic" abstract="true">
             <tag name="container.excluded" source="conditionally registered (e.g. via #[When])"/>
         </service>
+        <service id="Symfony\SwappedServiceClassNotInDic" class="Symfony\SwappedServiceClassNotInDic" abstract="true">
+            <tag name="container.excluded" source="#[Exclude]'d but constructed via Definition::setClass() in a compiler pass"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Detects $definition->setClass(X::class) calls in compiler passes. The DIC will construct X for the service whose class was swapped, so X's constructor is reachable at runtime even though no other source code may reference X directly.