### PR TITLE
Detect static methods referenced in composer.json scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ parameters:
 #### Composer:
 - Detects static methods referenced as PHP callbacks in `scripts` section of `composer.json`
   - e.g. `"post-install-cmd": "MyVendor\\MyClass::postInstall"`
-  - `composer.json` is autodetected, but you can point it elsewhere via `shipmonkDeadCode.usageProviders.composer.composerJsonPaths`
+  - `composer.json` is autodetected, but you can point it elsewhere via `shipmonkDeadCode.usageProviders.composer.composerJsonPath`
 
 Those providers are enabled by default, but you can disable them if needed.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ parameters:
 #### StreamWrapper:
 - Detects usages caused by `stream_wrapper_register`
 
+#### Composer:
+- Detects static methods referenced as PHP callbacks in `scripts` section of `composer.json`
+  - e.g. `"post-install-cmd": "MyVendor\\MyClass::postInstall"`
+  - `composer.json` is autodetected, but you can point it elsewhere via `shipmonkDeadCode.usageProviders.composer.composerJsonPaths`
+
 Those providers are enabled by default, but you can disable them if needed.
 
 ## Excluding usages in tests:

--- a/rules.neon
+++ b/rules.neon
@@ -176,7 +176,7 @@ services:
             - shipmonk.deadCode.memberUsageProvider
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.composer.enabled%
-            composerJsonPaths: %shipmonkDeadCode.usageProviders.composer.composerJsonPaths%
+            composerJsonPath: %shipmonkDeadCode.usageProviders.composer.composerJsonPath%
 
 
     -
@@ -315,7 +315,7 @@ parameters:
                 enabled: true
             composer:
                 enabled: true
-                composerJsonPaths: []
+                composerJsonPath: null
         usageExcluders:
             tests:
                 enabled: false
@@ -337,7 +337,7 @@ expandRelativePaths:
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][configDir]'
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][containerXmlPaths]'
     - '[parameters][shipmonkDeadCode][usageProviders][nette][containerNeonPaths]'
-    - '[parameters][shipmonkDeadCode][usageProviders][composer][composerJsonPaths]'
+    - '[parameters][shipmonkDeadCode][usageProviders][composer][composerJsonPath]'
     - '[parameters][shipmonkDeadCode][usageExcluders][tests][devPaths]'
 
 parametersSchema:
