### PR TITLE
Report excluded usages via error tip instead of message suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ parameters:
                     - %currentWorkingDirectory%/tests
 ```
 
-With such setup, members used only in tests will be reported with corresponding message, e.g:
+With such setup, members used only in tests will be reported with a corresponding tip, e.g:
 
 ```
-Unused AddressValidator::isValidPostalCode (all usages excluded by tests excluder)
+Unused AddressValidator::isValidPostalCode
+💡 All usages excluded by tests excluder
 ```
 
 > [!TIP]

--- a/src/Error/BlackMember.php
+++ b/src/Error/BlackMember.php
@@ -102,16 +102,16 @@ final class BlackMember
         }
     }
 
-    public function getExclusionMessage(): string
+    public function getExclusionTip(): ?string
     {
         if (count($this->excludedUsages) === 0) {
-            return '';
+            return null;
         }
 
         $excluderNames = implode(', ', array_keys($this->excludedUsages));
         $plural = count($this->excludedUsages) > 1 ? 's' : '';
 
-        return " (all usages excluded by {$excluderNames} excluder{$plural})";
+        return "All usages excluded by {$excluderNames} excluder{$plural}";
     }
 
     /**

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -839,12 +839,11 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
     {
         $representative = $blackMembersGroup[0];
 
-        $exclusionMessage = $representative->getExclusionMessage();
         $excludedUsages = $representative->getExcludedUsages();
 
         $mainErrorMessage = $this->buildMainErrorMessages($representative);
 
-        $builder = RuleErrorBuilder::message("{$mainErrorMessage}{$exclusionMessage}")
+        $builder = RuleErrorBuilder::message($mainErrorMessage)
             ->file($representative->getFile())
             ->line($representative->getLine())
             ->identifier($representative->getErrorIdentifier());
@@ -856,13 +855,22 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             'excludedUsages' => $excludedUsages,
         ];
 
+        $representativeExclusionTip = $representative->getExclusionTip();
+
+        if ($representativeExclusionTip !== null) {
+            $builder->addTip($representativeExclusionTip);
+        }
+
         $tips = [];
 
         foreach (array_slice($blackMembersGroup, 1) as $transitivelyDeadMember) {
-            $exclusionMessage = $transitivelyDeadMember->getExclusionMessage();
+            $exclusionTip = $transitivelyDeadMember->getExclusionTip();
             $excludedUsages = $transitivelyDeadMember->getExcludedUsages();
 
-            $tips[] = $this->buildTransitiveErrorMessages($transitivelyDeadMember) . $exclusionMessage;
+            $transitiveMessage = $this->buildTransitiveErrorMessages($transitivelyDeadMember);
+            $tips[] = $exclusionTip !== null
+                ? "{$transitiveMessage}. {$exclusionTip}"
+                : $transitiveMessage;
             $metadata[] = [
                 'blackMember' => $transitivelyDeadMember,
                 'transitive' => true,

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -401,8 +401,9 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         $this->debugMembers = ['DebugMixed\Foo::any'];
         $this->analyse([__DIR__ . '/data/debug/mixed.php'], [
             [
-                'Unused DebugMixed\Foo::any (all usages excluded by usageOverMixed excluder)',
+                'Unused DebugMixed\Foo::any',
                 7,
+                'All usages excluded by usageOverMixed excluder',
             ],
         ]);
         $rule = $this->getRule();

--- a/tests/Rule/data/constants/mixed/untracked.php
+++ b/tests/Rule/data/constants/mixed/untracked.php
@@ -5,9 +5,9 @@ namespace DeadConstMixed2;
 
 class Clazz {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\Clazz::CONST1 (all usages excluded by usageOverMixed excluder)
-    const CONST2 = 1; // error: Unused DeadConstMixed2\Clazz::CONST2 (all usages excluded by usageOverMixed excluder)
-    const CONST3 = 1; // error: Unused DeadConstMixed2\Clazz::CONST3 (all usages excluded by usageOverMixed excluder)
+    const CONST1 = 1; // error: Unused DeadConstMixed2\Clazz::CONST1
+    const CONST2 = 1; // error: Unused DeadConstMixed2\Clazz::CONST2
+    const CONST3 = 1; // error: Unused DeadConstMixed2\Clazz::CONST3
     const CONST4 = 1; // error: Unused DeadConstMixed2\Clazz::CONST4
     const CONST5 = 1;
     const CONST6 = 1; // error: Unused DeadConstMixed2\Clazz::CONST6
@@ -18,9 +18,9 @@ class Clazz {
 
 interface IFace {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\IFace::CONST1 (all usages excluded by usageOverMixed excluder)
-    const CONST2 = 1; // error: Unused DeadConstMixed2\IFace::CONST2 (all usages excluded by usageOverMixed excluder)
-    const CONST3 = 1; // error: Unused DeadConstMixed2\IFace::CONST3 (all usages excluded by usageOverMixed excluder)
+    const CONST1 = 1; // error: Unused DeadConstMixed2\IFace::CONST1
+    const CONST2 = 1; // error: Unused DeadConstMixed2\IFace::CONST2
+    const CONST3 = 1; // error: Unused DeadConstMixed2\IFace::CONST3
     const CONST4 = 1;
     const CONST5 = 1; // error: Unused DeadConstMixed2\IFace::CONST5
 
@@ -28,9 +28,9 @@ interface IFace {
 
 class Implementor implements IFace {
 
-    const CONST1 = 1; // error: Unused DeadConstMixed2\Implementor::CONST1 (all usages excluded by usageOverMixed excluder)
-    const CONST2 = 1; // error: Unused DeadConstMixed2\Implementor::CONST2 (all usages excluded by usageOverMixed excluder)
-    const CONST3 = 1; // error: Unused DeadConstMixed2\Implementor::CONST3 (all usages excluded by usageOverMixed excluder)
+    const CONST1 = 1; // error: Unused DeadConstMixed2\Implementor::CONST1
+    const CONST2 = 1; // error: Unused DeadConstMixed2\Implementor::CONST2
+    const CONST3 = 1; // error: Unused DeadConstMixed2\Implementor::CONST3
     const CONST4 = 1;
     const CONST5 = 1; // error: Unused DeadConstMixed2\Implementor::CONST5
     const CONST6 = 1;

--- a/tests/Rule/data/debug/exclude.php
+++ b/tests/Rule/data/debug/exclude.php
@@ -4,8 +4,8 @@ namespace DebugExclude;
 
 class Foo
 {
-    public static function mixedExcluder1() {} // error: Unused DebugExclude\Foo::mixedExcluder1 (all usages excluded by mixedPrefix excluder)
-    public static function mixedExcluder2() {} // error: Unused DebugExclude\Foo::mixedExcluder2 (all usages excluded by mixedPrefix excluder)
+    public static function mixedExcluder1() {} // error: Unused DebugExclude\Foo::mixedExcluder1
+    public static function mixedExcluder2() {} // error: Unused DebugExclude\Foo::mixedExcluder2
 }
 
 class Chld extends Foo {

--- a/tests/Rule/data/excluders/mixed/code.php
+++ b/tests/Rule/data/excluders/mixed/code.php
@@ -3,11 +3,11 @@
 namespace MixedExcluder;
 
 class SomeParent {
-    public function mixed1() {} // error: Unused MixedExcluder\SomeParent::mixed1 (all usages excluded by mixedPrefix excluder)
+    public function mixed1() {} // error: Unused MixedExcluder\SomeParent::mixed1
 }
 
 class Some extends SomeParent {
-    public function mixed2() {} // error: Unused MixedExcluder\Some::mixed2 (all usages excluded by mixedPrefix excluder)
+    public function mixed2() {} // error: Unused MixedExcluder\Some::mixed2
 }
 
 function test(Some $some) {

--- a/tests/Rule/data/excluders/tests/src/code.php
+++ b/tests/Rule/data/excluders/tests/src/code.php
@@ -1,7 +1,7 @@
 <?php
 
 class DeclaredInSrcUsedInTests {
-    const CONST = 1; // error: Unused DeclaredInSrcUsedInTests::CONST (all usages excluded by tests excluder)
+    const CONST = 1; // error: Unused DeclaredInSrcUsedInTests::CONST
     const MIXED = 2;
 }
 

--- a/tests/Rule/data/methods/mixed/tracked.php
+++ b/tests/Rule/data/methods/mixed/tracked.php
@@ -36,7 +36,7 @@ class Implementor implements IFace {
     public function getter4() {}
     public function getter5() {} // error: Unused DeadMixed1\Implementor::getter5
     public function getter6() {}
-    public function mixedGetter7() {} // error: Unused DeadMixed1\Implementor::mixedGetter7 (all usages excluded by mixedPrefix excluder)
+    public function mixedGetter7() {} // error: Unused DeadMixed1\Implementor::mixedGetter7
 
 }
 

--- a/tests/Rule/data/methods/mixed/untracked.php
+++ b/tests/Rule/data/methods/mixed/untracked.php
@@ -5,24 +5,24 @@ namespace DeadMixed2;
 
 class Clazz {
 
-    public function getter1() {} // error: Unused DeadMixed2\Clazz::getter1 (all usages excluded by usageOverMixed excluder)
-    public function getter2() {} // error: Unused DeadMixed2\Clazz::getter2 (all usages excluded by usageOverMixed excluder)
-    public function getter3() {} // error: Unused DeadMixed2\Clazz::getter3 (all usages excluded by usageOverMixed excluder)
+    public function getter1() {} // error: Unused DeadMixed2\Clazz::getter1
+    public function getter2() {} // error: Unused DeadMixed2\Clazz::getter2
+    public function getter3() {} // error: Unused DeadMixed2\Clazz::getter3
     public function getter4() {} // error: Unused DeadMixed2\Clazz::getter4
     public function getter5() {}
     public function getter6() {} // error: Unused DeadMixed2\Clazz::getter6
 
     public function someMethod() {} // error: Unused DeadMixed2\Clazz::someMethod
     public function nonStaticMethod() {} // error: Unused DeadMixed2\Clazz::nonStaticMethod
-    public static function staticMethod() {} // error: Unused DeadMixed2\Clazz::staticMethod (all usages excluded by usageOverMixed excluder)
+    public static function staticMethod() {} // error: Unused DeadMixed2\Clazz::staticMethod
 
 }
 
 interface IFace {
 
-    public function getter1(); // error: Unused DeadMixed2\IFace::getter1 (all usages excluded by usageOverMixed excluder)
-    public function getter2(); // error: Unused DeadMixed2\IFace::getter2 (all usages excluded by usageOverMixed excluder)
-    public function getter3(); // error: Unused DeadMixed2\IFace::getter3 (all usages excluded by usageOverMixed excluder)
+    public function getter1(); // error: Unused DeadMixed2\IFace::getter1
+    public function getter2(); // error: Unused DeadMixed2\IFace::getter2
+    public function getter3(); // error: Unused DeadMixed2\IFace::getter3
     public function getter4();
     public function getter5(); // error: Unused DeadMixed2\IFace::getter5
 
@@ -30,9 +30,9 @@ interface IFace {
 
 class Implementor implements IFace {
 
-    public function getter1() {} // error: Unused DeadMixed2\Implementor::getter1 (all usages excluded by usageOverMixed excluder)
-    public function getter2() {} // error: Unused DeadMixed2\Implementor::getter2 (all usages excluded by usageOverMixed excluder)
-    public function getter3() {} // error: Unused DeadMixed2\Implementor::getter3 (all usages excluded by usageOverMixed excluder)
+    public function getter1() {} // error: Unused DeadMixed2\Implementor::getter1
+    public function getter2() {} // error: Unused DeadMixed2\Implementor::getter2
+    public function getter3() {} // error: Unused DeadMixed2\Implementor::getter3
     public function getter4() {}
     public function getter5() {} // error: Unused DeadMixed2\Implementor::getter5
     public function getter6() {}

--- a/tests/Rule/data/properties/mixed/untracked.php
+++ b/tests/Rule/data/properties/mixed/untracked.php
@@ -5,9 +5,9 @@ namespace DeadPropertyMixed2;
 
 class Clazz {
 
-    public string $prop1; // error: Property DeadPropertyMixed2\Clazz::$prop1 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Clazz::$prop1 is never written
-    public string $prop2; // error: Property DeadPropertyMixed2\Clazz::$prop2 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Clazz::$prop2 is never written
-    public string $prop3; // error: Property DeadPropertyMixed2\Clazz::$prop3 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Clazz::$prop3 is never written
+    public string $prop1; // error: Property DeadPropertyMixed2\Clazz::$prop1 is never read // error: Property DeadPropertyMixed2\Clazz::$prop1 is never written
+    public string $prop2; // error: Property DeadPropertyMixed2\Clazz::$prop2 is never read // error: Property DeadPropertyMixed2\Clazz::$prop2 is never written
+    public string $prop3; // error: Property DeadPropertyMixed2\Clazz::$prop3 is never read // error: Property DeadPropertyMixed2\Clazz::$prop3 is never written
     public string $prop4; // error: Property DeadPropertyMixed2\Clazz::$prop4 is never read // error: Property DeadPropertyMixed2\Clazz::$prop4 is never written
     public string $prop5; // error: Property DeadPropertyMixed2\Clazz::$prop5 is never written
     public string $prop6; // error: Property DeadPropertyMixed2\Clazz::$prop6 is never read // error: Property DeadPropertyMixed2\Clazz::$prop6 is never written
@@ -22,9 +22,9 @@ interface IFace {
 
 class Implementor implements IFace {
 
-    public string $prop1; // error: Property DeadPropertyMixed2\Implementor::$prop1 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Implementor::$prop1 is never written
-    public string $prop2; // error: Property DeadPropertyMixed2\Implementor::$prop2 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Implementor::$prop2 is never written
-    public string $prop3; // error: Property DeadPropertyMixed2\Implementor::$prop3 is never read (all usages excluded by usageOverMixed excluder) // error: Property DeadPropertyMixed2\Implementor::$prop3 is never written
+    public string $prop1; // error: Property DeadPropertyMixed2\Implementor::$prop1 is never read // error: Property DeadPropertyMixed2\Implementor::$prop1 is never written
+    public string $prop2; // error: Property DeadPropertyMixed2\Implementor::$prop2 is never read // error: Property DeadPropertyMixed2\Implementor::$prop2 is never written
+    public string $prop3; // error: Property DeadPropertyMixed2\Implementor::$prop3 is never read // error: Property DeadPropertyMixed2\Implementor::$prop3 is never written
     public string $prop4; // error: Property DeadPropertyMixed2\Implementor::$prop4 is never written
     public string $prop5; // error: Property DeadPropertyMixed2\Implementor::$prop5 is never read // error: Property DeadPropertyMixed2\Implementor::$prop5 is never written
     public string $prop6; // error: Property DeadPropertyMixed2\Implementor::$prop6 is never written

--- a/tests/Rule/data/providers/custom.php
+++ b/tests/Rule/data/providers/custom.php
@@ -17,7 +17,7 @@ class Methods
 
     public function method(): void {}
 
-    public function mixedTestThatExcludersCanExcludeProvidedUsage(): void {} // error: Unused CustomProvider\Methods::mixedTestThatExcludersCanExcludeProvidedUsage (all usages excluded by mixedPrefix excluder)
+    public function mixedTestThatExcludersCanExcludeProvidedUsage(): void {} // error: Unused CustomProvider\Methods::mixedTestThatExcludersCanExcludeProvidedUsage
 }
 
 class Constants


### PR DESCRIPTION
The "(all usages excluded by X excluder)" text was appended to the error message itself, which mixed the diagnostic ("Unused X") with the explanation of why it survived analysis. Moving it to a PHPStan error tip keeps the message focused on the dead member and presents the excluder context the same way transitive-death reasons are already surfaced.

`BlackMember::getExclusionMessage()` becomes `getExclusionTip()`, returning null when nothing is excluded, and `DeadCodeRule::buildError()` emits it through `RuleErrorBuilder::addTip()` for both the representative and transitively dead members.

Fixes #359