### PR TITLE
NetteUsageProvider: @property with whitespace or newlines inside the type is silently ignored

### DIFF
--- a/src/Provider/NetteUsageProvider.php
+++ b/src/Provider/NetteUsageProvider.php
@@ -176,7 +176,7 @@ final class NetteUsageProvider extends ReflectionBasedMemberUsageProvider
         }
 
         preg_match_all(
-            '~^  [ \t*]*  @property(|-read|-write|-deprecated)  [ \t]+  [^\s$]+  [ \t]+  \$  (\w+)  ()~mx',
+            '~^  [ \t*]*  @property(|-read|-write|-deprecated)  [ \t]+  (?:(?!@)[^\s$*]+[\s*]+)++  \$  (\w+)  ()~mx',
             (string) $rc->getDocComment(),
             $matches,
             PREG_SET_ORDER,

--- a/tests/Rule/data/providers/nette.php
+++ b/tests/Rule/data/providers/nette.php
@@ -35,6 +35,11 @@ final class PagePresenter extends Presenter
 /**
  * @property float $radius
  * @property-read bool $visible
+ * @property array<string, string> $labels
+ * @property array{
+ *     x: float,
+ *     y: float,
+ * } $center
  */
 class Circle
 {
@@ -56,9 +61,35 @@ class Circle
     {
         return $this->radius > 0;
     }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getLabels(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    protected function setLabels(array $labels): void
+    {
+    }
+
+    /**
+     * @return array{x: float, y: float}
+     */
+    protected function getCenter(): array
+    {
+        return ['x' => 0.0, 'y' => 0.0];
+    }
 }
 
 $circle = new Circle;
 $circle->radius = 10; // actually calls setRadius(10)
 echo $circle->radius; // calls getRadius()
 echo $circle->visible; // calls isVisible()
+$circle->labels = ['color' => 'red']; // calls setLabels()
+print_r($circle->labels); // calls getLabels()
+echo $circle->center['x']; // calls getCenter()


### PR DESCRIPTION
Mirror update for the https://github.com/nette/utils/pull/339 fix
Let's wait whether the upstream change gets merged unchanged
Tell me whether I should add compatibility check (old regex for unfixed nette/utils versions)