### PR TITLE
Additional Laravel notification methods

### DIFF
--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -778,10 +778,23 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $notificationMethods = [
             'via', 'toMail', 'toArray', 'toDatabase', 'toBroadcast', 'toVonage', 'toSlack',
+            'afterSending',
         ];
 
         if (CaseInsensitiveName::isOneOf($methodName, $notificationMethods)) {
             return 'Laravel notification method';
+        }
+
+        if (!$classReflection->is('Illuminate\Contracts\Queue\ShouldQueue')) {
+            return null;
+        }
+
+        $queueableNotificationMethods = [
+            'shouldSend', 'viaConnections', 'viaQueues', 'withDelay', 'withMessageGroups', 'messageGroup', 'deduplicationId', 'withDeduplicators',
+        ];
+
+        if (CaseInsensitiveName::isOneOf($methodName, $queueableNotificationMethods)) {
+            return 'Laravel queueable notification method';
         }
 
         return null;

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -778,7 +778,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         $notificationMethods = [
             'via', 'toMail', 'toArray', 'toDatabase', 'toBroadcast', 'toVonage', 'toSlack',
-            'afterSending',
+            'afterSending', 'shouldSend',
         ];
 
         if (CaseInsensitiveName::isOneOf($methodName, $notificationMethods)) {
@@ -790,7 +790,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         }
 
         $queueableNotificationMethods = [
-            'shouldSend', 'viaConnections', 'viaQueues', 'withDelay', 'withMessageGroups', 'messageGroup', 'deduplicationId', 'withDeduplicators',
+            'viaConnections', 'viaQueues', 'withDelay', 'withMessageGroups', 'messageGroup', 'deduplicationId', 'withDeduplicators',
         ];
 
         if (CaseInsensitiveName::isOneOf($methodName, $queueableNotificationMethods)) {

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -493,6 +493,11 @@ class InvoiceNotification extends Notification
         return;
     }
 
+    public function shouldSend(object $notifiable, string $channel): bool
+    {
+        return true;
+    }
+
     private function helperMethod(): void // error: Unused Laravel\InvoiceNotification::helperMethod
     {
     }
@@ -502,10 +507,6 @@ class InvoiceNotification extends Notification
 
 class InvoiceQueueableNotification extends InvoiceNotification implements ShouldQueue
 {
-    public function shouldSend(object $notifiable, string $channel): bool
-    {
-        return true;
-    }
     /** @return array<string, string> */
     public function viaConnections(): array
     {

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -488,8 +488,34 @@ class InvoiceNotification extends Notification
         return new \stdClass();
     }
 
+    public function afterSending(object $notifiable, string $channel, mixed $response): void
+    {
+        return;
+    }
+
     private function helperMethod(): void // error: Unused Laravel\InvoiceNotification::helperMethod
     {
+    }
+}
+
+// --- Queueable notifications ---
+
+class InvoiceQueueableNotification extends InvoiceNotification implements ShouldQueue
+{
+    public function shouldSend(object $notifiable, string $channel): bool
+    {
+        return true;
+    }
+    /** @return array<string, string> */
+    public function viaConnections(): array
+    {
+        return [];
+    }
+
+    /** @return array<string, string> */
+    public function viaQueues(): array
+    {
+        return [];
     }
 }
 


### PR DESCRIPTION
Adding to the Laravel provider a few more notification methods used by the framework. Some of them are only used in queueable notifications.

For usage, see:
* https://github.com/laravel/framework/blob/7caa4d97a26aab181505dbece56fbb168037c383/src/Illuminate/Notifications/NotificationSender.php#L182 for `afterSending()`
* The `NotificationSender::queueNotification()` for queued notifications: https://github.com/laravel/framework/blob/7caa4d97a26aab181505dbece56fbb168037c383/src/Illuminate/Notifications/NotificationSender.php#L218