### PR TITLE
Add missing Laravel FormRequest methods

### DIFF
--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -798,7 +798,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         }
 
         $formRequestMethods = [
-            'authorize', 'rules', 'messages', 'attributes',
+            'authorize', 'rules', 'messages', 'attributes', 'after', 'validator', 'withValidator',
             'prepareForValidation', 'passedValidation', 'failedValidation', 'failedAuthorization',
         ];
 


### PR DESCRIPTION
This adds three methods to Laravel's `FormRequest` that are called by the framework:
https://github.com/laravel/framework/blob/800cd64f73b029248b74625e73c87c1d407b06fa/src/Illuminate/Foundation/Http/FormRequest.php#L104-L119