### PR TITLE
Symfony: expose public members of #[AsTwigComponent] classes to templates

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -85,6 +85,11 @@ services:
             enabled: %shipmonkDeadCode.usageProviders.behat.enabled%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\TemplateViewDataTraverser
+        arguments:
+            analysedPaths: %analysedPaths%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\SymfonyUsageProvider
         tags:
             - shipmonk.deadCode.memberUsageProvider
@@ -92,11 +97,6 @@ services:
             enabled: %shipmonkDeadCode.usageProviders.symfony.enabled%
             configDir: %shipmonkDeadCode.usageProviders.symfony.configDir%
             containerXmlPaths: %shipmonkDeadCode.usageProviders.symfony.containerXmlPaths%
-
-    -
-        class: ShipMonk\PHPStan\DeadCode\Provider\TemplateViewDataTraverser
-        arguments:
-            analysedPaths: %analysedPaths%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\TwigUsageProvider

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -36,6 +36,7 @@ use Reflector;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
@@ -69,6 +70,8 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 {
 
     private readonly ReflectionProvider $reflectionProvider;
+
+    private readonly TemplateViewDataTraverser $traverser;
 
     private readonly bool $enabled;
 
@@ -108,12 +111,14 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     public function __construct(
         Container $container,
         ReflectionProvider $reflectionProvider,
+        TemplateViewDataTraverser $traverser,
         ?bool $enabled,
         ?string $configDir,
         array $containerXmlPaths,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
+        $this->traverser = $traverser;
         $this->enabled = $enabled ?? $this->isSymfonyInstalled();
         $this->configDir = $configDir ?? $this->autodetectConfigDir();
 
@@ -155,6 +160,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 ...$this->getPropertyUsagesFromReflection($node),
                 ...$this->getConstantUsages($node->getClassReflection()),
                 ...$this->getInvokableCommandEnumUsages($node),
+                ...$this->getTwigComponentTemplateUsages($node),
             ];
         }
 
@@ -485,6 +491,24 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         return $usages;
+    }
+
+    /**
+     * @return list<ClassMemberUsage>
+     */
+    private function getTwigComponentTemplateUsages(InClassNode $node): array
+    {
+        $classReflection = $node->getClassReflection();
+        $nativeReflection = $classReflection->getNativeReflection();
+
+        if (!$this->hasAttribute($nativeReflection, 'Symfony\UX\TwigComponent\Attribute\AsTwigComponent', ReflectionAttribute::IS_INSTANCEOF)) {
+            return [];
+        }
+
+        $className = $classReflection->getName();
+        $rootContext = "Public members of #[AsTwigComponent] {$className} exposed in template";
+
+        return $this->traverser->getUsages([$className], $rootContext, $this);
     }
 
     private function createPropertyUsage(

--- a/tests/Provider/SymfonyUsageProviderTest.php
+++ b/tests/Provider/SymfonyUsageProviderTest.php
@@ -17,7 +17,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
         $configDir = __DIR__ . '/../../config';
         @mkdir($configDir);
 
-        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, []);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), new TemplateViewDataTraverser(self::getContainer()->getByType(ReflectionProvider::class), []), true, null, []);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $configDirPropertyReflection = $providerReflection->getProperty('configDir');
@@ -39,7 +39,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
     {
         $containerXmlPath = __DIR__ . '/../Rule/data/providers/symfony/services.xml';
 
-        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, [$containerXmlPath]);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), new TemplateViewDataTraverser(self::getContainer()->getByType(ReflectionProvider::class), []), true, null, [$containerXmlPath]);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');
@@ -62,7 +62,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
         $containerXmlPath = __DIR__ . '/../Rule/data/providers/symfony/services.xml';
 
         // Even though self::getContainer() has no symfony config, the explicit paths are used
