### PR TITLE
Add e2e test config for spaze/michalspacek.cz

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,12 @@ jobs:
                         repo: shipmonk-rnd/composer-dependency-analyser
                     -
                         repo: shipmonk-rnd/coverage-guard
+                    -
+                        repo: spaze/michalspacek.cz
+                        php: 8.5
+                        composer-working-directory: app/vendor-dev
+                        working-directory: app
+                        executable: vendor-dev/vendor/phpstan/phpstan/phpstan
 
             fail-fast: false
         steps:
@@ -54,6 +60,7 @@ jobs:
 
             -
                 name: Update Dead Code Detector
+                working-directory: ${{ matrix.composer-working-directory || '.' }}
                 env:
                     HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
                     HEAD_REF: ${{ github.head_ref }}
@@ -64,6 +71,7 @@ jobs:
             -
                 name: Run analysis
                 continue-on-error: true
+                working-directory: ${{ matrix.working-directory || '.' }}
                 run: ${{ matrix.executable || 'vendor/bin/phpstan' }} analyse ${{ matrix.args }} -vvv --ansi --error-format=prettyJson > /tmp/phpstan-output.json
 
             -


### PR DESCRIPTION
The repo has no `composer.json` at the root: dev tooling lives in `app/vendor-dev/` and the application in `app/`. The detector is therefore installed in `app/vendor-dev/`, and PHPStan runs from `app/` where its autoload discovery picks up the committed `app/vendor`.

Both `working-directory` inputs default to the repo root, so the existing matrix entries are unaffected, only this entry sets them.