### PR TITLE
PhpBench: handle single-string `#[ParamProviders('...')]` attribute

### DIFF
--- a/src/Provider/PhpBenchUsageProvider.php
+++ b/src/Provider/PhpBenchUsageProvider.php
@@ -243,10 +243,10 @@ final class PhpBenchUsageProvider implements MemberUsageProvider
         foreach ($method->getAttributes(ParamProviders::class) as $providerAttributeReflection) {
             $providers = $providerAttributeReflection->getArguments()[0]
                 ?? $providerAttributeReflection->getArguments()['providers']
-                ?? null;
+                ?? [];
 
             if (!is_array($providers)) {
-                continue;
+                $providers = [$providers];
             }
 
             foreach ($providers as $provider) {

--- a/tests/Rule/data/providers/phpbench.php
+++ b/tests/Rule/data/providers/phpbench.php
@@ -28,12 +28,22 @@ class SimpleBench
     {
     }
 
+    #[ParamProviders('provideSingleStringParams')]
+    public function benchWithSingleStringParams(array $params): void
+    {
+    }
+
     #[ParamProviders([1])]
     public function benchWithInvalidAttributeDontBreakIt(array $params): void
     {
     }
 
     public function provideParams(): array
+    {
+        return [];
+    }
+
+    public function provideSingleStringParams(): array
     {
         return [];
     }


### PR DESCRIPTION
Fixes #377

## Problem

PHPBench support already exists, but the `#[ParamProviders('...')]` attribute used with a **single string** argument (instead of an array) was not handled — the referenced provider method was reported as dead code.

This is exactly the false positive reported in #377, e.g. infection's [`TracingBench::providePercentile`](https://github.com/infection/infection/blob/837f2860d395a411577269b98baa42272686e60e/tests/benchmark/Tracing/TracingBench.php#L76):

```php
#[ParamProviders('providePercentile')] // single string, not an array
public function bench(array $info): void { /* ... */ }
```

## Root cause

PhpBench's attribute accepts `string|array` and casts internally:

```php
// vendor/phpbench/phpbench/lib/Attributes/ParamProviders.php
public function __construct(array | string $providers) {
    $this->providers = (array)$providers;
}
```

But `PhpBenchUsageProvider::getParamProvidersFromAttributes()` only handled the array form and `continue`d on anything else, dropping the single-string case. The before/after attribute path already wrapped non-array arguments into an array — this brings param providers in line with it.

## Fix

Wrap a non-array argument into `[$providers]` instead of skipping it. Added fixture coverage for the single-string form in `tests/Rule/data/providers/phpbench.php` (previously only the array and annotation forms were tested).