### PR TITLE
Readme: note abstract methods follow the same as interface methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ class ApiOutputPropertyUsageProvider extends ReflectionBasedMemberUsageProvider
 
 #### Interface methods:
 - If you never call interface method over the interface, but only over its implementors, it gets reported as dead
+  - The same applies for abstract methods
 - But you may want to keep the interface method to force some unification across implementors
   - The easiest way to ignore it is via custom `MemberUsageProvider`:
 


### PR DESCRIPTION
Clarifies in the README that the "interface methods" dead-detection behavior applies equally to abstract methods: when an abstract/interface declaration is only ever reached through a concrete implementor (never called over the abstraction itself), it gets reported as dead.

Prompted by [#364 (comment)](https://github.com/shipmonk-rnd/dead-code-detector/issues/364#issuecomment-4610626998), where an abstract Twig-component method (`AbstractChartComponent::getData`) is reported dead even though concrete subclasses override it and are used via templates. This is working as intended — same as the documented interface-method case — and the documented `IgnoreDeadInterfaceUsageProvider` workaround applies (widened to `isAbstract()`).
