### PR TITLE
Fix crash on debug usagesOf in only-files analysis

### DIFF
--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -51,6 +51,11 @@ final class DebugUsagePrinter
     private array $debugMembers;
 
     /**
+     * False until markAnalysedMembers() runs, which only happens for full (non only-files) analysis.
+     */
+    private bool $analysed = false;
+
+    /**
      * @param array{enabled: bool|null, deduplicateAcrossViews: bool} $bladeOptions
      */
     public function __construct(
@@ -233,6 +238,11 @@ final class DebugUsagePrinter
             return;
         }
 
+        if (!$this->analysed) {
+            $output->writeLineFormatted("\n<fg=yellow>Usage debugging is unavailable in single-file analysis; point the analysed paths at a directory.</>");
+            return;
+        }
+
         if ($this->bladeDedupActive) {
             $output->writeLineFormatted('');
             $output->writeLineFormatted('<fg=yellow>Warning: Blade view-data usages are deduplicated across call sites</>');
@@ -368,6 +378,8 @@ final class DebugUsagePrinter
      */
     public function markAnalysedMembers(array $blackMembers): void
     {
+        $this->analysed = true;
+
         foreach ($this->debugMembers as $memberKey => $debugMember) {
             $this->debugMembers[$memberKey]['analysed'] = isset($blackMembers[$memberKey]);
         }

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -239,7 +239,7 @@ final class DebugUsagePrinter
         }
 
         if (!$this->analysed) {
-            $output->writeLineFormatted("\n<fg=yellow>Usage debugging is unavailable in single-file analysis; point the analysed paths at a directory.</>");
+            $output->writeLineFormatted("\n<fg=yellow>Usage debugging is unavailable in files-only analysis.</>");
             return;
         }
 

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -450,6 +450,26 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         self::assertSame($expectedOutput . "\n", $this->trimFgColors($actualOutput));
     }
 
+    public function testDebugUsageSkippedInOnlyFilesAnalysis(): void
+    {
+        // In only-files analysis (e.g. editor on-the-fly single-file checks), DeadCodeRule::processNode()
+        // short-circuits before markAnalysedMembers() runs. The debug printer must degrade gracefully
+        // instead of asserting the missing 'analysed' flag. Skipping the analysis here mimics that short-circuit.
+        $this->debugMembers = ['DateTime::format'];
+
+        $rule = $this->getRule();
+
+        $actualOutput = '';
+        $rule->print($this->getOutputMock($actualOutput));
+
+        $expectedOutput = <<<'OUTPUT'
+
+        Usage debugging is unavailable in single-file analysis; point the analysed paths at a directory.
+        OUTPUT;
+
+        self::assertSame($expectedOutput . "\n", $this->trimFgColors($actualOutput));
+    }
+
     public function testDebugUsageOriginLink(): void
     {
         $this->editorUrl = '( %relFile% at line %line% )';

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -452,9 +452,6 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
     public function testDebugUsageSkippedInOnlyFilesAnalysis(): void
     {
-        // In only-files analysis (e.g. editor on-the-fly single-file checks), DeadCodeRule::processNode()
-        // short-circuits before markAnalysedMembers() runs. The debug printer must degrade gracefully
-        // instead of asserting the missing 'analysed' flag. Skipping the analysis here mimics that short-circuit.
         $this->debugMembers = ['DateTime::format'];
 
         $rule = $this->getRule();
@@ -464,7 +461,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
         $expectedOutput = <<<'OUTPUT'
 
-        Usage debugging is unavailable in single-file analysis; point the analysed paths at a directory.
+        Usage debugging is unavailable in files-only analysis.
         OUTPUT;
 
         self::assertSame($expectedOutput . "\n", $this->trimFgColors($actualOutput));


### PR DESCRIPTION
## Problem

With `shipmonkDeadCode.debug.usagesOf` set, running PHPStan at `-vvv` verbosity against **only-files** input (e.g. an editor's on-the-fly single-file check) crashed with:

```
LogicException: Debug member should always have analysed flag set, markAnalysedMembers not called?
```

All three conditions are required to trigger it:

| paths       | verbosity | result                  |
|-------------|-----------|-------------------------|
| single file | `-vvv`    | 💥 LogicException       |
| single file | normal    | OK (`Found 1 error`)    |
| directory   | `-vvv`    | OK (prints debug info)  |

## Root cause

`DeadCodeRule::processNode()` short-circuits in only-files mode **before** it calls `markAnalysedMembers()`, which is what stamps the `analysed` flag onto every debug member:

```php
if ($node->isOnlyFilesAnalysis()) {
    return [];   // bails out here, never reaches markAnalysedMembers()
}
```

The `print()` diagnose hook runs unconditionally at end-of-analysis. `printDebugMemberUsages()` only early-returns on the verbosity check, then asserts the flag that was never set — so `-vvv` + non-empty `debug.usagesOf` forces it past the early return into the assertion.

## Fix

Track whether `markAnalysedMembers()` ran (it only runs on full, non-only-files analysis) and, when it did not, print a graceful one-liner instead of asserting the never-set flag:

> Usage debugging is unavailable in single-file analysis; point the analysed paths at a directory.

The `LogicException` invariant is kept intact — it now only guards the genuine post-analysis path.

A regression test reproduces the original crash without the fix and verifies the graceful notice with it.

Co-Authored-By: Claude Code