### PR TITLE
Migrate switch to match in ReflectionUsageProvider

### DIFF
--- a/src/Provider/ReflectionUsageProvider.php
+++ b/src/Provider/ReflectionUsageProvider.php
@@ -229,21 +229,18 @@ final class ReflectionUsageProvider implements MemberUsageProvider
 
         foreach ($classNames as $ownerClass) {
             foreach ($memberNames as $memberName) {
-                switch ($memberType) {
-                    case 'method':
-                        $usages[] = $this->createMethodUsage($node, $scope, $ownerClass, $memberName);
-                        break;
-                    case 'property':
-                        $usages[] = $this->createPropertyUsage($node, $scope, $ownerClass, $memberName, AccessType::READ);
-                        $usages[] = $this->createPropertyUsage($node, $scope, $ownerClass, $memberName, AccessType::WRITE);
-                        break;
-                    case 'constant':
-                        $usages[] = $this->createConstantUsage($node, $scope, $ownerClass, $memberName);
-                        break;
-                    case 'enumCase':
-                        $usages[] = $this->createEnumCaseUsage($node, $scope, $ownerClass, $memberName);
-                        break;
-                }
+                $usages = [
+                    ...$usages,
+                    ...match ($memberType) {
+                        'method' => [$this->createMethodUsage($node, $scope, $ownerClass, $memberName)],
+                        'property' => [
+                            $this->createPropertyUsage($node, $scope, $ownerClass, $memberName, AccessType::READ),
+                            $this->createPropertyUsage($node, $scope, $ownerClass, $memberName, AccessType::WRITE),
+                        ],
+                        'constant' => [$this->createConstantUsage($node, $scope, $ownerClass, $memberName)],
+                        'enumCase' => [$this->createEnumCaseUsage($node, $scope, $ownerClass, $memberName)],
+                    },
+                ];
             }
         }
 


### PR DESCRIPTION
## Summary

Converts the only `switch` statement in `src/` (`ReflectionUsageProvider::processClassMemberConstructor`) to a `match` expression.

- The `property` arm yields two usages (`READ` + `WRITE`), so each arm returns an array that is spread into `$usages`.
- The `match` is exhaustive over the closed `'method'|'property'|'constant'|'enumCase'` union, so no `default` arm is needed (and PHPStan would flag a redundant one).
- Behavior is unchanged: the original `switch` had no `default` and silently ignored other values, which is impossible given the param type.

## Verification

- `composer check:types` — no errors
- `composer check:tests` — 781 tests, 4797 assertions, all passing
- Full `composer check` suite passes via pre-commit hook

Co-Authored-By: Claude Code