### PR TITLE
Match method/function names case-insensitively in usage providers

### DIFF
--- a/src/Naming/CaseInsensitiveName.php
+++ b/src/Naming/CaseInsensitiveName.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace ShipMonk\PHPStan\DeadCode\Provider;
+namespace ShipMonk\PHPStan\DeadCode\Naming;
 
 use function array_map;
 use function in_array;

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -18,6 +18,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use function strpos;
+use function strtolower;
 use function substr;
 
 final class BladeUsageProvider implements MemberUsageProvider
@@ -91,7 +92,7 @@ final class BladeUsageProvider implements MemberUsageProvider
             return [];
         }
 
-        if ($node->name->toString() !== 'view') {
+        if (!CaseInsensitiveName::equals($node->name->toString(), 'view')) {
             return [];
         }
 
@@ -120,7 +121,7 @@ final class BladeUsageProvider implements MemberUsageProvider
 
         $methodName = $node->name->toString();
 
-        if (!isset(self::VIEW_FACADE_METHODS[$methodName])) {
+        if (!isset(self::VIEW_FACADE_METHODS[strtolower($methodName)])) {
             return [];
         }
 
@@ -139,7 +140,7 @@ final class BladeUsageProvider implements MemberUsageProvider
                 $classReflection->is('Illuminate\Support\Facades\View')
                 || $classReflection->is('Illuminate\Contracts\View\Factory')
             ) {
-                if ($methodName === 'make' || $methodName === 'first') {
+                if (CaseInsensitiveName::equals($methodName, 'make') || CaseInsensitiveName::equals($methodName, 'first')) {
                     $args = $node->getArgs();
 
                     if (!isset($args[1])) {
@@ -176,7 +177,7 @@ final class BladeUsageProvider implements MemberUsageProvider
         $usages = [];
 
         // View::composer → compose, View::creator → create (see Illuminate\View\Concerns\ManagesEvents::classEventMethodForPrefix)
-        $defaultMethod = $methodName === 'composer' ? 'compose' : 'create';
+        $defaultMethod = CaseInsensitiveName::equals($methodName, 'composer') ? 'compose' : 'create';
 
         foreach ($callbackType->getConstantStrings() as $stringType) {
             $value = $stringType->getValue();
@@ -232,7 +233,7 @@ final class BladeUsageProvider implements MemberUsageProvider
             $classReflection = $this->reflectionProvider->getClass($className);
 
             if ($classReflection->is('Illuminate\Contracts\View\Factory')) {
-                if ($methodName === 'make' || $methodName === 'first') {
+                if (CaseInsensitiveName::equals($methodName, 'make') || CaseInsensitiveName::equals($methodName, 'first')) {
                     $args = $node->getArgs();
 
                     if (!isset($args[1])) {
@@ -242,13 +243,13 @@ final class BladeUsageProvider implements MemberUsageProvider
                     return $this->traverseDataArg($args[1]->value, $node, $scope);
                 }
 
-                if ($methodName === 'composer' || $methodName === 'creator') {
+                if (CaseInsensitiveName::equals($methodName, 'composer') || CaseInsensitiveName::equals($methodName, 'creator')) {
                     return $this->getUsagesFromComposerOrCreator($node, $node->getArgs(), $scope, $methodName);
                 }
             }
 
             if ($classReflection->is('Illuminate\Contracts\Routing\ResponseFactory')) {
-                if ($methodName === 'view') {
+                if (CaseInsensitiveName::equals($methodName, 'view')) {
                     $args = $node->getArgs();
 
                     if (!isset($args[1])) {
@@ -260,7 +261,7 @@ final class BladeUsageProvider implements MemberUsageProvider
             }
 
             if ($classReflection->is('Illuminate\Contracts\View\View')) {
-                if ($methodName === 'with') {
+                if (CaseInsensitiveName::equals($methodName, 'with')) {
                     return $this->getUsagesFromWithCall($node, $scope);
                 }
             }

--- a/src/Provider/BladeUsageProvider.php
+++ b/src/Provider/BladeUsageProvider.php
@@ -17,6 +17,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function strpos;
 use function strtolower;
 use function substr;

--- a/src/Provider/CaseInsensitiveName.php
+++ b/src/Provider/CaseInsensitiveName.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use function array_map;
+use function in_array;
+use function str_ends_with;
+use function str_starts_with;
+use function strcasecmp;
+use function strtolower;
+
+/**
+ * Helpers for matching method and function names, which PHP compares case-insensitively.
+ *
+ * Providers detect magic members by name (e.g. `getMethod`, `handleXxx`, lifecycle events). The actual
+ * call or declaration may use a different case than the literal we compare against, yet PHP would still
+ * dispatch to the same method/function - so all such comparisons must ignore case to match runtime.
+ *
+ * Only use this for method/function names. Constant names, enum case names and (config/route/service)
+ * strings are case-sensitive and must keep using plain comparisons.
+ */
+final class CaseInsensitiveName
+{
+
+    public static function equals(
+        string $name,
+        string $other,
+    ): bool
+    {
+        return strcasecmp($name, $other) === 0;
+    }
+
+    public static function startsWith(
+        string $name,
+        string $prefix,
+    ): bool
+    {
+        return str_starts_with(strtolower($name), strtolower($prefix));
+    }
+
+    public static function endsWith(
+        string $name,
+        string $suffix,
+    ): bool
+    {
+        return str_ends_with(strtolower($name), strtolower($suffix));
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    public static function isOneOf(
+        string $name,
+        array $names,
+    ): bool
+    {
+        return in_array(strtolower($name), array_map('strtolower', $names), true);
+    }
+
+}

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -23,6 +23,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function is_string;
 use function str_starts_with;
 

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -23,6 +23,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function is_string;
 use function str_starts_with;
 
 final class DoctrineUsageProvider implements MemberUsageProvider
@@ -128,7 +129,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             return [];
         }
 
-        if ($scope->getFunction()->getName() !== 'getSubscribedEvents') {
+        if (!CaseInsensitiveName::equals($scope->getFunction()->getName(), 'getSubscribedEvents')) {
             return [];
         }
 
@@ -224,21 +225,23 @@ final class DoctrineUsageProvider implements MemberUsageProvider
      */
     private function isProbablyDoctrineListener(string $methodName): bool
     {
-        return $methodName === 'preRemove'
-            || $methodName === 'postRemove'
-            || $methodName === 'prePersist'
-            || $methodName === 'postPersist'
-            || $methodName === 'preUpdate'
-            || $methodName === 'postUpdate'
-            || $methodName === 'postLoad'
-            || $methodName === 'loadClassMetadata'
-            || $methodName === 'onClassMetadataNotFound'
-            || $methodName === 'preFlush'
-            || $methodName === 'onFlush'
-            || $methodName === 'postFlush'
-            || $methodName === 'onClear'
-            || $methodName === 'postGenerateSchemaTable'
-            || $methodName === 'postGenerateSchema';
+        return CaseInsensitiveName::isOneOf($methodName, [
+            'preRemove',
+            'postRemove',
+            'prePersist',
+            'postPersist',
+            'preUpdate',
+            'postUpdate',
+            'postLoad',
+            'loadClassMetadata',
+            'onClassMetadataNotFound',
+            'preFlush',
+            'onFlush',
+            'postFlush',
+            'onClear',
+            'postGenerateSchemaTable',
+            'postGenerateSchema',
+        ]);
     }
 
     private function hasAttribute(
@@ -257,7 +260,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
         foreach ($class->getAttributes('Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener') as $attribute) {
             $listenerMethodName = $attribute->getArguments()['method'] ?? $attribute->getArguments()[1] ?? null;
 
-            if ($listenerMethodName === $methodName) {
+            if (is_string($listenerMethodName) && CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
                 return true;
             }
         }
@@ -275,7 +278,10 @@ final class DoctrineUsageProvider implements MemberUsageProvider
 
             // AsDoctrineListener doesn't have a 'method' parameter
             // Symfony looks for a method named after the event, or falls back to __invoke
-            if ($eventName === $methodName || $methodName === '__invoke') {
+            if (
+                (is_string($eventName) && CaseInsensitiveName::equals($eventName, $methodName))
+                || CaseInsensitiveName::equals($methodName, '__invoke')
+            ) {
                 return true;
             }
         }
@@ -303,10 +309,10 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             if ($listenerMethodName === null) {
                 $eventName = $arguments['event'] ?? null;
 
-                if ($eventName === $methodName) {
+                if (is_string($eventName) && CaseInsensitiveName::equals($eventName, $methodName)) {
                     return true;
                 }
-            } elseif ($listenerMethodName === $methodName) {
+            } elseif (is_string($listenerMethodName) && CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
                 return true;
             }
         }

--- a/src/Provider/EloquentUsageProvider.php
+++ b/src/Provider/EloquentUsageProvider.php
@@ -17,6 +17,7 @@ use PHPStan\Type\ObjectType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function is_array;
 use function is_string;
 use function str_starts_with;

--- a/src/Provider/EloquentUsageProvider.php
+++ b/src/Provider/EloquentUsageProvider.php
@@ -17,10 +17,8 @@ use PHPStan\Type\ObjectType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
-use function in_array;
 use function is_array;
 use function is_string;
-use function str_ends_with;
 use function str_starts_with;
 use function strlen;
 
@@ -211,11 +209,11 @@ final class EloquentUsageProvider implements MemberUsageProvider
             return 'Eloquent model constructor';
         }
 
-        if (in_array($methodName, ['boot', 'booted', 'casts', 'newFactory'], true)) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['boot', 'booted', 'casts', 'newFactory'])) {
             return 'Eloquent lifecycle/framework method';
         }
 
-        if (str_starts_with($methodName, 'scope') && $methodName !== 'scope') {
+        if (CaseInsensitiveName::startsWith($methodName, 'scope') && !CaseInsensitiveName::equals($methodName, 'scope')) {
             return 'Eloquent query scope';
         }
 
@@ -243,12 +241,12 @@ final class EloquentUsageProvider implements MemberUsageProvider
         $length = strlen($methodName);
 
         // Minimum: get + X + Attribute = 13 chars, same for set
-        if ($length <= 12 || !str_ends_with($methodName, 'Attribute')) {
+        if ($length <= 12 || !CaseInsensitiveName::endsWith($methodName, 'Attribute')) {
             return false;
         }
 
-        return str_starts_with($methodName, 'get')
-            || str_starts_with($methodName, 'set');
+        return CaseInsensitiveName::startsWith($methodName, 'get')
+            || CaseInsensitiveName::startsWith($methodName, 'set');
     }
 
     private function isFactoryMethod(
@@ -260,7 +258,7 @@ final class EloquentUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if (in_array($method->getName(), ['definition', 'configure'], true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), ['definition', 'configure'])) {
             return 'Eloquent factory method';
         }
 
@@ -276,7 +274,7 @@ final class EloquentUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if ($method->getName() === 'run') {
+        if (CaseInsensitiveName::equals($method->getName(), 'run')) {
             return 'Eloquent seeder method';
         }
 
@@ -292,7 +290,7 @@ final class EloquentUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if (in_array($method->getName(), ['up', 'down'], true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), ['up', 'down'])) {
             return 'Eloquent migration method';
         }
 

--- a/src/Provider/EnumUsageProvider.php
+++ b/src/Provider/EnumUsageProvider.php
@@ -20,7 +20,6 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use UnitEnum;
 use function array_filter;
-use function in_array;
 use function is_int;
 use function is_string;
 
@@ -76,7 +75,7 @@ final class EnumUsageProvider implements MemberUsageProvider
         $result = [];
 
         foreach ($methodNames as $methodName) {
-            if (!in_array($methodName, ['tryFrom', 'from', 'cases'], true)) {
+            if ($methodName === null || !CaseInsensitiveName::isOneOf($methodName, ['tryFrom', 'from', 'cases'])) {
                 continue;
             }
 

--- a/src/Provider/EnumUsageProvider.php
+++ b/src/Provider/EnumUsageProvider.php
@@ -18,6 +18,7 @@ use ReflectionEnumBackedCase;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use UnitEnum;
 use function array_filter;
 use function is_int;

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -20,6 +20,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function array_map;
 use function array_slice;
 use function count;

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -25,12 +25,10 @@ use function array_slice;
 use function count;
 use function explode;
 use function implode;
-use function in_array;
 use function lcfirst;
 use function str_contains;
 use function str_ends_with;
 use function str_replace;
-use function str_starts_with;
 use function strpos;
 use function strrpos;
 use function substr;
@@ -152,7 +150,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         $methodName = $node->name->name;
         $usages = [];
 
-        if (in_array($methodName, ['get', 'post', 'put', 'patch', 'delete', 'any'], true)) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['get', 'post', 'put', 'patch', 'delete', 'any'])) {
             foreach ($this->extractCallablesFromArg($node, $scope, 1) as [$className, $method]) {
                 foreach ([$method, '__construct'] as $usedMethod) {
                     $usages[] = new ClassMethodUsage(
@@ -183,7 +181,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($methodName === 'match') {
+        if (CaseInsensitiveName::equals($methodName, 'match')) {
             foreach ($this->extractCallablesFromArg($node, $scope, 2) as [$className, $method]) {
                 foreach ([$method, '__construct'] as $usedMethod) {
                     $usages[] = new ClassMethodUsage(
@@ -214,7 +212,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($methodName === 'resource') {
+        if (CaseInsensitiveName::equals($methodName, 'resource')) {
             $resourceMethods = ['__construct', 'index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
             foreach ($this->extractClassNamesFromArg($node, $scope, 1) as $className) {
@@ -227,7 +225,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($methodName === 'apiResource') {
+        if (CaseInsensitiveName::equals($methodName, 'apiResource')) {
             $apiResourceMethods = ['__construct', 'index', 'store', 'show', 'update', 'destroy'];
 
             foreach ($this->extractClassNamesFromArg($node, $scope, 1) as $className) {
@@ -258,7 +256,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         $methodName = $node->name->name;
         $usages = [];
 
-        if ($methodName === 'listen') {
+        if (CaseInsensitiveName::equals($methodName, 'listen')) {
             foreach ($this->extractClassNamesFromArg($node, $scope, 1) as $className) {
                 foreach (['handle', '__construct'] as $method) {
                     $usages[] = new ClassMethodUsage(
@@ -269,7 +267,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($methodName === 'subscribe') {
+        if (CaseInsensitiveName::equals($methodName, 'subscribe')) {
             foreach ($this->extractClassNamesFromArg($node, $scope, 0) as $className) {
                 foreach (['subscribe', '__construct'] as $method) {
                     $usages[] = new ClassMethodUsage(
@@ -298,7 +296,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         $methodName = $node->name->name;
         $usages = [];
 
-        if ($methodName === 'job') {
+        if (CaseInsensitiveName::equals($methodName, 'job')) {
             foreach ($this->extractClassNamesFromArg($node, $scope, 0) as $className) {
                 foreach (['handle', '__construct'] as $method) {
                     $usages[] = new ClassMethodUsage(
@@ -327,7 +325,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         $methodName = $node->name->name;
         $usages = [];
 
-        if ($methodName === 'define') {
+        if (CaseInsensitiveName::equals($methodName, 'define')) {
             foreach ($this->extractCallablesFromArg($node, $scope, 1) as [$className, $method]) {
                 foreach ([$method, '__construct'] as $usedMethod) {
                     $usages[] = new ClassMethodUsage(
@@ -347,13 +345,13 @@ final class LaravelUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($methodName === 'policy') {
+        if (CaseInsensitiveName::equals($methodName, 'policy')) {
             foreach ($this->extractClassNamesFromArg($node, $scope, 1) as $policyClassName) {
                 $usages = [...$usages, ...$this->markAllPublicPolicyMethods($policyClassName, UsageOrigin::createRegular($node, $scope))];
             }
         }
 
-        if (in_array($methodName, ['allows', 'denies', 'check', 'any', 'none', 'authorize'], true)) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['allows', 'denies', 'check', 'any', 'none', 'authorize'])) {
             $usages = [...$usages, ...$this->getUsagesFromAbilityArgs($node->getArgs(), $scope, $node)];
         }
 
@@ -374,7 +372,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $methodName = $node->name->name;
 
-        if (!in_array($methodName, ['authorize', 'can', 'cannot', 'cant'], true)) {
+        if (!CaseInsensitiveName::isOneOf($methodName, ['authorize', 'can', 'cannot', 'cant'])) {
             return [];
         }
 
@@ -387,11 +385,11 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
             $callerReflection = $this->reflectionProvider->getClass($callerClassName);
 
-            if ($methodName === 'authorize') {
+            if (CaseInsensitiveName::equals($methodName, 'authorize')) {
                 if ($callerReflection->hasTraitUse('Illuminate\Foundation\Auth\Access\AuthorizesRequests')) {
                     return $this->getUsagesFromAbilityArgs($node->getArgs(), $scope, $node);
                 }
-            } elseif ($methodName === 'can') {
+            } elseif (CaseInsensitiveName::equals($methodName, 'can')) {
                 if (
                     $callerReflection->is('Illuminate\Contracts\Auth\Access\Authorizable')
                     || $callerReflection->hasTraitUse('Illuminate\Foundation\Auth\Access\Authorizable')
@@ -684,7 +682,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if ($method->isConstructor() || $method->getName() === 'handle') {
+        if ($method->isConstructor() || CaseInsensitiveName::equals($method->getName(), 'handle')) {
             return 'Laravel console command method';
         }
 
@@ -708,7 +706,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             'uniqueId', 'tags', 'backoff', 'uniqueVia', 'displayName',
         ];
 
-        if (in_array($method->getName(), $jobMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $jobMethods)) {
             return 'Laravel job method';
         }
 
@@ -724,7 +722,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if ($method->isConstructor() || in_array($method->getName(), ['register', 'boot'], true)) {
+        if ($method->isConstructor() || CaseInsensitiveName::isOneOf($method->getName(), ['register', 'boot'])) {
             return 'Laravel service provider method';
         }
 
@@ -738,7 +736,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
     {
         $methodName = $method->getName();
 
-        if ($methodName !== 'handle' && $methodName !== 'terminate' && !$method->isConstructor()) {
+        if (!CaseInsensitiveName::equals($methodName, 'handle') && !CaseInsensitiveName::equals($methodName, 'terminate') && !$method->isConstructor()) {
             return null;
         }
 
@@ -781,7 +779,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             'via', 'toMail', 'toArray', 'toDatabase', 'toBroadcast', 'toVonage', 'toSlack',
         ];
 
-        if (in_array($methodName, $notificationMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($methodName, $notificationMethods)) {
             return 'Laravel notification method';
         }
 
@@ -802,7 +800,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             'prepareForValidation', 'passedValidation', 'failedValidation', 'failedAuthorization',
         ];
 
-        if (in_array($method->getName(), $formRequestMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $formRequestMethods)) {
             return 'Laravel form request method';
         }
 
@@ -831,7 +829,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore', 'forceDelete',
         ];
 
-        if (in_array($method->getName(), $policyMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $policyMethods)) {
             return 'Laravel policy method';
         }
 
@@ -849,7 +847,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $mailableMethods = ['build', 'content', 'envelope', 'attachments', 'headers'];
 
-        if (in_array($method->getName(), $mailableMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $mailableMethods)) {
             return 'Laravel mailable method';
         }
 
@@ -867,7 +865,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $broadcastMethods = ['broadcastWith', 'broadcastAs', 'broadcastWhen'];
 
-        if (in_array($method->getName(), $broadcastMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $broadcastMethods)) {
             return 'Laravel broadcast event method';
         }
 
@@ -885,7 +883,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $resourceMethods = ['paginationInformation'];
 
-        if (in_array($method->getName(), $resourceMethods, true)) {
+        if (CaseInsensitiveName::isOneOf($method->getName(), $resourceMethods)) {
             return 'Laravel JSON resource method';
         }
 
@@ -904,7 +902,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
             return null;
         }
 
-        if (str_starts_with($method->getName(), 'routeNotificationFor')) {
+        if (CaseInsensitiveName::startsWith($method->getName(), 'routeNotificationFor')) {
             return 'Laravel notification routing method';
         }
 
@@ -918,7 +916,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
     {
         $methodName = $method->getName();
 
-        if ($method->isPublic() && (str_starts_with($methodName, 'handle') || $methodName === '__invoke')) {
+        if ($method->isPublic() && (CaseInsensitiveName::startsWith($methodName, 'handle') || CaseInsensitiveName::equals($methodName, '__invoke'))) {
             if ($this->firstParamHasClassType($methodName, $classReflection)) {
                 return 'Laravel auto-discovered event listener method';
             }
@@ -942,7 +940,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
             $name = $classMethod->getName();
 
-            if (!str_starts_with($name, 'handle') && $name !== '__invoke') {
+            if (!CaseInsensitiveName::startsWith($name, 'handle') && !CaseInsensitiveName::equals($name, '__invoke')) {
                 continue;
             }
 

--- a/src/Provider/NetteTesterUsageProvider.php
+++ b/src/Provider/NetteTesterUsageProvider.php
@@ -10,6 +10,7 @@ use PHPStan\Node\InClassNode;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function preg_match;
 use function preg_match_all;
 use function str_contains;

--- a/src/Provider/NetteTesterUsageProvider.php
+++ b/src/Provider/NetteTesterUsageProvider.php
@@ -50,7 +50,7 @@ final class NetteTesterUsageProvider implements MemberUsageProvider
                 $usages[] = $this->createUsage($className, $methodName, 'Test method');
             }
 
-            if ($methodName === 'setUp' || $methodName === 'tearDown') {
+            if (CaseInsensitiveName::isOneOf($methodName, ['setUp', 'tearDown'])) {
                 $usages[] = $this->createUsage($className, $methodName, 'Lifecycle method');
             }
 

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -101,27 +101,27 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
     {
         if (
             $reflection->is(SignalReceiver::class)
-            && str_starts_with($methodName, 'handle')
+            && CaseInsensitiveName::startsWith($methodName, 'handle')
         ) {
             return VirtualUsageData::withNote('Signal handler method');
         }
 
         if (
             $reflection->is(Container::class)
-            && str_starts_with($methodName, 'createComponent')
+            && CaseInsensitiveName::startsWith($methodName, 'createComponent')
         ) {
             return VirtualUsageData::withNote('Component factory method');
         }
 
         if (
             $reflection->is(Control::class)
-            && str_starts_with($methodName, 'render')
+            && CaseInsensitiveName::startsWith($methodName, 'render')
         ) {
             return VirtualUsageData::withNote('Render method');
         }
 
         if (
-            $reflection->is(Presenter::class) && str_starts_with($methodName, 'action')
+            $reflection->is(Presenter::class) && CaseInsensitiveName::startsWith($methodName, 'action')
         ) {
             return VirtualUsageData::withNote('Presenter action method');
         }

--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -14,6 +14,7 @@ use Nette\SmartObject;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use ReflectionMethod;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function class_exists;
 use function file_get_contents;
 use function is_array;

--- a/src/Provider/PhpBenchUsageProvider.php
+++ b/src/Provider/PhpBenchUsageProvider.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDocParser\Parser\TokenIterator;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function array_merge;
 use function explode;
 use function is_array;

--- a/src/Provider/PhpBenchUsageProvider.php
+++ b/src/Provider/PhpBenchUsageProvider.php
@@ -18,7 +18,6 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use function array_merge;
 use function explode;
-use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
@@ -149,7 +148,7 @@ final class PhpBenchUsageProvider implements MemberUsageProvider
             $beforeMethodsFromAnnotations = $this->getMethodNamesFromAnnotation($docComment, '@BeforeMethods');
             $afterMethodsFromAnnotations = $this->getMethodNamesFromAnnotation($docComment, '@AfterMethods');
 
-            if (in_array($methodName, $beforeMethodsFromAnnotations, true) || in_array($methodName, $afterMethodsFromAnnotations, true)) {
+            if (CaseInsensitiveName::isOneOf($methodName, $beforeMethodsFromAnnotations) || CaseInsensitiveName::isOneOf($methodName, $afterMethodsFromAnnotations)) {
                 return true;
             }
         }
@@ -162,7 +161,7 @@ final class PhpBenchUsageProvider implements MemberUsageProvider
             }
 
             foreach ($methods as $beforeMethod) {
-                if ($beforeMethod === $methodName) {
+                if (is_string($beforeMethod) && CaseInsensitiveName::equals($beforeMethod, $methodName)) {
                     return true;
                 }
             }
@@ -175,7 +174,7 @@ final class PhpBenchUsageProvider implements MemberUsageProvider
             }
 
             foreach ($methods as $afterMethod) {
-                if ($afterMethod === $methodName) {
+                if (is_string($afterMethod) && CaseInsensitiveName::equals($afterMethod, $methodName)) {
                     return true;
                 }
             }

--- a/src/Provider/ReflectionUsageProvider.php
+++ b/src/Provider/ReflectionUsageProvider.php
@@ -33,7 +33,6 @@ use function array_key_first;
 use function array_values;
 use function count;
 use function explode;
-use function in_array;
 
 final class ReflectionUsageProvider implements MemberUsageProvider
 {
@@ -122,7 +121,7 @@ final class ReflectionUsageProvider implements MemberUsageProvider
         $methodName = $node->name->toString();
         $args = $node->getArgs();
 
-        if ($className === ReflectionMethod::class && $methodName === 'createFromMethodName' && count($args) === 1) {
+        if ($className === ReflectionMethod::class && CaseInsensitiveName::equals($methodName, 'createFromMethodName') && count($args) === 1) {
             return $this->processClassMethodString($args[array_key_first($args)], $node, $scope);
         }
 
@@ -320,11 +319,11 @@ final class ReflectionUsageProvider implements MemberUsageProvider
     {
         $usedConstants = [];
 
-        if ($methodName === 'getConstants' || $methodName === 'getReflectionConstants') {
+        if (CaseInsensitiveName::isOneOf($methodName, ['getConstants', 'getReflectionConstants'])) {
             $usedConstants[] = $this->createConstantUsage($node, $scope, $genericClassName, null);
         }
 
-        if (($methodName === 'getConstant' || $methodName === 'getReflectionConstant') && count($args) === 1) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['getConstant', 'getReflectionConstant']) && count($args) === 1) {
             $firstArg = $args[array_key_first($args)];
 
             foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {
@@ -349,11 +348,11 @@ final class ReflectionUsageProvider implements MemberUsageProvider
     {
         $usedConstants = [];
 
-        if ($methodName === 'getCases') {
+        if (CaseInsensitiveName::equals($methodName, 'getCases')) {
             $usedConstants[] = $this->createEnumCaseUsage($node, $scope, $genericClassName, null);
         }
 
-        if (($methodName === 'getCase') && count($args) === 1) {
+        if (CaseInsensitiveName::equals($methodName, 'getCase') && count($args) === 1) {
             $firstArg = $args[array_key_first($args)];
 
             foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {
@@ -378,11 +377,11 @@ final class ReflectionUsageProvider implements MemberUsageProvider
     {
         $usedMethods = [];
 
-        if ($methodName === 'getMethods') {
+        if (CaseInsensitiveName::equals($methodName, 'getMethods')) {
             $usedMethods[] = $this->createMethodUsage($node, $scope, $genericClassName, null);
         }
 
-        if ($methodName === 'getMethod' && count($args) === 1) {
+        if (CaseInsensitiveName::equals($methodName, 'getMethod') && count($args) === 1) {
             $firstArg = $args[array_key_first($args)];
 
             foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {
@@ -390,7 +389,7 @@ final class ReflectionUsageProvider implements MemberUsageProvider
             }
         }
 
-        if (in_array($methodName, ['getConstructor', 'newInstance', 'newInstanceArgs'], true)) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['getConstructor', 'newInstance', 'newInstanceArgs'])) {
             $usedMethods[] = $this->createMethodUsage($node, $scope, $genericClassName, '__construct');
         }
 
@@ -412,15 +411,17 @@ final class ReflectionUsageProvider implements MemberUsageProvider
         $usedProperties = [];
 
         if (
-            $methodName === 'getProperties'
-            || $methodName === 'getDefaultProperties' // simplified, ideally should mark white only default properties
-            || $methodName === 'getStaticProperties' // simplified, ideally should mark white only static properties
+            CaseInsensitiveName::isOneOf($methodName, [
+                'getProperties',
+                'getDefaultProperties', // simplified, ideally should mark white only default properties
+                'getStaticProperties', // simplified, ideally should mark white only static properties
+            ])
         ) {
             $usedProperties[] = $this->createPropertyUsage($node, $scope, $genericClassName, null, AccessType::READ);
             $usedProperties[] = $this->createPropertyUsage($node, $scope, $genericClassName, null, AccessType::WRITE); // ReflectionProperty is not generic, so we cannot track setValue call
         }
 
-        if (in_array($methodName, ['getProperty', 'getStaticPropertyValue'], true) && count($args) >= 1) {
+        if (CaseInsensitiveName::isOneOf($methodName, ['getProperty', 'getStaticPropertyValue']) && count($args) >= 1) {
             $firstArg = $args[array_key_first($args)];
 
             foreach ($scope->getType($firstArg->value)->getConstantStrings() as $constantString) {

--- a/src/Provider/ReflectionUsageProvider.php
+++ b/src/Provider/ReflectionUsageProvider.php
@@ -28,6 +28,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function array_filter;
 use function array_key_first;
 use function array_values;

--- a/src/Provider/StreamWrapperUsageProvider.php
+++ b/src/Provider/StreamWrapperUsageProvider.php
@@ -9,7 +9,6 @@ use PHPStan\Analyser\Scope;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
-use function in_array;
 
 /**
  * See: https://php.net/manual/en/class.streamwrapper.php
@@ -75,7 +74,7 @@ final class StreamWrapperUsageProvider implements MemberUsageProvider
     {
         $functionNames = $this->getFunctionNames($node, $scope);
 
-        if (in_array('stream_wrapper_register', $functionNames, true)) {
+        if (CaseInsensitiveName::isOneOf('stream_wrapper_register', $functionNames)) {
             return $this->handleStreamWrapperRegister($node, $scope);
         }
 

--- a/src/Provider/StreamWrapperUsageProvider.php
+++ b/src/Provider/StreamWrapperUsageProvider.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Scope;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 
 /**
  * See: https://php.net/manual/en/class.streamwrapper.php

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -250,7 +250,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return [];
         }
 
-        if ($scope->getFunction()->getName() !== 'getSubscribedEvents') {
+        if (!CaseInsensitiveName::equals($scope->getFunction()->getName(), 'getSubscribedEvents')) {
             return [];
         }
 
@@ -674,7 +674,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
      */
     private function getMapInputUsages(InClassMethodNode $node): array
     {
-        if ($node->getMethodReflection()->getName() !== '__invoke') {
+        if (!CaseInsensitiveName::equals($node->getMethodReflection()->getName(), '__invoke')) {
             return [];
         }
 
@@ -904,7 +904,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         Scope $scope,
     ): ?string
     {
-        if ($methodName === 'setDefaults' && isset($args[0])) {
+        if (CaseInsensitiveName::equals($methodName, 'setDefaults') && isset($args[0])) {
             if (!$this->isOptionsResolverType($scope->getType($node->var))) {
                 return null;
             }
@@ -912,7 +912,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             return $this->extractDataClassFromArray($scope->getType($args[0]->value));
         }
 
-        if ($methodName === 'setDefault' && isset($args[0], $args[1])) {
+        if (CaseInsensitiveName::equals($methodName, 'setDefault') && isset($args[0], $args[1])) {
             if (!$this->isOptionsResolverType($scope->getType($node->var))) {
                 return null;
             }
@@ -959,16 +959,16 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         $dataArgIndex = null;
         $optionsArgIndex = null;
 
-        if ($methodName === 'createFormBuilder' && $this->isAbstractControllerType($callerType)) {
+        if (CaseInsensitiveName::equals($methodName, 'createFormBuilder') && $this->isAbstractControllerType($callerType)) {
             $dataArgIndex = 0;
             $optionsArgIndex = 1;
-        } elseif ($methodName === 'createForm' && $this->isAbstractControllerType($callerType)) {
+        } elseif (CaseInsensitiveName::equals($methodName, 'createForm') && $this->isAbstractControllerType($callerType)) {
             $dataArgIndex = 1;
             $optionsArgIndex = 2;
-        } elseif (in_array($methodName, ['create', 'createBuilder'], true) && $this->isFormFactoryType($callerType)) {
+        } elseif (CaseInsensitiveName::isOneOf($methodName, ['create', 'createBuilder']) && $this->isFormFactoryType($callerType)) {
             $dataArgIndex = 1;
             $optionsArgIndex = 2;
-        } elseif (in_array($methodName, ['createNamed', 'createNamedBuilder'], true) && $this->isFormFactoryType($callerType)) {
+        } elseif (CaseInsensitiveName::isOneOf($methodName, ['createNamed', 'createNamedBuilder']) && $this->isFormFactoryType($callerType)) {
             $dataArgIndex = 2;
             $optionsArgIndex = 3;
         } else {
@@ -1136,7 +1136,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     private function isPropertyAccessorMethod(string $methodName): bool
     {
         foreach (['get', 'set', 'is', 'has', 'can', 'add', 'remove'] as $prefix) {
-            if (str_starts_with($methodName, $prefix) && isset($methodName[strlen($prefix)]) && $methodName[strlen($prefix)] >= 'A' && $methodName[strlen($prefix)] <= 'Z') {
+            if (CaseInsensitiveName::startsWith($methodName, $prefix) && isset($methodName[strlen($prefix)]) && $methodName[strlen($prefix)] >= 'A' && $methodName[strlen($prefix)] <= 'Z') {
                 return true;
             }
         }
@@ -1345,7 +1345,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $arguments = $attribute->getArguments();
             $targetMethod = $arguments['method'] ?? $arguments[3] ?? $methodName;
 
-            if ($targetMethod === $methodName) {
+            if (is_string($targetMethod) && CaseInsensitiveName::equals($targetMethod, $methodName)) {
                 return true;
             }
         }
@@ -1355,21 +1355,21 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             $arguments = $attribute->getArguments();
             $targetMethod = $arguments['method'] ?? $arguments[3] ?? '__invoke';
 
-            if ($targetMethod === $methodName) {
+            if (is_string($targetMethod) && CaseInsensitiveName::equals($targetMethod, $methodName)) {
                 return true;
             }
         }
 
         // Check if any other method points to this method (only if explicitly specified)
         foreach ($class->getMethods() as $otherMethod) {
-            if ($otherMethod->getName() === $methodName) {
+            if (CaseInsensitiveName::equals($otherMethod->getName(), $methodName)) {
                 continue;
             }
 
             foreach ($otherMethod->getAttributes('Symfony\Component\Messenger\Attribute\AsMessageHandler') as $attribute) {
                 $arguments = $attribute->getArguments();
                 $targetMethod = $arguments['method'] ?? $arguments[3] ?? null;
-                if ($methodName === $targetMethod) {
+                if (is_string($targetMethod) && CaseInsensitiveName::equals($methodName, $targetMethod)) {
                     return true;
                 }
             }
@@ -1424,7 +1424,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
             $callback = $arguments['callback'] ?? $arguments[0] ?? null;
 
-            if ($callback === $method->getName()) {
+            if (is_string($callback) && CaseInsensitiveName::equals($callback, $method->getName())) {
                 return true;
             }
         }
@@ -1464,11 +1464,11 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                 $arguments = $attribute->getArguments();
                 $targetMethod = $arguments['method'] ?? null;
 
-                if ($targetMethod === $methodName) {
+                if (is_string($targetMethod) && CaseInsensitiveName::equals($targetMethod, $methodName)) {
                     return true;
                 }
 
-                if ($targetMethod === null && $methodName === '__invoke') {
+                if ($targetMethod === null && CaseInsensitiveName::equals($methodName, '__invoke')) {
                     return true;
                 }
             }
@@ -1479,7 +1479,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
     private function isConstructorOrMountOnTwigComponent(ReflectionMethod $method): bool
     {
-        if (!$method->isConstructor() && $method->getName() !== 'mount') {
+        if (!$method->isConstructor() && !CaseInsensitiveName::equals($method->getName(), 'mount')) {
             return false;
         }
 
@@ -1513,13 +1513,15 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     {
         $methodName = $method->getName();
 
-        return $methodName === 'onKernelResponse'
-            || $methodName === 'onKernelException'
-            || $methodName === 'onKernelRequest'
-            || $methodName === 'onConsoleError'
-            || $methodName === 'onConsoleCommand'
-            || $methodName === 'onConsoleSignal'
-            || $methodName === 'onConsoleTerminate';
+        return CaseInsensitiveName::isOneOf($methodName, [
+            'onKernelResponse',
+            'onKernelException',
+            'onKernelRequest',
+            'onConsoleError',
+            'onConsoleCommand',
+            'onConsoleSignal',
+            'onConsoleTerminate',
+        ]);
     }
 
     /**
@@ -1709,7 +1711,7 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         $invokeMethod = null;
 
         foreach ($nativeReflection->getMethods() as $method) {
-            if ($method->getName() === '__invoke') {
+            if (CaseInsensitiveName::equals($method->getName(), '__invoke')) {
                 $invokeMethod = $method;
                 break;
             }

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -42,6 +42,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use SimpleXMLElement;
 use SplFileInfo;
 use Symfony\UX\TwigComponent\Attribute\FromMethod;

--- a/src/Provider/TwigUsageProvider.php
+++ b/src/Provider/TwigUsageProvider.php
@@ -28,6 +28,7 @@ use function array_map;
 use function count;
 use function explode;
 use function in_array;
+use function strtolower;
 
 final class TwigUsageProvider implements MemberUsageProvider
 {
@@ -341,7 +342,7 @@ final class TwigUsageProvider implements MemberUsageProvider
             $classReflection = $this->reflectionProvider->getClass($className);
 
             if ($classReflection->is('Twig\Environment')) {
-                if ($methodName === 'render' || $methodName === 'display') {
+                if (CaseInsensitiveName::isOneOf($methodName, ['render', 'display'])) {
                     return 1;
                 }
             }
@@ -351,24 +352,24 @@ final class TwigUsageProvider implements MemberUsageProvider
                     'render' => 0,
                     'display' => 0,
                     'stream' => 0,
-                    'streamBlock' => 1,
-                    'renderBlock' => 1,
-                    'displayBlock' => 1,
+                    'streamblock' => 1,
+                    'renderblock' => 1,
+                    'displayblock' => 1,
                 ];
 
-                return $wrapperMethods[$methodName] ?? null;
+                return $wrapperMethods[strtolower($methodName)] ?? null;
             }
 
             if ($classReflection->is('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
                 $controllerMethods = [
                     'render' => 1,
-                    'renderView' => 1,
-                    'renderBlock' => 2,
-                    'renderBlockView' => 2,
+                    'renderview' => 1,
+                    'renderblock' => 2,
+                    'renderblockview' => 2,
                     'stream' => 1,
                 ];
 
-                return $controllerMethods[$methodName] ?? null;
+                return $controllerMethods[strtolower($methodName)] ?? null;
             }
         }
 

--- a/src/Provider/TwigUsageProvider.php
+++ b/src/Provider/TwigUsageProvider.php
@@ -24,6 +24,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMemberUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function array_map;
 use function count;
 use function explode;

--- a/tests/Rule/data/providers/nette.php
+++ b/tests/Rule/data/providers/nette.php
@@ -26,6 +26,10 @@ final class PagePresenter extends Presenter
         $this->redirect('Login:');
     }
 
+    public function HandleCaseInsensitive() { // upper-cased 'H': Nette resolves signals via case-insensitive getMethod(), so this is still a live handler
+        $this->redirect('Login:');
+    }
+
 }
 
 /**

--- a/tests/Rule/data/providers/reflection.php
+++ b/tests/Rule/data/providers/reflection.php
@@ -107,6 +107,12 @@ class DirectHolder2
     public function usedViaObjectArg() {}
 }
 
+class CaseInsensitiveHolder
+{
+    public function usedViaUppercasedGetMethod() {}
+    public function notUsedCaseInsensitive() {} // error: Unused Reflection\CaseInsensitiveHolder::notUsedCaseInsensitive
+}
+
 function test() {
     GetAllConstantsChild::getConstants();
     GetAllConstantsChild::getConstants2();
@@ -141,6 +147,9 @@ function test() {
 
     $obj = new DirectHolder2();
     new \ReflectionMethod($obj, 'usedViaObjectArg');
+
+    $reflectionCi = new \ReflectionClass(CaseInsensitiveHolder::class);
+    $reflectionCi->GETMETHOD('usedViaUppercasedGetMethod'); // differently-cased getMethod() must still mark the member used
 
     new \ReflectionClassConstant(DirectConstHolder::class, 'USED_CONST');
 }


### PR DESCRIPTION
Follow-up to #384, which made the core graph matching case-insensitive for method names. The library-specific usage providers still compared method/function names case-sensitively (e.g. `$methodName === 'getMethod'`, `str_starts_with($m, 'handle')`), so a differently-cased call or declaration that PHP would dispatch to the same member was missed.

## Approach

Added a small `CaseInsensitiveName` helper (`equals` / `startsWith` / `endsWith` / `isOneOf`) so each converted site reads as "case-insensitive on purpose", and converted the genuine method/function-name comparison sites.

The casing decision is **not** a blanket sweep — it was made per framework by verifying against vendor source, because it depends on *how the framework reaches the method*:

**Made case-insensitive** — framework constructs the name and dispatches via `getMethod` / `method_exists` / `call_user_func` / variable call, or the comparison is against a call written in the analyzed source (so a differently-cased name reaches the same member):
- Reflection (`getMethod`/`getCases`/`getConstant`/…), Enum (`tryFrom`/`from`/`cases`), StreamWrapper (`stream_wrapper_register`)
- Nette signals / `render` / `action` / `createComponent` (`tryCall`→`getMethod`, `method_exists`)
- Doctrine event/listener/lifecycle name matches, Symfony event-subscriber / callable / form / property-accessor / `mount` / `__invoke`, all Laravel/Eloquent/Blade, Twig source calls, PhpBench `@BeforeMethods`/`@AfterMethods`, Nette Tester `setUp`/`tearDown`

**Deliberately kept case-sensitive** — framework *discovers* methods by a case-sensitive declared-name scan, so an oddly-cased method is genuinely never called and must still be reported dead:
- PHPUnit / PhpBench / Phpat `test`/`bench` prefixes, Nette Tester `^test[A-Z0-9_]` regex
- Nette `inject` + SmartObject `get`/`set`/`is` accessors — `ObjectHelpers::getMagicProperties` re-checks `$rm->name === $expected` case-sensitively after the case-insensitive `getMethod`, so e.g. `GetRadius` is **not** a magic accessor
- magic-method `__` filter (PHP magic method names are always lowercase)

Class names / FQCNs, constant names, enum-case names and config/route keys keep their case-sensitive comparisons.

## Tests
- `providers/reflection.php`: a method reached via an upper-cased `->GETMETHOD('…')` is no longer reported dead.
- `providers/nette.php`: an upper-cased `HandleCaseInsensitive()` signal handler stays live.

The existing suite (which covers the correctly-cased scenarios, including the case-sensitive frameworks) still passes, locking in that the change does not over-reach.

## Note for review
Doctrine's `#[AsEntityListener(method: '…')]` / `#[AsDoctrineListener(event: '…')]` config-string-vs-declared-method matches are treated as case-insensitive (Doctrine dispatches them via `$instance->$method()`). If you'd prefer config-string comparisons stay exact, those four sites in `DoctrineUsageProvider` are the ones to flip back.