### PR TITLE
Treat array_column() string keys as property reads

### DIFF
--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -373,7 +373,7 @@ final class PropertyAccessCollector implements Collector
     {
         $elementType = $firstArgType->getIterableValueType();
 
-        if ($elementType->isObject()->no()) {
+        if (!$elementType->isObject()->yes()) {
             return;
         }
 

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -4,6 +4,7 @@ namespace ShipMonk\PHPStan\DeadCode\Collector;
 
 use JsonSerializable;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Cast\Array_ as ArrayCast;
 use PhpParser\Node\Expr\FuncCall;
@@ -348,6 +349,53 @@ final class PropertyAccessCollector implements Collector
 
             if ($functionName === 'serialize') {
                 $this->registerSerializePropertyReads($firstArgType, $node, $scope);
+            }
+
+            if ($functionName === 'array_column') {
+                $this->registerArrayColumnPropertyReads($firstArgType, $args, $node, $scope);
+            }
+        }
+    }
+
+    /**
+     * array_column($array, $column_key, $index_key) reads public properties
+     * named by the string $column_key and $index_key from objects in $array.
+     * For array elements, it reads array keys instead — not relevant here.
+     *
+     * @param array<Arg> $args
+     */
+    private function registerArrayColumnPropertyReads(
+        Type $firstArgType,
+        array $args,
+        FuncCall $node,
+        Scope $scope,
+    ): void
+    {
+        $elementType = $firstArgType->getIterableValueType();
+
+        if ($elementType->isObject()->no()) {
+            return;
+        }
+
+        foreach ([1, 2] as $argIndex) {
+            if (!isset($args[$argIndex])) {
+                continue;
+            }
+
+            foreach ($scope->getType($args[$argIndex]->value)->getConstantStrings() as $constantString) {
+                $propertyName = $constantString->getValue();
+
+                foreach ($this->getDeclaringTypesWithProperty($propertyName, $elementType, null) as $propertyRef) {
+                    $this->registerUsage(
+                        new ClassPropertyUsage(
+                            UsageOrigin::createRegular($node, $scope),
+                            $propertyRef,
+                            AccessType::READ,
+                        ),
+                        $node,
+                        $scope,
+                    );
+                }
             }
         }
     }

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -335,6 +335,18 @@ function testArrayColumn(): void
     array_column($list, null, 'idxNull');
 }
 
+final class ArrayColumnUnrelated
+{
+    public string $onlyTouchedByMixedCall; // error: Property NativePropertyReads\ArrayColumnUnrelated::$onlyTouchedByMixedCall is never read // error: Property NativePropertyReads\ArrayColumnUnrelated::$onlyTouchedByMixedCall is never written
+}
+
+/** @param mixed $mixed */
+function testArrayColumnMixed($mixed): void
+{
+    // mixed element type could be array — don't mark every $onlyTouchedByMixedCall in the codebase
+    array_column($mixed, 'onlyTouchedByMixedCall');
+}
+
 function testSerialize(): void
 {
     $default = new SerializeDefault();

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -347,6 +347,43 @@ function testArrayColumnMixed($mixed): void
     array_column($mixed, 'onlyTouchedByMixedCall');
 }
 
+class ArrayColumnParent
+{
+    public string $inherited;
+
+    public function __construct()
+    {
+        $this->inherited = 'p';
+    }
+}
+
+final class ArrayColumnChild extends ArrayColumnParent
+{
+}
+
+final class ArrayColumnUnion
+{
+    public string $shared;
+
+    public function __construct()
+    {
+        $this->shared = 'u';
+    }
+}
+
+/**
+ * @param list<ArrayColumnChild> $children
+ * @param list<ArrayColumnClass|ArrayColumnUnion> $mixed
+ */
+function testArrayColumnInheritedAndUnion(array $children, array $mixed): void
+{
+    array_column($children, 'inherited');
+    array_column($mixed, 'shared');
+
+    new ArrayColumnChild();
+    new ArrayColumnUnion();
+}
+
 function testSerialize(): void
 {
     $default = new SerializeDefault();

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -310,6 +310,31 @@ function testJsonEncode(): void
     json_encode($outerWithJsonSerializable);
 }
 
+// --- array_column ---
+
+final class ArrayColumnClass
+{
+    public string $col;
+    public string $idx;
+    public string $idxNull;
+    public string $unused; // error: Property NativePropertyReads\ArrayColumnClass::$unused is never read
+
+    public function __construct()
+    {
+        $this->col = 'a';
+        $this->idx = 'b';
+        $this->idxNull = 'c';
+        $this->unused = 'd';
+    }
+}
+
+function testArrayColumn(): void
+{
+    $list = [new ArrayColumnClass()];
+    array_column($list, 'col', 'idx');
+    array_column($list, null, 'idxNull');
+}
+
 function testSerialize(): void
 {
     $default = new SerializeDefault();


### PR DESCRIPTION
## Summary
- Mark the 2nd (`column_key`) and 3rd (`index_key`) string arguments of `array_column()` as property READs on the iterable value type of the 1st arg, when that element type is definitely an object.
- Mirrors PHP semantics: only string keys map to properties (ints are array offsets), and only object element types trigger property access — array/mixed/union-with-array element types fall through to avoid false negatives elsewhere.

Closes #361