### PR TITLE
Fix crash on array callable with unknown method name

### DIFF
--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -19,6 +19,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Node\MethodCallableNode;
 use PHPStan\Node\StaticMethodCallableNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -181,8 +182,13 @@ final class MethodCallCollector implements Collector
                 $callableTypeAndNames = $constantArray->findTypeAndMethodNames();
 
                 foreach ($callableTypeAndNames as $typeAndName) {
-                    $caller = $typeAndName->getType();
-                    $methodName = $typeAndName->getMethod();
+                    if ($typeAndName->isUnknown()) {
+                        $caller = $constantArray->getOffsetValueType(new ConstantIntegerType(0));
+                        $methodName = null; // unknown method name
+                    } else {
+                        $caller = $typeAndName->getType();
+                        $methodName = $typeAndName->getMethod();
+                    }
 
                     foreach ($this->getDeclaringTypesWithMethod($methodName, $caller, TrinaryLogic::createMaybe()) as $methodRef) {
                         $this->registerUsage(

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -179,17 +179,20 @@ final class MethodCallCollector implements Collector
     {
         if ($scope->getType($array)->isCallable()->yes()) {
             foreach ($scope->getType($array)->getConstantArrays() as $constantArray) {
-                $callableTypeAndNames = $constantArray->findTypeAndMethodNames();
+                $caller = $constantArray->getOffsetValueType(new ConstantIntegerType(0));
+                $methodNameType = $constantArray->getOffsetValueType(new ConstantIntegerType(1));
 
-                foreach ($callableTypeAndNames as $typeAndName) {
-                    if ($typeAndName->isUnknown()) {
-                        $caller = $constantArray->getOffsetValueType(new ConstantIntegerType(0));
-                        $methodName = null; // unknown method name
-                    } else {
-                        $caller = $typeAndName->getType();
-                        $methodName = $typeAndName->getMethod();
-                    }
+                $methodNames = [];
 
+                foreach ($methodNameType->getConstantStrings() as $constantString) {
+                    $methodNames[] = $constantString->getValue();
+                }
+
+                if ($methodNames === []) {
+                    $methodNames = [null]; // unknown method name
+                }
+
+                foreach ($methodNames as $methodName) {
                     foreach ($this->getDeclaringTypesWithMethod($methodName, $caller, TrinaryLogic::createMaybe()) as $methodRef) {
                         $this->registerUsage(
                             new ClassMethodUsage(

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -904,7 +904,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'method-anonym' => [__DIR__ . '/data/methods/anonym.php'];
         yield 'method-enum' => [__DIR__ . '/data/methods/enum.php'];
         yield 'method-callables' => [__DIR__ . '/data/methods/callables.php'];
-        yield 'method-array-callable-dynamic-name' => [__DIR__ . '/data/methods/array-callable-dynamic-name.php'];
+        yield 'method-array-callable-dynamic-name' => [__DIR__ . '/data/methods/array-callable-dynamic-name.php', self::requiresPackage('phpstan/phpstan', '>= 2.1.54')]; // is_callable() narrowing of [$obj, $method] arrays exists since 2.1.54
         yield 'method-code' => [__DIR__ . '/data/methods/basic.php'];
         yield 'method-ctor' => [__DIR__ . '/data/methods/ctor.php'];
         yield 'method-ctor-interface' => [__DIR__ . '/data/methods/ctor-interface.php'];

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -904,6 +904,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'method-anonym' => [__DIR__ . '/data/methods/anonym.php'];
         yield 'method-enum' => [__DIR__ . '/data/methods/enum.php'];
         yield 'method-callables' => [__DIR__ . '/data/methods/callables.php'];
+        yield 'method-array-callable-dynamic-name' => [__DIR__ . '/data/methods/array-callable-dynamic-name.php'];
         yield 'method-code' => [__DIR__ . '/data/methods/basic.php'];
         yield 'method-ctor' => [__DIR__ . '/data/methods/ctor.php'];
         yield 'method-ctor-interface' => [__DIR__ . '/data/methods/ctor-interface.php'];

--- a/tests/Rule/data/methods/array-callable-dynamic-name.php
+++ b/tests/Rule/data/methods/array-callable-dynamic-name.php
@@ -47,5 +47,3 @@ function runFullyUnknown(string $className, string $methodName): void
 }
 
 (new Test())->run('maybeCalledDynamically');
-runOverDynamicClassString(StaticHandler::class);
-runFullyUnknown('AnyClass', 'anyMethod');

--- a/tests/Rule/data/methods/array-callable-dynamic-name.php
+++ b/tests/Rule/data/methods/array-callable-dynamic-name.php
@@ -6,6 +6,7 @@ class Test {
 
     public function run(string $methodName): void
     {
+        // known class, unknown method name => marks all methods of Test as used
         if (is_callable([$this, $methodName])) {
             call_user_func([$this, $methodName]);
         }
@@ -17,4 +18,34 @@ class Test {
 
 }
 
+class StaticHandler {
+
+    public static function maybeCalledOverDynamicClassString(): void
+    {
+    }
+
+    public static function deadMethod(): void // error: Unused ArrayCallableDynamicName\StaticHandler::deadMethod
+    {
+    }
+
+}
+
+function runOverDynamicClassString(string $className): void
+{
+    // unknown class, known method name => marks the method as used in all classes declaring it
+    if (is_callable([$className, 'maybeCalledOverDynamicClassString'])) {
+        call_user_func([$className, 'maybeCalledOverDynamicClassString']);
+    }
+}
+
+function runFullyUnknown(string $className, string $methodName): void
+{
+    // unknown class, unknown method name => marks nothing as used
+    if (is_callable([$className, $methodName])) {
+        call_user_func([$className, $methodName]);
+    }
+}
+
 (new Test())->run('maybeCalledDynamically');
+runOverDynamicClassString(StaticHandler::class);
+runFullyUnknown('AnyClass', 'anyMethod');

--- a/tests/Rule/data/methods/array-callable-dynamic-name.php
+++ b/tests/Rule/data/methods/array-callable-dynamic-name.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ArrayCallableDynamicName;
+
+class Test {
+
+    public function run(string $methodName): void
+    {
+        if (is_callable([$this, $methodName])) {
+            call_user_func([$this, $methodName]);
+        }
+    }
+
+    public function maybeCalledDynamically(): void
+    {
+    }
+
+}
+
+(new Test())->run('maybeCalledDynamically');


### PR DESCRIPTION
When an array callable like `[$this, $methodName]` with a non-constant method name is narrowed to callable (e.g. by an `is_callable()` check), `ConstantArrayType::findTypeAndMethodNames()` returns `ConstantArrayTypeAndMethod::createUnknown()`, and calling `getType()` on it throws `ShouldNotHappenException`.

Handle the unknown case like other dynamic method names: register a usage with unknown method name over the array's first element type.