### PR TITLE
Support for Laravel real-time facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ parameters:
 - Event listeners — `Event::listen()`, `Event::subscribe()`, auto-discovered listeners (`handle*`/`__invoke` with typed first param)
 - Scheduled jobs — `Schedule::job()`
 - Gates & policies — `Gate::define()`, `Gate::policy()`, `$this->authorize()` with automatic policy class resolution
+- Real-time facades — `\Facades\...` static calls mapped to the underlying class
 - Console commands, jobs, service providers, middleware, notifications, form requests, mailables, broadcast events, JSON resources, notifiable routing
 
 #### Eloquent:

--- a/src/Provider/LaravelUsageProvider.php
+++ b/src/Provider/LaravelUsageProvider.php
@@ -30,6 +30,8 @@ use function lcfirst;
 use function str_contains;
 use function str_ends_with;
 use function str_replace;
+use function str_starts_with;
+use function strlen;
 use function strpos;
 use function strrpos;
 use function substr;
@@ -131,9 +133,74 @@ final class LaravelUsageProvider implements MemberUsageProvider
             if ($className === 'Illuminate\Support\Facades\Gate' || $className === 'Illuminate\Auth\Access\Gate') {
                 $usages = [...$usages, ...$this->getUsagesFromGateCall($node, $scope)];
             }
+
+            if (str_starts_with($className, 'Facades\\')) {
+                $usages = [...$usages, ...$this->getUsagesFromRealTimeFacadeCall($node, $scope, $className)];
+            }
         }
 
         return $usages;
+    }
+
+    /**
+     * @return list<ClassMethodUsage>
+     *
+     * @see \Illuminate\Foundation\AliasLoader::load()
+     */
+    private function getUsagesFromRealTimeFacadeCall(
+        StaticCall $node,
+        Scope $scope,
+        string $facadeClassName,
+    ): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $underlyingClassName = substr($facadeClassName, strlen('Facades\\'));
+
+        if ($underlyingClassName === '') {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+
+        if ($this->isFacadeBuiltInMethod($methodName)) {
+            return [];
+        }
+
+        $usages = [];
+
+        foreach ([$methodName, '__construct'] as $method) {
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createRegular($node, $scope),
+                new ClassMethodRef($underlyingClassName, $method, possibleDescendant: true),
+            );
+        }
+
+        return $usages;
+    }
+
+    /**
+     * @see \Illuminate\Support\Facades\Facade
+     */
+    private function isFacadeBuiltInMethod(string $methodName): bool
+    {
+        return CaseInsensitiveName::isOneOf($methodName, [
+            'clearResolvedInstance',
+            'clearResolvedInstances',
+            'defaultAliases',
+            'expects',
+            'getFacadeApplication',
+            'getFacadeRoot',
+            'isFake',
+            'partialMock',
+            'resolved',
+            'setFacadeApplication',
+            'shouldReceive',
+            'spy',
+            'swap',
+        ]);
     }
 
     /**

--- a/tests/Rule/data/providers/laravel.php
+++ b/tests/Rule/data/providers/laravel.php
@@ -819,6 +819,24 @@ function registerPolicies(): void
     Route::post('/songs/upload', [SongController::class, 'upload']);
 }
 
+// --- Real-time facades ---
+
+class RealtimeFacadeService
+{
+    public function usedViaFacade(): void
+    {
+    }
+
+    public function unusedViaFacade(): void // error: Unused Laravel\RealtimeFacadeService::unusedViaFacade
+    {
+    }
+}
+
+function useRealTimeFacade(): void
+{
+    \Facades\Laravel\RealtimeFacadeService::usedViaFacade();
+}
+
 // --- can/cannot/cant and Gate::allows/denies/check (policy resolution via Authorizable) ---
 
 function testCanAndGateMethods(Post $post, Song $song, User $user): void


### PR DESCRIPTION
This PR introduces support for [Laravel's real-time facades](https://laravel.com/docs/13.x/facades#real-time-facades), a feature that allows to access classes as static classes via the service container:
* a call like `\Facades\App\SomeClass::someMethod()` marks the underlying class method `\App\SomeClass::someMethod()` as used
* standard facade methods like `SomeClass::shouldReceive()` (used for testing or by the framework) are ignored