### PR TITLE
Nette: mark constructors of DI container services as used

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ parameters:
 #### Nette:
 - `handleXxx`, `renderXxx`, `actionXxx`, `injectXxx`, `createComponentXxx`
 - `SmartObject` magic calls for `@property` annotations
+- constructors of classes instantiated by the DI container, when `shipmonkDeadCode.usageProviders.nette.containerPaths` is configured (requires `nette/neon`):
+
+```neon
+parameters:
+    shipmonkDeadCode:
+        usageProviders:
+            nette:
+                containerPaths:
+                    - app/config/services.neon
+```
+
+  Paths are resolved relative to the config file. Resolves service definitions of every supported shape (`- Foo\Bar`, `name: Foo\Bar`, `Foo\Bar(args)`, `create:`/`factory:`, `class:`, `type:`, `implement:`), but `imported: true` services and `@service::method` factory-call references are skipped. Currently only constructors are marked; methods referenced in `setup:`/`arguments:` are out of scope.
 
 #### Nette Tester:
 - `test*` methods, `setUp`/`tearDown`, `@dataProvider` methods in `Tester\TestCase` subclasses

--- a/README.md
+++ b/README.md
@@ -102,18 +102,7 @@ parameters:
 #### Nette:
 - `handleXxx`, `renderXxx`, `actionXxx`, `injectXxx`, `createComponentXxx`
 - `SmartObject` magic calls for `@property` annotations
-- constructors of classes instantiated by the DI container, when `shipmonkDeadCode.usageProviders.nette.containerPaths` is configured (requires `nette/neon`):
-
-```neon
-parameters:
-    shipmonkDeadCode:
-        usageProviders:
-            nette:
-                containerPaths:
-                    - app/config/services.neon
-```
-
-  Paths are resolved relative to the config file. Resolves service definitions of every supported shape (`- Foo\Bar`, `name: Foo\Bar`, `Foo\Bar(args)`, `create:`/`factory:`, `class:`, `type:`, `implement:`), but `imported: true` services and `@service::method` factory-call references are skipped. Currently only constructors are marked; methods referenced in `setup:`/`arguments:` are out of scope.
+- constructors of classes instantiated by the DI container, when `shipmonkDeadCode.usageProviders.nette.containerNeonPaths` is configured (requires `nette/neon`)
 
 #### Nette Tester:
 - `test*` methods, `setUp`/`tearDown`, `@dataProvider` methods in `Tester\TestCase` subclasses

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "laravel/framework": "^10.0 || ^11.0 || ^12.0",
         "nette/application": "^3.1",
         "nette/component-model": "^3.0",
+        "nette/neon": "^3.4",
         "nette/tester": "^2.4",
         "nette/utils": "^3.0 || ^4.0",
         "nikic/php-parser": "^5.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a24b57f996c94a3df027eade4f9ee0c1",
+    "content-hash": "ed15447247dcb8ead76fa32afaf8514b",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -4402,6 +4402,77 @@
                 "source": "https://github.com/nette/http/tree/v3.3.3"
             },
             "time": "2025-10-30T22:32:24+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v3.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "9009f99ce1396b366a88ca16c90177148352b7d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/9009f99ce1396b366a88ca16c90177148352b7d3",
+                "reference": "9009f99ce1396b366a88ca16c90177148352b7d3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "8.0 - 8.5"
+            },
+            "require-dev": {
+                "nette/tester": "^2.4",
+                "phpstan/phpstan-nette": "^2.0@stable",
+                "tracy/tracy": "^2.7"
+            },
+            "bin": [
+                "bin/neon-lint"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "https://neon.nette.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/neon/issues",
+                "source": "https://github.com/nette/neon/tree/v3.4.8"
+            },
+            "time": "2026-05-11T21:34:00+00:00"
         },
         {
             "name": "nette/routing",

--- a/rules.neon
+++ b/rules.neon
@@ -147,6 +147,7 @@ services:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.nette.enabled%
+            containerPaths: %shipmonkDeadCode.usageProviders.nette.containerPaths%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\NetteTesterUsageProvider
@@ -290,6 +291,7 @@ parameters:
                 deduplicateAcrossViews: true
             nette:
                 enabled: null
+                containerPaths: []
             netteTester:
                 enabled: null
             streamWrapper:
@@ -314,6 +316,7 @@ parameters:
 expandRelativePaths:
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][configDir]'
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][containerXmlPaths]'
+    - '[parameters][shipmonkDeadCode][usageProviders][nette][containerPaths]'
     - '[parameters][shipmonkDeadCode][usageExcluders][tests][devPaths]'
 
 parametersSchema:
