### PR TITLE
Fix coverage guard error message

### DIFF
--- a/coverage-guard.php
+++ b/coverage-guard.php
@@ -36,7 +36,7 @@ $config->addRule(new class implements CoverageRule {
         $requiredCoverage = $this->getRequiredCoverage($classReflection, $codeBlock->getMethodName());
 
         if ($codeBlock->getCoveragePercentage() < $requiredCoverage) {
-            return CoverageError::create("Method <white>{$codeBlock->getMethodName()}</white> requires $requiredCoverage% coverage, but has only $coverage%.");
+            return CoverageError::create("Method <bold>{$codeBlock->getMethodName()}</bold> requires $requiredCoverage% coverage, but has only $coverage%.");
         }
 
         return null;


### PR DESCRIPTION
The coverage guard message emphasized the method name with a `<white>` tag, but `ShipMonk\CoverageGuard\Printer` never supported it — the color map only knows `<red>`, `<green>`, `<orange>`, `<gray>`, and `<bold>`. As a result `<white>...</white>` was printed as literal text instead of being colorized.

Switched to `<bold>`, which the printer renders for emphasis (same tag it uses for the `Info:` prefix).

Co-Authored-By: Claude Code