@@ -420,7 +420,7 @@ parametersSchema:
             ])
             composer: structure([
                 enabled: bool()
-                composerJsonPaths: listOf(string())
+                composerJsonPath: schema(string(), nullable())
             ])
         ])
         usageExcluders: structure([

--- a/rules.neon
+++ b/rules.neon
@@ -170,6 +170,14 @@ services:
         arguments:
             enabled: %shipmonkDeadCode.usageProviders.streamWrapper.enabled%
 
+    -
+        class: ShipMonk\PHPStan\DeadCode\Provider\ComposerUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.composer.enabled%
+            composerJsonPaths: %shipmonkDeadCode.usageProviders.composer.composerJsonPaths%
+
 
     -
         class: ShipMonk\PHPStan\DeadCode\Excluder\TestsUsageExcluder
@@ -305,6 +313,9 @@ parameters:
                 enabled: null
             streamWrapper:
                 enabled: true
+            composer:
+                enabled: true
+                composerJsonPaths: []
         usageExcluders:
             tests:
                 enabled: false
@@ -326,6 +337,7 @@ expandRelativePaths:
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][configDir]'
     - '[parameters][shipmonkDeadCode][usageProviders][symfony][containerXmlPaths]'
     - '[parameters][shipmonkDeadCode][usageProviders][nette][containerNeonPaths]'
+    - '[parameters][shipmonkDeadCode][usageProviders][composer][composerJsonPaths]'
     - '[parameters][shipmonkDeadCode][usageExcluders][tests][devPaths]'
 
 parametersSchema:
@@ -405,6 +417,10 @@ parametersSchema:
             ])
             streamWrapper: structure([
                 enabled: bool()
+            ])
+            composer: structure([
+                enabled: bool()
+                composerJsonPaths: listOf(string())
             ])
         ])
         usageExcluders: structure([

--- a/src/Provider/ComposerUsageProvider.php
+++ b/src/Provider/ComposerUsageProvider.php
@@ -46,24 +46,21 @@ final class ComposerUsageProvider implements MemberUsageProvider
      */
     private array $scriptCalls = [];
 
-    /**
-     * @param list<string> $composerJsonPaths
-     */
     public function __construct(
         bool $enabled,
-        array $composerJsonPaths,
+        ?string $composerJsonPath,
     )
     {
         $this->enabled = $enabled;
 
-        if ($enabled && $composerJsonPaths === []) {
-            $autodetectedPath = $this->autodetectComposerJsonPath();
+        if ($enabled) {
+            if ($composerJsonPath === null) {
+                $autodetectedPath = $this->autodetectComposerJsonPath();
 
-            if ($autodetectedPath !== null) {
-                $this->extractScriptCallbacks($autodetectedPath);
-            }
-        } elseif ($enabled) {
-            foreach ($composerJsonPaths as $composerJsonPath) {
+                if ($autodetectedPath !== null) {
+                    $this->extractScriptCallbacks($autodetectedPath);
+                }
+            } else {
                 if (!is_file($composerJsonPath)) {
                     throw new LogicException(sprintf('Composer json %s does not exist', $composerJsonPath));
                 }

--- a/src/Provider/ComposerUsageProvider.php
+++ b/src/Provider/ComposerUsageProvider.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use Composer\Autoload\ClassLoader;
+use LogicException;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use function array_filter;
+use function array_keys;
+use function count;
+use function explode;
+use function file_get_contents;
+use function is_array;
+use function is_file;
+use function is_string;
+use function json_decode;
+use function json_last_error;
+use function ltrim;
+use function reset;
+use function sprintf;
+use function str_contains;
+use function str_starts_with;
+use const JSON_ERROR_NONE;
+
+/**
+ * Detects static methods referenced as PHP callbacks in the scripts section of composer.json,
+ * e.g. "post-install-cmd": "MyVendor\\MyClass::postInstall"
+ *
+ * @see https://getcomposer.org/doc/articles/scripts.md#defining-scripts
+ */
+final class ComposerUsageProvider implements MemberUsageProvider
+{
+
+    private readonly bool $enabled;
+
+    /**
+     * class => [method => note]
+     *
+     * @var array<string, array<string, string>>
+     */
+    private array $scriptCalls = [];
+
+    /**
+     * @param list<string> $composerJsonPaths
+     */
+    public function __construct(
+        bool $enabled,
+        array $composerJsonPaths,
+    )
+    {
+        $this->enabled = $enabled;
+
+        if ($enabled && $composerJsonPaths === []) {
+            $autodetectedPath = $this->autodetectComposerJsonPath();
+
+            if ($autodetectedPath !== null) {
+                $this->extractScriptCallbacks($autodetectedPath);
+            }
+        } elseif ($enabled) {
+            foreach ($composerJsonPaths as $composerJsonPath) {
+                if (!is_file($composerJsonPath)) {
+                    throw new LogicException(sprintf('Composer json %s does not exist', $composerJsonPath));
+                }
+
+                $this->extractScriptCallbacks($composerJsonPath);
+            }
+        }
+    }
+
+    public function getUsages(
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$this->enabled || $this->scriptCalls === []) {
+            return [];
+        }
+
+        if ($node instanceof InClassNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
+            return $this->getScriptUsages($node->getClassReflection());
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<ClassMethodUsage>
+     */
+    private function getScriptUsages(ClassReflection $classReflection): array
+    {
+        $usages = [];
+
+        foreach ($this->scriptCalls[$classReflection->getName()] ?? [] as $methodName => $note) {
+            if (!$classReflection->hasNativeMethod($methodName)) {
+                continue;
+            }
+
+            $methodReflection = $classReflection->getNativeMethod($methodName);
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
+                new ClassMethodRef(
+                    $methodReflection->getDeclaringClass()->getName(),
+                    $methodReflection->getName(),
+                    possibleDescendant: false,
+                ),
+            );
+        }
+
+        return $usages;
+    }
+
+    private function extractScriptCallbacks(string $composerJsonPath): void
+    {
+        $composerJsonRawData = file_get_contents($composerJsonPath);
+
+        if ($composerJsonRawData === false) {
+            return;
+        }
+
+        $composerJsonData = json_decode($composerJsonRawData, associative: true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($composerJsonData)) {
+            return;
+        }
+
+        $scripts = $composerJsonData['scripts'] ?? [];
+
+        if (!is_array($scripts)) {
+            return;
+        }
+
+        foreach ($scripts as $scriptName => $listeners) {
+            if (!is_array($listeners)) {
+                $listeners = [$listeners];
+            }
+
+            foreach ($listeners as $listener) {
+                if (!is_string($listener) || !$this->isPhpScript($listener)) {
+                    continue;
+                }
+
+                [$className, $methodName] = explode('::', $listener, 2); // @phpstan-ignore offsetAccess.notFound
+                $className = ltrim($className, '\\');
+
+                $this->scriptCalls[$className][$methodName] = sprintf("Composer script '%s' in %s", $scriptName, $composerJsonPath);
+            }
+        }
+    }
+
+    /**
+     * Mirrors Composer\EventDispatcher\EventDispatcher::isPhpScript, listeners starting with @ are script/command references.
+     */
+    private function isPhpScript(string $listener): bool
+    {
+        return !str_starts_with($listener, '@')
+            && !str_contains($listener, ' ')
+            && str_contains($listener, '::');
+    }
+
+    private function autodetectComposerJsonPath(): ?string
+    {
+        $vendorDirs = array_filter(array_keys(ClassLoader::getRegisteredLoaders()), static function (string $vendorDir): bool {
+            return !str_starts_with($vendorDir, 'phar://');
+        });
+
+        if (count($vendorDirs) !== 1) {
+            return null;
+        }
+
+        $composerJsonPath = reset($vendorDirs) . '/../composer.json';
+
+        if (!is_file($composerJsonPath)) {
+            return null;
+        }
+
+        return $composerJsonPath;
+    }
+
+}

--- a/src/Provider/ComposerUsageProvider.php
+++ b/src/Provider/ComposerUsageProvider.php
@@ -4,13 +4,8 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 
 use Composer\Autoload\ClassLoader;
 use LogicException;
-use PhpParser\Node;
-use PHPStan\Analyser\Scope;
-use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\ClassReflection;
-use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
-use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
-use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use PHPStan\Reflection\ReflectionProvider;
+use ReflectionMethod;
 use function array_filter;
 use function array_keys;
 use function count;
@@ -34,24 +29,25 @@ use const JSON_ERROR_NONE;
  *
  * @see https://getcomposer.org/doc/articles/scripts.md#defining-scripts
  */
-final class ComposerUsageProvider implements MemberUsageProvider
+final class ComposerUsageProvider extends ReflectionBasedMemberUsageProvider
 {
 
-    private readonly bool $enabled;
+    private readonly ReflectionProvider $reflectionProvider;
 
     /**
-     * class => [method => note]
+     * declaring class => [method => note]
      *
      * @var array<string, array<string, string>>
      */
     private array $scriptCalls = [];
 
     public function __construct(
+        ReflectionProvider $reflectionProvider,
         bool $enabled,
         ?string $composerJsonPath,
     )
     {
-        $this->enabled = $enabled;
+        $this->reflectionProvider = $reflectionProvider;
 
         if ($enabled) {
             if ($composerJsonPath === null) {
@@ -70,47 +66,13 @@ final class ComposerUsageProvider implements MemberUsageProvider
         }
     }
 
-    public function getUsages(
-        Node $node,
-        Scope $scope,
-    ): array
+    protected function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData
     {
-        if (!$this->enabled || $this->scriptCalls === []) {
-            return [];
-        }
+        $note = $this->scriptCalls[$method->getDeclaringClass()->getName()][$method->getName()] ?? null;
 
-        if ($node instanceof InClassNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
-            return $this->getScriptUsages($node->getClassReflection());
-        }
-
-        return [];
-    }
-
-    /**
-     * @return list<ClassMethodUsage>
-     */
-    private function getScriptUsages(ClassReflection $classReflection): array
-    {
-        $usages = [];
-
-        foreach ($this->scriptCalls[$classReflection->getName()] ?? [] as $methodName => $note) {
-            if (!$classReflection->hasNativeMethod($methodName)) {
-                continue;
-            }
-
-            $methodReflection = $classReflection->getNativeMethod($methodName);
-
-            $usages[] = new ClassMethodUsage(
-                UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
-                new ClassMethodRef(
-                    $methodReflection->getDeclaringClass()->getName(),
-                    $methodReflection->getName(),
-                    possibleDescendant: false,
-                ),
-            );
-        }
-
-        return $usages;
+        return $note === null
+            ? null
+            : VirtualUsageData::withNote($note);
     }
 
     private function extractScriptCallbacks(string $composerJsonPath): void
@@ -146,9 +108,30 @@ final class ComposerUsageProvider implements MemberUsageProvider
                 [$className, $methodName] = explode('::', $listener, 2); // @phpstan-ignore offsetAccess.notFound
                 $className = ltrim($className, '\\');
 
-                $this->scriptCalls[$className][$methodName] = sprintf("Composer script '%s' in %s", $scriptName, $composerJsonPath);
+                $this->registerScriptCallback($className, $methodName, sprintf("Composer script '%s' in %s", $scriptName, $composerJsonPath));
             }
         }
+    }
+
+    private function registerScriptCallback(
+        string $className,
+        string $methodName,
+        string $note,
+    ): void
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return;
+        }
+
+        $nativeClassReflection = $this->reflectionProvider->getClass($className)->getNativeReflection();
+
+        if (!$nativeClassReflection->hasMethod($methodName)) {
+            return;
+        }
+
+        $nativeMethodReflection = $nativeClassReflection->getMethod($methodName); // @phpstan-ignore missingType.checkedException (guarded by hasMethod above)
+
+        $this->scriptCalls[$nativeMethodReflection->getDeclaringClass()->getName()][$nativeMethodReflection->getName()] = $note;
     }
 
     /**

--- a/src/Provider/ComposerUsageProvider.php
+++ b/src/Provider/ComposerUsageProvider.php
@@ -48,22 +48,33 @@ final class ComposerUsageProvider extends ReflectionBasedMemberUsageProvider
     )
     {
         $this->reflectionProvider = $reflectionProvider;
+        $this->loadScriptCallbacks($enabled, $composerJsonPath);
+    }
 
-        if ($enabled) {
-            if ($composerJsonPath === null) {
-                $autodetectedPath = $this->autodetectComposerJsonPath();
-
-                if ($autodetectedPath !== null) {
-                    $this->extractScriptCallbacks($autodetectedPath);
-                }
-            } else {
-                if (!is_file($composerJsonPath)) {
-                    throw new LogicException(sprintf('Composer json %s does not exist', $composerJsonPath));
-                }
-
-                $this->extractScriptCallbacks($composerJsonPath);
-            }
+    private function loadScriptCallbacks(
+        bool $enabled,
+        ?string $composerJsonPath,
+    ): void
+    {
+        if (!$enabled) {
+            return;
         }
+
+        if ($composerJsonPath === null) {
+            $autodetectedPath = $this->autodetectComposerJsonPath();
+
+            if ($autodetectedPath !== null) {
+                $this->extractScriptCallbacks($autodetectedPath);
+            }
+
+            return;
+        }
+
+        if (!is_file($composerJsonPath)) {
+            throw new LogicException(sprintf('Composer json %s does not exist', $composerJsonPath));
+        }
+
+        $this->extractScriptCallbacks($composerJsonPath);
     }
 
     protected function shouldMarkMethodAsUsed(ReflectionMethod $method): ?VirtualUsageData

--- a/tests/Provider/ComposerUsageProviderTest.php
+++ b/tests/Provider/ComposerUsageProviderTest.php
@@ -4,6 +4,7 @@ namespace ShipMonk\PHPStan\DeadCode\Provider;
 
 use Composer\Autoload\ClassLoader;
 use LogicException;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use ReflectionClass;
 
@@ -14,7 +15,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
     {
         $composerJsonPath = __DIR__ . '/../Rule/data/providers/composer/composer.json';
 
-        $provider = new ComposerUsageProvider(true, $composerJsonPath);
+        $provider = new ComposerUsageProvider($this->getReflectionProviderFromContainer(), true, $composerJsonPath);
         $scriptCalls = $this->getScriptCalls($provider);
 
         self::assertArrayHasKey('ComposerProvider\Scripts', $scriptCalls);
@@ -27,12 +28,19 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
         // listeners with spaces are shell commands, not PHP callbacks
         self::assertArrayNotHasKey('notAPhpScript', $scriptCalls['ComposerProvider\Scripts']);
 
-        self::assertArrayHasKey('ComposerProvider\Child', $scriptCalls);
+        // methods referenced via a child class are credited to the declaring ancestor
+        self::assertArrayHasKey('ComposerProvider\ScriptsParent', $scriptCalls);
+        self::assertArrayHasKey('inheritedHook', $scriptCalls['ComposerProvider\ScriptsParent']);
+        self::assertArrayNotHasKey('ComposerProvider\Child', $scriptCalls);
+
+        // unknown classes and methods are dropped
+        self::assertArrayNotHasKey('nonExistingMethod', $scriptCalls['ComposerProvider\Scripts']);
+        self::assertArrayNotHasKey('ComposerProvider\NonExistingClass', $scriptCalls);
     }
 
     public function testAutodetectsComposerJson(): void
     {
-        $provider = new ComposerUsageProvider(true, null);
+        $provider = new ComposerUsageProvider($this->getReflectionProviderFromContainer(), true, null);
 
         // this repository has no PHP callbacks in its own composer.json scripts
         self::assertSame([], $this->getScriptCalls($provider));
@@ -44,7 +52,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
         $extraLoader->register();
 
         try {
-            $provider = new ComposerUsageProvider(true, null);
+            $provider = new ComposerUsageProvider($this->getReflectionProviderFromContainer(), true, null);
 
             self::assertSame([], $this->getScriptCalls($provider));
         } finally {
@@ -54,7 +62,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
 
     public function testDisabled(): void
     {
-        $provider = new ComposerUsageProvider(false, __DIR__ . '/not-a-file.json');
+        $provider = new ComposerUsageProvider($this->getReflectionProviderFromContainer(), false, __DIR__ . '/not-a-file.json');
 
         self::assertSame([], $this->getScriptCalls($provider));
     }
@@ -63,7 +71,12 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
     {
         self::expectException(LogicException::class);
 
-        new ComposerUsageProvider(true, __DIR__ . '/not-a-file.json');
+        new ComposerUsageProvider($this->getReflectionProviderFromContainer(), true, __DIR__ . '/not-a-file.json');
+    }
+
+    private function getReflectionProviderFromContainer(): ReflectionProvider
+    {
+        return self::getContainer()->getByType(ReflectionProvider::class);
     }
 
     /**

--- a/tests/Provider/ComposerUsageProviderTest.php
+++ b/tests/Provider/ComposerUsageProviderTest.php
@@ -10,11 +10,11 @@ use ReflectionClass;
 final class ComposerUsageProviderTest extends PHPStanTestCase
 {
 
-    public function testComposerJsonPathsCollectScriptCallbacks(): void
+    public function testComposerJsonPathCollectsScriptCallbacks(): void
     {
         $composerJsonPath = __DIR__ . '/../Rule/data/providers/composer/composer.json';
 
-        $provider = new ComposerUsageProvider(true, [$composerJsonPath]);
+        $provider = new ComposerUsageProvider(true, $composerJsonPath);
         $scriptCalls = $this->getScriptCalls($provider);
 
         self::assertArrayHasKey('ComposerProvider\Scripts', $scriptCalls);
@@ -32,7 +32,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
 
     public function testAutodetectsComposerJson(): void
     {
-        $provider = new ComposerUsageProvider(true, []);
+        $provider = new ComposerUsageProvider(true, null);
 
         // this repository has no PHP callbacks in its own composer.json scripts
         self::assertSame([], $this->getScriptCalls($provider));
@@ -44,7 +44,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
         $extraLoader->register();
 
         try {
-            $provider = new ComposerUsageProvider(true, []);
+            $provider = new ComposerUsageProvider(true, null);
 
             self::assertSame([], $this->getScriptCalls($provider));
         } finally {
@@ -54,7 +54,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
 
     public function testDisabled(): void
     {
-        $provider = new ComposerUsageProvider(false, [__DIR__ . '/not-a-file.json']);
+        $provider = new ComposerUsageProvider(false, __DIR__ . '/not-a-file.json');
 
         self::assertSame([], $this->getScriptCalls($provider));
     }
@@ -63,7 +63,7 @@ final class ComposerUsageProviderTest extends PHPStanTestCase
     {
         self::expectException(LogicException::class);
 
-        new ComposerUsageProvider(true, [__DIR__ . '/not-a-file.json']);
+        new ComposerUsageProvider(true, __DIR__ . '/not-a-file.json');
     }
 
     /**

--- a/tests/Provider/ComposerUsageProviderTest.php
+++ b/tests/Provider/ComposerUsageProviderTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use Composer\Autoload\ClassLoader;
+use LogicException;
+use PHPStan\Testing\PHPStanTestCase;
+use ReflectionClass;
+
+final class ComposerUsageProviderTest extends PHPStanTestCase
+{
+
+    public function testComposerJsonPathsCollectScriptCallbacks(): void
+    {
+        $composerJsonPath = __DIR__ . '/../Rule/data/providers/composer/composer.json';
+
+        $provider = new ComposerUsageProvider(true, [$composerJsonPath]);
+        $scriptCalls = $this->getScriptCalls($provider);
+
+        self::assertArrayHasKey('ComposerProvider\Scripts', $scriptCalls);
+        self::assertArrayHasKey('postInstall', $scriptCalls['ComposerProvider\Scripts']);
+        self::assertArrayHasKey('first', $scriptCalls['ComposerProvider\Scripts']);
+
+        // leading backslash is trimmed
+        self::assertArrayHasKey('withLeadingSlash', $scriptCalls['ComposerProvider\Scripts']);
+
+        // listeners with spaces are shell commands, not PHP callbacks
+        self::assertArrayNotHasKey('notAPhpScript', $scriptCalls['ComposerProvider\Scripts']);
+
+        self::assertArrayHasKey('ComposerProvider\Child', $scriptCalls);
+    }
+
+    public function testAutodetectsComposerJson(): void
+    {
+        $provider = new ComposerUsageProvider(true, []);
+
+        // this repository has no PHP callbacks in its own composer.json scripts
+        self::assertSame([], $this->getScriptCalls($provider));
+    }
+
+    public function testAutodetectionRequiresSingleVendorDir(): void
+    {
+        $extraLoader = new ClassLoader(__DIR__);
+        $extraLoader->register();
+
+        try {
+            $provider = new ComposerUsageProvider(true, []);
+
+            self::assertSame([], $this->getScriptCalls($provider));
+        } finally {
+            $extraLoader->unregister();
+        }
+    }
+
+    public function testDisabled(): void
+    {
+        $provider = new ComposerUsageProvider(false, [__DIR__ . '/not-a-file.json']);
+
+        self::assertSame([], $this->getScriptCalls($provider));
+    }
+
+    public function testInvalidPathThrows(): void
+    {
+        self::expectException(LogicException::class);
+
+        new ComposerUsageProvider(true, [__DIR__ . '/not-a-file.json']);
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function getScriptCalls(ComposerUsageProvider $provider): array
+    {
+        $providerReflection = new ReflectionClass(ComposerUsageProvider::class);
+        $scriptCallsReflection = $providerReflection->getProperty('scriptCalls');
+
+        /** @var array<string, array<string, string>> $scriptCalls */
+        $scriptCalls = $scriptCallsReflection->getValue($provider);
+
+        return $scriptCalls;
+    }
+
+}

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1262,7 +1262,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             ),
             new ComposerUsageProvider(
                 $this->providersEnabled,
-                [__DIR__ . '/data/providers/composer/composer.json'],
+                __DIR__ . '/data/providers/composer/composer.json',
             ),
             new SymfonyUsageProvider(
                 $this->createContainerMockWithSymfonyConfig(),

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1261,6 +1261,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 $this->providersEnabled,
             ),
             new ComposerUsageProvider(
+                self::getContainer()->getByType(ReflectionProvider::class),
                 $this->providersEnabled,
                 __DIR__ . '/data/providers/composer/composer.json',
             ),

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -51,6 +51,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\ApiPhpDocUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BehatUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BladeUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\BuiltinUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\ComposerUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EloquentUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EnumUsageProvider;
@@ -1026,6 +1027,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-nette-container' => [__DIR__ . '/data/providers/nette-container.php'];
         yield 'provider-nette-tester' => [__DIR__ . '/data/providers/nette-tester.php'];
         yield 'provider-apiphpdoc' => [__DIR__ . '/data/providers/api-phpdoc.php'];
+        yield 'provider-composer' => [__DIR__ . '/data/providers/composer.php'];
         yield 'provider-enum' => [__DIR__ . '/data/providers/enum.php'];
         yield 'provider-enum-hooks' => [__DIR__ . '/data/providers/enum-hooks.php'];
         yield 'provider-builtin' => [__DIR__ . '/data/providers/builtin.php'];
@@ -1257,6 +1259,10 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             ),
             new StreamWrapperUsageProvider(
                 $this->providersEnabled,
+            ),
+            new ComposerUsageProvider(
+                $this->providersEnabled,
+                [__DIR__ . '/data/providers/composer/composer.json'],
             ),
             new SymfonyUsageProvider(
                 $this->createContainerMockWithSymfonyConfig(),

--- a/tests/Rule/data/providers/composer.php
+++ b/tests/Rule/data/providers/composer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ComposerProvider;
+
+class Scripts
+{
+    public static function postInstall(): void {} // post-install-cmd script
+    public static function first(): void {} // multiple script
+    public static function withLeadingSlash(): void {} // multiple script, leading backslash
+    public static function notAPhpScript(): void {} // error: Unused ComposerProvider\Scripts::notAPhpScript
+    public static function unused(): void {} // error: Unused ComposerProvider\Scripts::unused
+}
+
+class ScriptsParent
+{
+    public static function inheritedHook(): void {} // inherited script referenced via Child
+}
+
+class Child extends ScriptsParent
+{
+}

--- a/tests/Rule/data/providers/composer/composer.json
+++ b/tests/Rule/data/providers/composer/composer.json
@@ -1,0 +1,15 @@
+{
+    "scripts": {
+        "post-install-cmd": "ComposerProvider\\Scripts::postInstall",
+        "multiple": [
+            "ComposerProvider\\Scripts::first",
+            "\\ComposerProvider\\Scripts::withLeadingSlash",
+            "echo done",
+            "@post-install-cmd"
+        ],
+        "with-space": "ComposerProvider\\Scripts::notAPhpScript --arg",
+        "inherited": "ComposerProvider\\Child::inheritedHook",
+        "unknown-method": "ComposerProvider\\Scripts::nonExistingMethod",
+        "unknown-class": "ComposerProvider\\NonExistingClass::method"
+    }
+}


### PR DESCRIPTION
Closes #396

Adds a new default-enabled `ComposerUsageProvider` that marks static methods referenced as PHP callbacks in the `scripts` section of `composer.json` (e.g. `"post-install-cmd": "MyVendor\\MyClass::postInstall"`) as used.

- Callback detection mirrors `Composer\EventDispatcher\EventDispatcher::isPhpScript`: an entry is a PHP callback iff it contains `::` and no space; `@script` references and shell commands are ignored, leading backslash is trimmed
- The root `composer.json` is autodetected from the registered autoloader's vendor dir; configurable via `shipmonkDeadCode.usageProviders.composer.composerJsonPath` (single path, since Composer only executes scripts of the root package)
- Built on `ReflectionBasedMemberUsageProvider`; callbacks are resolved to their declaring class at load time via `ReflectionProvider`, so callbacks referencing inherited methods keep working

Co-Authored-By: Claude Code