@@ -383,6 +386,7 @@ parametersSchema:
             ])
             nette: structure([
                 enabled: schema(bool(), nullable())
+                containerPaths: listOf(string())
             ])
             netteTester: structure([
                 enabled: schema(bool(), nullable())

--- a/rules.neon
+++ b/rules.neon
@@ -147,7 +147,7 @@ services:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.nette.enabled%
-            containerPaths: %shipmonkDeadCode.usageProviders.nette.containerPaths%
+            containerNeonPaths: %shipmonkDeadCode.usageProviders.nette.containerNeonPaths%
 
     -
         class: ShipMonk\PHPStan\DeadCode\Provider\NetteTesterUsageProvider
@@ -291,7 +291,7 @@ parameters:
                 deduplicateAcrossViews: true
             nette:
                 enabled: null
-                containerPaths: []
+                containerNeonPaths: []
             netteTester:
                 enabled: null
             streamWrapper:
@@ -316,7 +316,7 @@ parameters:
 expandRelativePaths:
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][configDir]'
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][containerXmlPaths]'
-    - '[parameters][shipmonkDeadCode][usageProviders][nette][containerPaths]'
+    - '[parameters][shipmonkDeadCode][usageProviders][nette][containerNeonPaths]'
     - '[parameters][shipmonkDeadCode][usageExcluders][tests][devPaths]'
 
 parametersSchema:
