### PR TITLE
Free the usage graph after emitting errors

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -320,11 +320,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
         $errors = $this->processKnownCollectedUsages($knownCollectedUsages);
 
-        // the usage graph is the analysis output and has just been turned into errors;
-        // processNode(CollectedDataNode) runs once per process, so this state would
-        // otherwise stay allocated for the rest of the process (~90k objects on a
-        // 2.4k-file codebase). DebugUsagePrinter received its own copies earlier;
-        // $typeDefinitions and $mixedClassNameUsages are kept for print().
+        // free memory, this data can be huge and are no longer needed
         $this->traitMembers = [];
         $this->memberAlternativesCache = [];
         $this->blackMembers = [];

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -318,7 +318,19 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             }
         }
 
-        return $this->processKnownCollectedUsages($knownCollectedUsages);
+        $errors = $this->processKnownCollectedUsages($knownCollectedUsages);
+
+        // the usage graph is the analysis output and has just been turned into errors;
+        // processNode(CollectedDataNode) runs once per process, so this state would
+        // otherwise stay allocated for the rest of the process (~90k objects on a
+        // 2.4k-file codebase). DebugUsagePrinter received its own copies earlier;
+        // $typeDefinitions and $mixedClassNameUsages are kept for print().
+        $this->traitMembers = [];
+        $this->memberAlternativesCache = [];
+        $this->blackMembers = [];
+        $this->usageGraph = [];
+
+        return $errors;
     }
 
     /**


### PR DESCRIPTION
## Problem

`DeadCodeRule::processNode(CollectedDataNode)` runs once per process, at result finalization in PHPStan's main process. After `processKnownCollectedUsages()` has turned the accumulated state into errors, `$traitMembers`, `$memberAlternativesCache`, `$blackMembers` and `$usageGraph` are dead weight retained until the process exits.

Found while instrumenting PHPStan memory retention on the ShipMonk backend: a per-service retention census attributed ~90k objects to the rule instance on a 2.4k-file slice (`UsageOrigin`, `ClassMethodRef`/`ClassPropertyRef`/usages, `BlackMember`), and an interleaved A/B benchmark on the full 25k-file codebase measured **−55 MB main-process peak RSS** (3.07 GB → 3.02 GB, consistent across duplicate runs) with byte-identical error output and no time cost.

## Change

Reset the four members at the end of `processNode()`.

Deliberately kept: `$typeDefinitions` and `$mixedClassNameUsages` — the `DiagnoseExtension::print()` reads them after analysis (clearing them broke `testDiagnoseMixedCalls` & co., which is how they earned their exemption). `DebugUsagePrinter` received its own copies of the analysed members earlier (PHP array value semantics), so `-vvv` debug output is unaffected.

`composer check:tests` (702 tests), `check:types`, `check:cs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrTvR9j1mW2NNNC8RkuTsF
