### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Bedabox, LLC dba ShipMonk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The `composer.json` declares the MIT license, but the repository has no `LICENSE` file. GitHub detects licenses only from a root `LICENSE` file. It does not read `composer.json`.

Therefore the GitHub API reports no license for this repository:

- `GET /repos/{owner}/{repo}` returns `"license": null`
- `GET /repos/{owner}/{repo}/license` returns 404
- The search filter `license:mit` does not match the repository
- The SBOM export reports `NOASSERTION`
- License scanners see the package as unlicensed
- The sidebar shows no license, and the Community Standards checklist stays incomplete

Packagist and `composer licenses` were always correct, because they read `composer.json`.

This repository was the only ShipMonk PHP tool without the file. `composer-dependency-analyser`, `phpstan-rules`, `coverage-guard`, `name-collision-detector` and the others all have it.

The new file matches those repositories exactly. The copyright year is 2023, the year of the first commit. The file stays out of `.gitattributes` `export-ignore`, so Composer dist archives include it.

Claude