@@ -386,7 +386,7 @@ parametersSchema:
             ])
             nette: structure([
                 enabled: schema(bool(), nullable())
-                containerPaths: listOf(string())
+                containerNeonPaths: listOf(string())
             ])
             netteTester: structure([
                 enabled: schema(bool(), nullable())

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -48,24 +48,24 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
     private array $serviceClasses = [];
 
     /**
-     * @param list<string> $containerPaths Paths to NEON files describing the DI container services
+     * @param list<string> $containerNeonPaths Paths to NEON files describing the DI container services
      */
     public function __construct(
         ReflectionProvider $reflectionProvider,
         ?bool $enabled,
-        array $containerPaths,
+        array $containerNeonPaths,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->enabled = $enabled ?? $this->isNetteInstalled();
 
-        if ($this->enabled && $containerPaths !== []) {
+        if ($this->enabled && $containerNeonPaths !== []) {
             if (!class_exists(Neon::class)) {
-                throw new LogicException('Install nette/neon to use the containerPaths option of the Nette usage provider');
+                throw new LogicException('Install nette/neon to use the containerNeonPaths option of the Nette usage provider');
             }
 
-            foreach ($containerPaths as $containerPath) {
-                $this->loadServicesFromNeon($containerPath);
+            foreach ($containerNeonPaths as $containerNeonPath) {
+                $this->loadServicesFromNeon($containerNeonPath);
             }
         }
     }
@@ -235,12 +235,12 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         return $classes;
     }
 
-    private function loadServicesFromNeon(string $containerPath): void
+    private function loadServicesFromNeon(string $containerNeonPath): void
     {
-        $contents = file_get_contents($containerPath);
+        $contents = file_get_contents($containerNeonPath);
 
         if ($contents === false) {
-            throw new LogicException(sprintf('Nette container file %s does not exist or is not readable', $containerPath));
+            throw new LogicException(sprintf('Nette container file %s does not exist or is not readable', $containerNeonPath));
         }
 
         foreach (self::findServiceClassesInNeon($contents) as $class) {

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -3,16 +3,26 @@
 namespace ShipMonk\PHPStan\DeadCode\Provider;
 
 use Composer\InstalledVersions;
+use LogicException;
 use Nette\Application\UI\Control;
 use Nette\Application\UI\Presenter;
 use Nette\Application\UI\SignalReceiver;
 use Nette\ComponentModel\Container;
+use Nette\Neon\Entity;
+use Nette\Neon\Neon;
 use Nette\SmartObject;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use ReflectionMethod;
+use function class_exists;
+use function file_get_contents;
+use function is_array;
+use function is_string;
 use function lcfirst;
+use function ltrim;
+use function preg_match;
 use function preg_match_all;
+use function sprintf;
 use function str_starts_with;
 use function substr;
 use function ucfirst;
@@ -30,13 +40,34 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
      */
     private array $smartObjectCache = [];
 
+    /**
+     * Classes declaring a constructor invoked by the Nette DI container, collected from NEON `services:` config.
+     *
+     * @var array<class-string, true>
+     */
+    private array $serviceClasses = [];
+
+    /**
+     * @param list<string> $containerPaths Paths to NEON files describing the DI container services
+     */
     public function __construct(
         ReflectionProvider $reflectionProvider,
         ?bool $enabled,
+        array $containerPaths,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->enabled = $enabled ?? $this->isNetteInstalled();
+
+        if ($this->enabled && $containerPaths !== []) {
+            if (!class_exists(Neon::class)) {
+                throw new LogicException('Install nette/neon to use the containerPaths option of the Nette usage provider');
+            }
+
+            foreach ($containerPaths as $containerPath) {
+                $this->loadServicesFromNeon($containerPath);
+            }
+        }
     }
 
     public function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
@@ -50,7 +81,17 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         $className = $class->getName();
         $reflection = $this->reflectionProvider->getClass($className);
 
-        return $this->isNetteMagic($reflection, $methodName);
+        $magicUsage = $this->isNetteMagic($reflection, $methodName);
+
+        if ($magicUsage !== null) {
+            return $magicUsage;
+        }
+
+        if ($methodName === '__construct' && isset($this->serviceClasses[$className])) {
+            return VirtualUsageData::withNote('Registered as a service in Nette DI container');
+        }
+
+        return null;
     }
 
     private function isNetteMagic(
@@ -166,6 +207,146 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
 
         $this->smartObjectCache[$class] = $props;
         return $props;
+    }
+
+    /**
+     * Extracts the FQCNs the container instantiates from a NEON `services:` block.
+     *
+     * @return list<class-string>
+     */
+    public static function findServiceClassesInNeon(string $neonContent): array
+    {
+        $decoded = Neon::decode($neonContent);
+
+        if (!is_array($decoded) || !isset($decoded['services']) || !is_array($decoded['services'])) {
+            return [];
+        }
+
+        $classes = [];
+
+        foreach ($decoded['services'] as $entry) {
+            $class = self::resolveServiceClass($entry);
+
+            if ($class !== null) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    private function loadServicesFromNeon(string $containerPath): void
+    {
+        $contents = file_get_contents($containerPath);
+
+        if ($contents === false) {
+            throw new LogicException(sprintf('Nette container file %s does not exist or is not readable', $containerPath));
+        }
+
+        foreach (self::findServiceClassesInNeon($contents) as $class) {
+            if ($this->reflectionProvider->hasClass($class)) {
+                $this->markServiceClass($class);
+            }
+        }
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function markServiceClass(string $class): void
+    {
+        $classReflection = $this->reflectionProvider->getClass($class);
+
+        $this->markConstructorDeclaringClass($classReflection);
+
+        // Automatically generated factory interfaces: Nette DI generates a class implementing
+        // the interface whose create() returns `new ReturnType(...)`. That return type's
+        // constructor also needs to be marked as used - there is no statically visible `new`.
+        if (!$classReflection->isInterface() || !$classReflection->hasNativeMethod('create')) {
+            return;
+        }
+
+        $createMethod = $classReflection->getNativeMethod('create');
+
+        foreach ($createMethod->getVariants() as $variant) {
+            foreach ($variant->getReturnType()->getObjectClassNames() as $returnedClass) {
+                if ($this->reflectionProvider->hasClass($returnedClass)) {
+                    $this->markConstructorDeclaringClass($this->reflectionProvider->getClass($returnedClass));
+                }
+            }
+        }
+    }
+
+    /**
+     * Records the class that actually declares the constructor, so a service that inherits its
+     * constructor credits the declaring ancestor (matching where the dead-code rule reports it).
+     */
+    private function markConstructorDeclaringClass(ClassReflection $classReflection): void
+    {
+        if (!$classReflection->hasConstructor()) {
+            return;
+        }
+
+        $this->serviceClasses[$classReflection->getConstructor()->getDeclaringClass()->getName()] = true;
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private static function resolveServiceClass(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return self::extractClassName($value);
+        }
+
+        if ($value instanceof Entity && is_string($value->value)) {
+            return self::extractClassName($value->value);
+        }
+
+        if (is_array($value)) {
+            // Imported services are provided at runtime (e.g. via addImportedDefinition), not instantiated by the container.
+            if (($value['imported'] ?? null) === true) {
+                return null;
+            }
+
+            if (isset($value['create'])) {
+                return self::resolveServiceClass($value['create']);
+            }
+
+            if (isset($value['factory'])) { // legacy alias of create
+                return self::resolveServiceClass($value['factory']);
+            }
+
+            if (isset($value['class'])) {
+                return self::resolveServiceClass($value['class']);
+            }
+
+            if (isset($value['type'])) {
+                return self::resolveServiceClass($value['type']);
+            }
+
+            if (isset($value['implement'])) {
+                return self::resolveServiceClass($value['implement']);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private static function extractClassName(string $value): ?string
+    {
+        // Reject @serviceName::method references, callables, values with spaces etc.
+        if (preg_match('/^\\\\?[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$/', $value) !== 1) {
+            return null;
+        }
+
+        /** @var class-string $normalised */
+        $normalised = ltrim($value, '\\');
+
+        return $normalised;
     }
 
     private function isNetteInstalled(): bool

--- a/tests/Provider/NetteUsageProviderTest.php
+++ b/tests/Provider/NetteUsageProviderTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+
+final class NetteUsageProviderTest extends PHPStanTestCase
+{
+
+    public function testContainerPathsCollectsServiceClasses(): void
+    {
+        $neonPath = __DIR__ . '/../Rule/data/providers/nette/services.neon';
+
+        $provider = new NetteUsageProvider(
+            self::getContainer()->getByType(ReflectionProvider::class),
+            true,
+            [$neonPath],
+        );
+
+        $providerReflection = new ReflectionClass(NetteUsageProvider::class);
+        $serviceClassesReflection = $providerReflection->getProperty('serviceClasses');
+
+        /** @var array<string, true> $serviceClasses */
+        $serviceClasses = $serviceClassesReflection->getValue($provider);
+
+        // every supported service-definition shape resolves to the instantiated class
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredScalar', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredNamed', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredEntity', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredViaCreate', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredViaFactoryKey', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredViaClass', $serviceClasses);
+        self::assertArrayHasKey('NetteContainerProvider\RegisteredViaType', $serviceClasses);
+
+        // an inherited constructor is credited on the declaring ancestor, not the registered child
+        self::assertArrayHasKey('NetteContainerProvider\ServiceParent', $serviceClasses);
+        self::assertArrayNotHasKey('NetteContainerProvider\RegisteredChild', $serviceClasses);
+
+        // a factory interface marks the constructor of its create() return type
+        self::assertArrayHasKey('NetteContainerProvider\FactoryProduct', $serviceClasses);
+        self::assertArrayNotHasKey('NetteContainerProvider\ProductFactory', $serviceClasses);
+
+        // imported services and factory-call references are not instantiated by the container
+        self::assertArrayNotHasKey('NetteContainerProvider\ImportedService', $serviceClasses);
+    }
+
+    /**
+     * @param list<string> $expectedClasses
+     */
+    #[DataProvider('provideNeonShapes')]
+    public function testFindServiceClassesInNeon(
+        string $neon,
+        array $expectedClasses,
+    ): void
+    {
+        self::assertSame($expectedClasses, NetteUsageProvider::findServiceClassesInNeon($neon));
+    }
+
+    /**
+     * @return iterable<string, array{string, list<string>}>
+     */
+    public static function provideNeonShapes(): iterable
+    {
+        yield 'scalar FQCN' => ["services:\n\t- Foo\\Bar", ['Foo\Bar']];
+        yield 'leading backslash is trimmed' => ["services:\n\t- \\Foo\\Bar", ['Foo\Bar']];
+        yield 'named entry' => ["services:\n\tname: Foo\\Bar", ['Foo\Bar']];
+        yield 'entity with arguments' => ["services:\n\tname: Foo\\Bar(arg)", ['Foo\Bar']];
+        yield 'create key' => ["services:\n\tname:\n\t\tcreate: Foo\\Bar", ['Foo\Bar']];
+        yield 'create key with constructor arguments' => ["services:\n\tname:\n\t\tcreate: Foo\\Bar(@dep, 1)", ['Foo\Bar']];
+        yield 'factory key' => ["services:\n\tname:\n\t\tfactory: Foo\\Bar", ['Foo\Bar']];
+        yield 'class key' => ["services:\n\tname:\n\t\tclass: Foo\\Bar", ['Foo\Bar']];
+        yield 'type key' => ["services:\n\tname:\n\t\ttype: Foo\\Bar", ['Foo\Bar']];
+        yield 'implement key' => ["services:\n\tname:\n\t\timplement: Foo\\BarFactory", ['Foo\BarFactory']];
+        yield 'create wins over type' => ["services:\n\tname:\n\t\tcreate: Foo\\Bar\n\t\ttype: Foo\\Baz", ['Foo\Bar']];
+
+        yield 'imported: true is skipped' => ["services:\n\tname:\n\t\ttype: Foo\\Bar\n\t\timported: true", []];
+        yield 'imported: yes is skipped' => ["services:\n\tname:\n\t\ttype: Foo\\Bar\n\t\timported: yes", []];
+        yield 'static factory method call is skipped' => ["services:\n\tname:\n\t\tcreate: Foo\\Bar::create()", []];
+        yield 'service factory method call is skipped' => ["services:\n\tname:\n\t\tcreate: @other::make()", []];
+        yield 'callable array factory is skipped' => ["services:\n\tname:\n\t\tcreate: [Foo\\Bar, create]", []];
+        yield 'service reference is skipped' => ["services:\n\tname: @other", []];
+        yield 'no services block' => ['parameters:', []];
+        yield 'empty services block' => ['services:', []];
+    }
+
+}

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1000,6 +1000,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-laravel' => [__DIR__ . '/data/providers/laravel.php'];
         yield 'provider-blade' => [__DIR__ . '/data/providers/blade.php'];
         yield 'provider-nette' => [__DIR__ . '/data/providers/nette.php'];
+        yield 'provider-nette-container' => [__DIR__ . '/data/providers/nette-container.php'];
         yield 'provider-nette-tester' => [__DIR__ . '/data/providers/nette-tester.php'];
         yield 'provider-apiphpdoc' => [__DIR__ . '/data/providers/api-phpdoc.php'];
         yield 'provider-enum' => [__DIR__ . '/data/providers/enum.php'];
@@ -1224,6 +1225,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             new NetteUsageProvider(
                 self::getContainer()->getByType(ReflectionProvider::class),
                 $this->providersEnabled,
+                [__DIR__ . '/data/providers/nette/services.neon'],
             ),
             new StreamWrapperUsageProvider(
                 $this->providersEnabled,

--- a/tests/Rule/data/providers/nette-container.php
+++ b/tests/Rule/data/providers/nette-container.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NetteContainerProvider;
+
+class RegisteredScalar // - NetteContainerProvider\RegisteredScalar
+{
+    public function __construct() {}
+}
+
+class RegisteredNamed // name: NetteContainerProvider\RegisteredNamed
+{
+    public function __construct() {}
+}
+
+class RegisteredEntity // entity: NetteContainerProvider\RegisteredEntity(arg)
+{
+    public function __construct(string $arg) {}
+}
+
+class RegisteredViaCreate // viaCreate: { create: NetteContainerProvider\RegisteredViaCreate }
+{
+    public function __construct() {}
+}
+
+class RegisteredViaFactoryKey // viaFactory: { factory: NetteContainerProvider\RegisteredViaFactoryKey }
+{
+    public function __construct() {}
+}
+
+class RegisteredViaClass // viaClass: { class: NetteContainerProvider\RegisteredViaClass }
+{
+    public function __construct() {}
+}
+
+class RegisteredViaType // viaType: { type: NetteContainerProvider\RegisteredViaType }
+{
+    public function __construct() {}
+}
+
+class ServiceParent // not in container, but RegisteredChild inherits its constructor
+{
+    public function __construct() {}
+}
+
+class RegisteredChild extends ServiceParent // child: NetteContainerProvider\RegisteredChild (inherits constructor)
+{
+}
+
+class ImportedService // imported: { type: NetteContainerProvider\ImportedService, imported: true }
+{
+    public function __construct() {} // error: Unused NetteContainerProvider\ImportedService::__construct
+}
+
+class NotRegistered
+{
+    public function __construct() {} // error: Unused NetteContainerProvider\NotRegistered::__construct
+}

--- a/tests/Rule/data/providers/nette/factory.php
+++ b/tests/Rule/data/providers/nette/factory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace NetteContainerProvider;
+
+interface ProductFactory
+{
+    public function create(): FactoryProduct;
+}
+
+class FactoryProduct
+{
+    public function __construct() {}
+}

--- a/tests/Rule/data/providers/nette/services.neon
+++ b/tests/Rule/data/providers/nette/services.neon
@@ -1,0 +1,19 @@
+services:
+    - NetteContainerProvider\RegisteredScalar
+    named: NetteContainerProvider\RegisteredNamed
+    entity: NetteContainerProvider\RegisteredEntity(some-arg)
+    viaCreate:
+        create: NetteContainerProvider\RegisteredViaCreate
+    viaFactory:
+        factory: NetteContainerProvider\RegisteredViaFactoryKey
+    viaClass:
+        class: NetteContainerProvider\RegisteredViaClass
+    viaType:
+        type: NetteContainerProvider\RegisteredViaType
+    child: NetteContainerProvider\RegisteredChild
+    productFactory:
+        implement: NetteContainerProvider\ProductFactory
+    imported:
+        type: NetteContainerProvider\ImportedService
+        imported: true
+    factoryCall: @serviceName::createSomething


### PR DESCRIPTION
Adds an opt-in `usageProviders.nette.containerNeonPaths` option to the bundled NetteUsageProvider. When set, it reads the project's NEON `services:` config and marks each registered service class's constructor as used, since the Nette DI container instantiates them via `new $class(...)` with no statically visible `new`.

Resolves every service-definition shape: scalar FQCN, `name: Foo`, NEON entities `Foo(args)`, `create:`/`factory:`, `class:`, `type:`, and `implement:` (whose generated `create()` return type is marked too). Skips `imported: true` services and `@service::method` factory-call references. Inherited constructors are credited on the declaring ancestor.

`nette/neon` is an optional dependency, runtime-checked when containerPaths is used (mirrors how the Symfony provider guards ext-simplexml).

Out of scope: methods referenced in `setup:`/`arguments:`.

Refs #363