### PR TITLE
Laravel exception methods

### DIFF
--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -951,7 +951,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         ClassReflection $classReflection,
     ): ?string
     {
-        if (!$classReflection->is('Exception')) {
+        if (!$classReflection->is('Throwable')) {
             return null;
         }
 

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -671,7 +671,8 @@ final class LaravelUsageProvider implements MemberUsageProvider
             ?? $this->isBroadcastEventMethod($method, $classReflection)
             ?? $this->isJsonResourceMethod($method, $classReflection)
             ?? $this->isNotifiableMethod($method, $classReflection)
-            ?? $this->isEventListenerMethod($method, $classReflection);
+            ?? $this->isEventListenerMethod($method, $classReflection)
+            ?? $this->isExceptionMethod($method, $classReflection);
     }
 
     private function isCommandMethod(
@@ -940,6 +941,28 @@ final class LaravelUsageProvider implements MemberUsageProvider
 
         if ($method->isConstructor() && $this->hasAutoDiscoveredListenerMethod($classReflection)) {
             return 'Laravel auto-discovered event listener method';
+        }
+
+        return null;
+    }
+
+    private function isExceptionMethod(
+        ReflectionMethod $method,
+        ClassReflection $classReflection,
+    ): ?string
+    {
+        if (!$classReflection->is('Exception')) {
+            return null;
+        }
+
+        $methodName = $method->getName();
+
+        $exceptionMethods = [
+            'context', 'render', 'report',
+        ];
+
+        if ($method->isPublic() && CaseInsensitiveName::isOneOf($methodName, $exceptionMethods)) {
+            return 'Laravel exceptiopn method';
         }
 
         return null;

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -962,7 +962,7 @@ final class LaravelUsageProvider implements MemberUsageProvider
         ];
 
         if ($method->isPublic() && CaseInsensitiveName::isOneOf($methodName, $exceptionMethods)) {
-            return 'Laravel exceptiopn method';
+            return 'Laravel exception method';
         }
 
         return null;

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -761,6 +761,19 @@ class InvalidOrderException extends Exception
     }
 }
 
+// Throwable that is not an Exception (extends Error) — the framework reports/renders it the same way
+class InvalidOrderError extends \Error
+{
+    public function report(): bool
+    {
+        return false;
+    }
+
+    private function helperMethod(): void // error: Unused Laravel\InvalidOrderError::helperMethod
+    {
+    }
+}
+
 // =====================
 // Route/Event/Schedule Registrations (AST-based detection)
 // =====================

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -748,12 +748,12 @@ class InvalidOrderException extends Exception
 
     public function render(Request $request): Response
     {
-        return response();
+        return new Response();
     }
 
     public function report(): bool
     {
-        return [];
+        return false;
     }
 
     private function helperMethod(): void // error: Unused Laravel\InvalidOrderException::helperMethod

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -2,6 +2,7 @@
 
 namespace Laravel;
 
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Mail\Mailable;
 use Illuminate\Notifications\Notifiable;
@@ -729,6 +731,32 @@ class ThrottleMiddleware
     }
 
     private function helperMethod(): void // error: Unused Laravel\ThrottleMiddleware::helperMethod
+    {
+    }
+}
+
+
+// --- Exceptions ---
+
+class InvalidOrderException extends Exception
+{
+    /** @return array<string, mixed> */
+    public function context(): array
+    {
+        return [];
+    }
+
+    public function render(Request $request): Response
+    {
+        return response();
+    }
+
+    public function report(): bool
+    {
+        return [];
+    }
+
+    private function helperMethod(): void // error: Unused Laravel\InvalidOrderException::helperMethod
     {
     }
 }


### PR DESCRIPTION
Letting the Laravel provider recognize some exception methods used by the framework (`context()`, `render()`, `report()`). See [Laravel docs](https://laravel.com/docs/13.x/errors).