### PR TITLE
CI: whitelist laravel/framework in composer audit so PHP 8.1 jobs install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,11 @@
             "dealerdirect/phpcodesniffer-composer-installer": false,
             "ergebnis/composer-normalize": true
         },
+        "audit": {
+            "ignore": {
+                "laravel/framework": "dev-only dep for provider tests; need to be able to install on PHP 8.1 (bugfixes not backported)"
+            }
+        },
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
## Problem

All PRs currently fail the PHP **8.1** CI jobs (`cda`, `phpstan`, `tests`) at the `composer update` step:

```
laravel/framework[v12.60.0, …, v12.61.0] require php ^8.2
-> your php version (8.1.34) does not satisfy that requirement.
```

## Root cause

Composer's resolution-time security-advisory blocking is dropping every PHP-8.1-compatible `laravel/framework` version:

- `CVE-2026-48019` (reported 2026-05-19) marks the entire 10.x and 11.x lines affected, with the fix only shipped in **12.60.0** (and 13.10.0) — Laravel did not backport it.
- Per Laravel's support policy, the only 8.1-compatible line (10.x) reached **end of security support on 2026-02-04**, so no backport is coming.
- The patched 12.60+ releases require **PHP 8.2**.

⟹ On PHP 8.1 there is no secure Laravel left, so composer empties the candidate set down to 12.60+ and then trips the `php ^8.2` requirement.

## Fix

`laravel/framework` is a **dev-only** dependency used solely to exercise the usage providers in tests — the extension ships no runtime framework code, so its advisories are irrelevant here. Whitelist just that package via `config.audit.ignore` (narrower than disabling advisory blocking globally). Verified locally under a simulated `platform.php = 8.1.34`: resolution succeeds, downgrading to `laravel/framework v10.50.2`.

Co-Authored-By: Claude Code