### PR TITLE
Drop README note about PHPStan 1.x provider interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,6 @@ services:
             - shipmonk.deadCode.memberUsageProvider
 ```
 
-> [!IMPORTANT]
-> _The interface & tag changed in [0.7](../../releases/tag/0.7.0). If you are using PHPStan 1.x, those were [used differently](../../blob/0.5.0/README.md#customization)._
-
 ### Reflection-based customization:
 - For simple reflection usecases, you can just extend `ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider`:
 


### PR DESCRIPTION
Removes the `[!IMPORTANT]` note that pointed PHPStan 1.x users at the old `0.5.0` provider interface docs.

The `0.x` extension line (the one compatible with PHPStan 1.x) sees <100 daily downloads out of ~15k total, so the migration note is no longer worth keeping in the README.

Co-Authored-By: Claude Code