-        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, [$containerXmlPath]);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), new TemplateViewDataTraverser(self::getContainer()->getByType(ReflectionProvider::class), []), true, null, [$containerXmlPath]);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');
@@ -77,7 +77,7 @@ final class SymfonyUsageProviderTest extends PHPStanTestCase
     {
         // When containerXmlPaths is empty, it falls back to getContainerXmlPath(container)
         // self::getContainer() has no symfony parameter, so no DIC classes are loaded
-        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), true, null, []);
+        $provider = new SymfonyUsageProvider(self::getContainer(), self::getContainer()->getByType(ReflectionProvider::class), new TemplateViewDataTraverser(self::getContainer()->getByType(ReflectionProvider::class), []), true, null, []);
 
         $providerReflection = new ReflectionClass(SymfonyUsageProvider::class);
         $dicCallsReflection = $providerReflection->getProperty('dicCalls');

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1171,6 +1171,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             [
                 __DIR__ . '/data/providers/twig-template.php',
                 __DIR__ . '/data/providers/blade.php',
+                __DIR__ . '/data/providers/symfony-ux.php',
             ],
         );
 
@@ -1230,6 +1231,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             new SymfonyUsageProvider(
                 $this->createContainerMockWithSymfonyConfig(),
                 self::getContainer()->getByType(ReflectionProvider::class),
+                $templateViewDataTraverser,
                 $this->providersEnabled,
                 __DIR__ . '/data/providers/symfony/',
                 [],

--- a/tests/Rule/data/providers/symfony-ux.php
+++ b/tests/Rule/data/providers/symfony-ux.php
@@ -38,9 +38,11 @@ class AlertComponent
     #[ExposeInTemplate]
     public function computedValue(): string { return ''; }
 
-    public string $notExposed = ''; // error: Property SymfonyUx\AlertComponent::$notExposed is never read
+    public string $notExposed = '';
 
-    public function deadMethod(): void {} // error: Unused SymfonyUx\AlertComponent::deadMethod
+    public function exposedByDefault(): void {}
+
+    private function reallyDead(): void {} // error: Unused SymfonyUx\AlertComponent::reallyDead
 }
 
 #[AsLiveComponent]
@@ -71,9 +73,11 @@ class CounterComponent
     #[PreReRender]
     public function beforeReRender(): void {}
 
-    public int $notLiveProp = 0; // error: Property SymfonyUx\CounterComponent::$notLiveProp is never read
+    public int $notLiveProp = 0;
 
-    public function deadMethod(): void {} // error: Unused SymfonyUx\CounterComponent::deadMethod
+    public function exposedByDefault(): void {}
+
+    private function reallyDead(): void {} // error: Unused SymfonyUx\CounterComponent::reallyDead
 }
 
 #[AsLiveComponent(defaultAction: 'render')]
@@ -105,7 +109,9 @@ class CustomActionComponent
 
     public function getFieldName(): string { return 'field'; }
 
-    public function deadMethod(): void {} // error: Unused SymfonyUx\CustomActionComponent::deadMethod
+    public function exposedByDefault(): void {}
+
+    private function reallyDead(): void {} // error: Unused SymfonyUx\CustomActionComponent::reallyDead
 }
 
 #[AsTwigComponent(template: new \Symfony\UX\TwigComponent\Attribute\FromMethod('getTemplatePath'))]
@@ -120,5 +126,7 @@ class DynamicTemplateComponent
         return 'components/dynamic.html.twig';
     }
 
-    public function deadMethod(): void {} // error: Unused SymfonyUx\DynamicTemplateComponent::deadMethod
+    public function exposedByDefault(): void {}
+
+    private function reallyDead(): void {} // error: Unused SymfonyUx\DynamicTemplateComponent::reallyDead
 }


### PR DESCRIPTION
## Summary
- Twig components render with `this` bound to the component instance, so every public property and method is reachable from the template (e.g. `{{ this.getTranslatedTitle() }}`) — previously we required `#[ExposeInTemplate]` and reported such members as dead otherwise.
- Now `SymfonyUsageProvider` routes `#[AsTwigComponent]` / `#[AsLiveComponent]` classes through the existing `TemplateViewDataTraverser`, the same machinery used for data passed to `render()`. Public members (and the classes they return) are marked as used.

Fixes #364

Co-Authored-By: Claude Code