### PR TITLE
Adopt new shipmonk/coding-standard custom sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan-symfony": "^2.0.15",
         "phpunit/phpcov": "^9.0.2",
         "phpunit/phpunit": "^10.5.46",
-        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
+        "shipmonk/coding-standard": "^0.3.0",
         "shipmonk/composer-dependency-analyser": "^1.8.4",
         "shipmonk/coverage-guard": "^1.0.2",
         "shipmonk/name-collision-detector": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan-symfony": "^2.0.15",
         "phpunit/phpcov": "^9.0.2",
         "phpunit/phpunit": "^10.5.46",
-        "shipmonk/coding-standard": "^0.2.2",
+        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
         "shipmonk/composer-dependency-analyser": "^1.8.4",
         "shipmonk/coverage-guard": "^1.0.2",
         "shipmonk/name-collision-detector": "^2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed15447247dcb8ead76fa32afaf8514b",
+    "content-hash": "efdb207f36aa08e895068779672cebb7",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -601,16 +601,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -693,7 +693,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -7663,21 +7663,23 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "0.2.4",
+            "version": "dev-add-generic-custom-sniffs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275"
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/ca7fa071f5943d87f67e791fe36a691a36d10275",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
                 "shasum": ""
             },
             "require": {
+                "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "slevomat/coding-standard": "^8.28.0"
+                "slevomat/coding-standard": "^8.28.0",
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.6",
@@ -7695,7 +7697,7 @@
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "ShipMonk\\CodingStandard\\": "ShipMonkCodingStandard/"
+                    "ShipMonkCodingStandard\\": "ShipMonkCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7705,9 +7707,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.4"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-03-16T16:23:10+00:00"
+            "time": "2026-06-22T07:30:14+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -8009,20 +8011,20 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.28.1",
+            "version": "8.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2"
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.3.2",
                 "squizlabs/php_codesniffer": "^4.0.1"
@@ -8030,11 +8032,11 @@
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.42",
+                "phpstan/phpstan": "2.1.54",
                 "phpstan/phpstan-deprecation-rules": "2.0.4",
                 "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.10",
-                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.50|12.5.14"
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -8058,7 +8060,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.28.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
             },
             "funding": [
                 {
@@ -8070,7 +8072,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-22T17:22:38+00:00"
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -12509,7 +12511,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "shipmonk/coding-standard": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efdb207f36aa08e895068779672cebb7",
+    "content-hash": "6f4a0db1ef161282a3ea56c4a2403d0b",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -7663,21 +7663,21 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "dev-add-generic-custom-sniffs",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/15182bf6b0e17682990c049dd17f593d3235ec62",
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "slevomat/coding-standard": "^8.28.0",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
@@ -7688,9 +7688,9 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.5.62",
                 "shipmonk/composer-dependency-analyser": "^1.8",
-                "shipmonk/dead-code-detector": "^0.12",
+                "shipmonk/dead-code-detector": "^1.0",
                 "shipmonk/name-collision-detector": "^2.1",
                 "shipmonk/phpstan-rules": "^4.1"
             },
@@ -7707,9 +7707,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.3.0"
             },
-            "time": "2026-06-22T07:30:14+00:00"
+            "time": "2026-06-23T07:41:40+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -12511,9 +12511,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shipmonk/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Collector/ClassDefinitionCollector.php
+++ b/src/Collector/ClassDefinitionCollector.php
@@ -206,7 +206,9 @@ final class ClassDefinitionCollector implements Collector
         return $traits;
     }
 
-    /** @return value-of<ClassLikeKind> */
+    /**
+     * @return value-of<ClassLikeKind>
+     */
     private function getKind(ClassLike $node): string
     {
         if ($node instanceof Class_) {

--- a/src/Provider/PhpBenchUsageProvider.php
+++ b/src/Provider/PhpBenchUsageProvider.php
@@ -235,7 +235,9 @@ final class PhpBenchUsageProvider implements MemberUsageProvider
         return $result;
     }
 
-    /** @return list<string> */
+    /**
+     * @return list<string>
+     */
     private function getParamProvidersFromAttributes(ReflectionMethod $method): array
     {
         $result = [];


### PR DESCRIPTION
Bumps `shipmonk/coding-standard` to `^0.3.0`, which adds the new ShipMonk custom sniffs, and applies the auto-fixable results (`phpcbf`). All violations were auto-fixable; no manual changes.

Co-Authored-By: Claude Code