### PR TITLE
Match method usages case-insensitively

### DIFF
--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -91,16 +91,16 @@ final class DebugUsagePrinter
         $mixedClassNameUsages = [];
 
         foreach ($mixedMemberUsages as $memberType => $collectedUsagesByMemberName) {
-            foreach ($collectedUsagesByMemberName as $memberName => $collectedUsages) {
+            foreach ($collectedUsagesByMemberName as $normalizedMemberNameOrAny => $collectedUsages) {
                 foreach ($collectedUsages as $collectedUsage) {
                     if ($collectedUsage->isExcluded()) {
                         continue;
                     }
 
-                    if ($memberName === self::ANY_MEMBER) {
+                    if ($normalizedMemberNameOrAny === self::ANY_MEMBER) {
                         $mixedEverythingUsages[$memberType][] = $collectedUsage;
                     } else {
-                        $mixedClassNameUsages[$memberType][$memberName][] = $collectedUsage;
+                        $mixedClassNameUsages[$memberType][$normalizedMemberNameOrAny][] = $collectedUsage;
                     }
                 }
             }
@@ -130,11 +130,11 @@ final class DebugUsagePrinter
         $output->writeLineFormatted(sprintf('<fg=yellow>Found %d usage%s over unknown type</>:', $totalCount, $plural));
 
         foreach ($mixedMemberUsages as $memberType => $collectedUsages) {
-            foreach ($collectedUsages as $memberName => $usages) {
+            foreach ($collectedUsages as $normalizedMemberName => $usages) {
                 $examplesShown++;
                 $memberTypeString = $this->getMemberTypeString(MemberType::from($memberType)); // @phpstan-ignore missingType.checkedException, missingType.checkedException
                 // method buckets are keyed in lowercase (case-insensitive matching), so show the original-case name from the usage
-                $displayName = $usages[0]->getUsage()->getMemberRef()->getMemberName() ?? $memberName;
+                $displayName = $usages[0]->getUsage()->getMemberRef()->getMemberName() ?? $normalizedMemberName;
                 $output->writeFormatted(sprintf(' • <fg=white>%s</> %s', $displayName, $memberTypeString));
 
                 $exampleCaller = $this->getExampleCaller($usages);

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -133,7 +133,9 @@ final class DebugUsagePrinter
             foreach ($collectedUsages as $memberName => $usages) {
                 $examplesShown++;
                 $memberTypeString = $this->getMemberTypeString(MemberType::from($memberType)); // @phpstan-ignore missingType.checkedException, missingType.checkedException
-                $output->writeFormatted(sprintf(' • <fg=white>%s</> %s', $memberName, $memberTypeString));
+                // method buckets are keyed in lowercase (case-insensitive matching), so show the original-case name from the usage
+                $displayName = $usages[0]->getUsage()->getMemberRef()->getMemberName() ?? $memberName;
+                $output->writeFormatted(sprintf(' • <fg=white>%s</> %s', $displayName, $memberTypeString));
 
                 $exampleCaller = $this->getExampleCaller($usages);
                 $output->writeFormatted(sprintf(', for example in <fg=white>%s</>', $exampleCaller));

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -119,7 +119,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
     private array $blackMembers = [];
 
     /**
-     * memberType => [memberName => CollectedUsage[]]
+     * memberType => [normalizedMemberNameOrAny => CollectedUsage[]] where the index is the normalized member name or the ANY_MEMBER sentinel
      *
      * @var array<value-of<MemberType>, array<string, non-empty-list<CollectedUsage>>>
      */
@@ -190,10 +190,10 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
                         if ($className === null) {
                             $memberType = $memberUsage->getMemberType()->value;
-                            $memberNameString = $memberName === null
+                            $normalizedMemberNameOrAny = $memberName === null
                                 ? DebugUsagePrinter::ANY_MEMBER
-                                : $this->getMixedUsageMemberKey($memberType, $memberName);
-                            $this->mixedClassNameUsages[$memberType][$memberNameString][] = $collectedUsage;
+                                : $this->getNormalizedMemberName($memberType, $memberName);
+                            $this->mixedClassNameUsages[$memberType][$normalizedMemberNameOrAny][] = $collectedUsage;
                             continue;
                         }
 
@@ -309,9 +309,9 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
             foreach ($memberNamesForMixedExpand as $memberType => $memberNames) {
                 foreach ($memberNames as $memberName) {
-                    $mixedUsageKey = $this->getMixedUsageMemberKey($memberType, $memberName);
+                    $normalizedMemberName = $this->getNormalizedMemberName($memberType, $memberName);
 
-                    foreach ($this->mixedClassNameUsages[$memberType][$mixedUsageKey] ?? [] as $mixedUsage) {
+                    foreach ($this->mixedClassNameUsages[$memberType][$normalizedMemberName] ?? [] as $mixedUsage) {
                         $knownCollectedUsages[] = $mixedUsage->concretizeMixedClassNameUsage($typeName);
                     }
                 }
@@ -1047,7 +1047,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
      *
      * @param value-of<MemberType> $memberType
      */
-    private function getMixedUsageMemberKey(
+    private function getNormalizedMemberName(
         int $memberType,
         string $memberName,
     ): string

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -46,6 +46,8 @@ use function in_array;
 use function ksort;
 use function serialize;
 use function str_starts_with;
+use function strcasecmp;
+use function strtolower;
 
 /**
  * @implements Rule<CollectedDataNode>
@@ -187,8 +189,11 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
                         $memberName = $memberUsage->getMemberRef()->getMemberName();
 
                         if ($className === null) {
-                            $memberNameString = $memberName ?? DebugUsagePrinter::ANY_MEMBER;
-                            $this->mixedClassNameUsages[$memberUsage->getMemberType()->value][$memberNameString][] = $collectedUsage;
+                            $memberType = $memberUsage->getMemberType()->value;
+                            $memberNameString = $memberName === null
+                                ? DebugUsagePrinter::ANY_MEMBER
+                                : $this->getMixedUsageMemberKey($memberType, $memberName);
+                            $this->mixedClassNameUsages[$memberType][$memberNameString][] = $collectedUsage;
                             continue;
                         }
 
@@ -304,7 +309,9 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
             foreach ($memberNamesForMixedExpand as $memberType => $memberNames) {
                 foreach ($memberNames as $memberName) {
-                    foreach ($this->mixedClassNameUsages[$memberType][$memberName] ?? [] as $mixedUsage) {
+                    $mixedUsageKey = $this->getMixedUsageMemberKey($memberType, $memberName);
+
+                    foreach ($this->mixedClassNameUsages[$memberType][$mixedUsageKey] ?? [] as $mixedUsage) {
                         $knownCollectedUsages[] = $mixedUsage->concretizeMixedClassNameUsage($typeName);
                     }
                 }
@@ -574,8 +581,11 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         bool $includeParentLookup = true,
     ): array
     {
-        if ($this->isExistingRef($memberRef)) {
-            return $memberRef->toKeys($accessType);
+        $definedMemberName = $this->findDefinedMemberName($memberRef);
+
+        if ($definedMemberName !== null) {
+            // use the declared-case name so the usage matches the definition even when called with a different case
+            return $memberRef->withKnownMember($definedMemberName)->toKeys($accessType);
         }
 
         // search for definition in traits
@@ -673,10 +683,14 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         $memberType = $memberRef->getMemberType();
         $className = $memberRef->getClassName();
         $memberName = $memberRef->getMemberName();
+        $caseInsensitive = $memberRef instanceof ClassMethodRef; // method names are case-insensitive in PHP
 
         foreach ($this->traitMembers[$memberType->value][$className] ?? [] as $traitName => $traitMemberNames) {
             foreach ($traitMemberNames as $aliasedMemberName => $traitMemberName) {
-                if ($memberName === $aliasedMemberName) {
+                if (
+                    $memberName === $aliasedMemberName
+                    || ($caseInsensitive && strcasecmp($aliasedMemberName, $memberName) === 0)
+                ) {
                     return $memberRef->withKnownNames($traitName, $traitMemberName)->toKeys($accessType);
                 }
             }
@@ -947,23 +961,38 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
     }
 
     /**
+     * Returns the name of the member as actually declared on the class, or null if it does not exist there.
+     * Method lookups are case-insensitive (PHP method names are), so the returned name may differ in case
+     * from the one in $memberRef - that declared-case name is then used for graph matching and reporting.
+     *
      * @param ClassMemberRef<string, string> $memberRef
      */
-    private function isExistingRef(
+    private function findDefinedMemberName(
         ClassMemberRef $memberRef,
-    ): bool
+    ): ?string
     {
         $typeName = $memberRef->getClassName();
         $memberName = $memberRef->getMemberName();
+        $caseInsensitive = $memberRef instanceof ClassMethodRef; // method names are case-insensitive in PHP
 
         $keys = $this->getTypeDefinitionKeysForMemberType($memberRef);
 
         foreach ($keys as $key) {
-            if (array_key_exists($memberName, $this->typeDefinitions[$typeName][$key] ?? [])) {
-                return true;
+            $definedMembers = $this->typeDefinitions[$typeName][$key] ?? [];
+
+            if (array_key_exists($memberName, $definedMembers)) {
+                return $memberName;
+            }
+
+            if ($caseInsensitive) {
+                foreach (array_keys($definedMembers) as $definedName) {
+                    if (strcasecmp($definedName, $memberName) === 0) {
+                        return $definedName;
+                    }
+                }
             }
         }
-        return false;
+        return null;
     }
 
     /**
@@ -1010,6 +1039,20 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         }
 
         throw new LogicException('Invalid member type');
+    }
+
+    /**
+     * Member name used to bucket usages with unknown class name. Method names are normalized to lowercase
+     * since they are case-insensitive in PHP; other member types stay case-sensitive.
+     *
+     * @param value-of<MemberType> $memberType
+     */
+    private function getMixedUsageMemberKey(
+        int $memberType,
+        string $memberName,
+    ): string
+    {
+        return $memberType === MemberType::METHOD->value ? strtolower($memberName) : $memberName;
     }
 
     /**

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -925,6 +925,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'method-callables' => [__DIR__ . '/data/methods/callables.php'];
         yield 'method-array-callable-dynamic-name' => [__DIR__ . '/data/methods/array-callable-dynamic-name.php', self::requiresPackage('phpstan/phpstan', '>= 2.1.54')]; // is_callable() narrowing of [$obj, $method] arrays exists since 2.1.54
         yield 'method-code' => [__DIR__ . '/data/methods/basic.php'];
+        yield 'method-case-insensitive' => [__DIR__ . '/data/methods/case-insensitive.php'];
         yield 'method-ctor' => [__DIR__ . '/data/methods/ctor.php'];
         yield 'method-ctor-interface' => [__DIR__ . '/data/methods/ctor-interface.php'];
         yield 'method-ctor-private' => [__DIR__ . '/data/methods/ctor-private.php'];

--- a/tests/Rule/data/methods/case-insensitive.php
+++ b/tests/Rule/data/methods/case-insensitive.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace DeadCaseInsensitive;
+
+class Calculator
+{
+
+    public function getIdByReference(): int // used below via a differently-cased call
+    {
+        return 1;
+    }
+
+    public static function createInstance(): self // used below via a differently-cased static call
+    {
+        return new self();
+    }
+
+    public function reallyUnused(): void // error: Unused DeadCaseInsensitive\Calculator::reallyUnused
+    {
+    }
+
+}
+
+trait GreetingTrait
+{
+
+    public function sayHello(): string // used below via a differently-cased call on the consumer
+    {
+        return 'hi';
+    }
+
+}
+
+class Service
+{
+
+    use GreetingTrait;
+
+    public function run(Calculator $calc): void
+    {
+        $calc->getIdByreference();    // lowercase 'r'
+        Calculator::CREATEINSTANCE(); // upper-cased static call
+        $this->SAYHELLO();            // upper-cased trait method call
+    }
+
+}
+
+function entry(Service $service, Calculator $calc): void
+{
+    $service->Run($calc); // upper-cased 'R'
+}


### PR DESCRIPTION
## Problem

PHP method names are case-insensitive — `$obj->getName()` and `$obj->getNAME()` call the same method. But the detector matched method *usages* against *definitions* by exact-case keys, so a differently-cased call did not mark the method used and it was reported as dead:

```php
class Repo
{
    public function getIdByReference(): int { /* ... */ }
}

$repo->getIdByreference(); // note the lowercase 'r' — valid PHP, same method
```

Here `Repo::getIdByReference()` was reported as unused, even though it is called above. This is the scenario from #383 (the reporter hit it via a real `getIdByReference` / `getIdByreference` typo-but-valid call).

## Root cause

Usages and definitions are matched through string keys of the form `m/Class::member`, built by `ClassMemberRef::toKeys()`. The class name comes from PHPStan reflection (already canonical), but the method name on the usage side comes straight from the AST (`$call->name->toString()`) — i.e. whatever case was typed. So `m/Repo::getIdByreference` (usage) never collided with `m/Repo::getIdByReference` (definition), and the definition stayed in the dead set.

## Fix

Resolve a method usage to the **declared-case** name at match time, for methods only:

- `DeadCodeRule::findDefinedMemberName()` (was `isExistingRef()`) now looks up the member case-insensitively **for `ClassMethodRef` only** and returns the name as actually declared on the class. `findDefinerKeys()` rebuilds the ref with that name before producing keys, so the usage key matches the definition key.
- Trait-alias resolution (`getDeclaringTraitKeys()`) and the unknown-class/mixed-usage bucket (`getNormalizedMemberName()`) are likewise case-insensitive for methods.
- Because the reported `BlackMember` is still built from the declared definition, **error messages keep the original declared case** (`Repo::getIdByReference`) — no lowercased names leak into output.

Constants, enum cases and properties remain **case-sensitive**, as PHP requires — only `ClassMethodRef` lookups are normalized.

## Scope / note on "functions"

#383 is titled around *functions*, but the detector only analyzes **class members** — standalone/global functions are not tracked at all. The reporter's actual case was a class **method**, which is what this PR fixes. Method names are the case-insensitive identifier here; the fix covers direct, static, nullsafe, inherited, trait (incl. `as` aliases), interface, descendant and first-class-callable calls.

## Verification

Beyond the new `case-insensitive.php` fixture, the change was stress-tested by uppercasing **every method call site** across all rule fixtures (~350 call sites in ~120 files) while leaving definitions and expected error output canonical: all dead-code classification fixtures pass unchanged, confirming the resolution covers every usage form.

## Known, out-of-scope limitation

Library *providers* and user-configured *excluders* detect framework APIs by literal method name **case-sensitively** (e.g. `ReflectionUsageProvider` matches `=== 'getMethod'`, Nette matches the `handle`/`render` prefixes, etc.). A non-canonically-cased call like `$r->GETMETHOD('x')` would slip past that detection. This is a separate, pre-existing concern from the call-graph matching fixed here, has effectively zero real-world impact (IDEs/PSR/convention enforce canonical casing), and will be addressed separately.

Closes #383

Co-Authored-By: Claude Code
