### PR TITLE
Fix PHPStan 2.2.5 unmatched offsetAccess.notFound ignores

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.3",
+            "version": "2.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4048833dd47b377287818841877fb3087289509c",
-                "reference": "4048833dd47b377287818841877fb3087289509c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +68,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-30T21:15:26+00:00"
+            "time": "2026-07-05T06:31:06+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Collector/ConstantFetchCollector.php
+++ b/src/Collector/ConstantFetchCollector.php
@@ -102,7 +102,6 @@ final class ConstantFetchCollector implements Collector
                     continue;
                 }
 
-                // @phpstan-ignore offsetAccess.notFound
                 [$className, $constantName] = explode('::', $constantString->getValue());
 
                 if ($this->reflectionProvider->hasClass($className)) {

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -438,7 +438,7 @@ final class DebugUsagePrinter
                 throw new LogicException("Invalid debug member format: '$debugMember', expected 'ClassName::memberName'");
             }
 
-            [$class, $memberName] = explode('::', $debugMember); // @phpstan-ignore offsetAccess.notFound
+            [$class, $memberName] = explode('::', $debugMember);
             $normalizedClass = ltrim($class, '\\');
             $memberName = ltrim($memberName, '$');
 


### PR DESCRIPTION
## Summary

Latest PHPStan (2.2.5) broke CI. PHPStan 2.2.5 improved `explode()` return-type analysis and no longer reports `offsetAccess.notFound` when list-destructuring a string that is known to contain the delimiter. That made two `@phpstan-ignore offsetAccess.notFound` comments unmatched, failing the (always-latest) `phpstan` CI job.

- Drop the now-stale ignores in `ConstantFetchCollector` and `DebugUsagePrinter`.
- Bump locked `phpstan/phpstan` to 2.2.5.

`composer check` passes locally.

Co-Authored-By: Claude Code