### PR TITLE
Fix test fixture broken by PHPStan 2.2.6 removal of ReadWritePropertiesExtensionProvider

### DIFF
--- a/tests/Rule/data/providers/vendor.php
+++ b/tests/Rule/data/providers/vendor.php
@@ -3,8 +3,8 @@
 namespace Default;
 
 use PhpParser\Node;
+use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule as RuleFromVendor;
 use PHPUnit\Framework\TestCase;
 
@@ -13,9 +13,9 @@ interface IMyRule extends RuleFromVendor
     public function getNodeType(): string;
 }
 
-interface MyPropertiesExtensionProvider extends ReadWritePropertiesExtensionProvider {
+interface MyNodeVisitor extends NodeVisitor {
 
-    public const EXTENSION_TAG = 'overridden-from-vendor';
+    public const DONT_TRAVERSE_CHILDREN = 100;
 
 }
 


### PR DESCRIPTION
PHPStan 2.2.6 removed `PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider`. It replaced extension providers with the `#[ExtensionInterface]` attribute.

The `provider-vendor` fixture extended that interface and overrode its `EXTENSION_TAG` constant. The test checks that a constant which overrides a vendor constant is not reported as dead. After the upgrade to PHPStan 2.2.8, the parent constant no longer exists. The detector then reports the constant as unused. This breaks the `prefer-stable` CI jobs.

This PR points the fixture to `PhpParser\NodeVisitor::DONT_TRAVERSE_CHILDREN` instead. The test intent stays the same. Tests pass with both PHPStan 2.2.5 (locked) and 2.2.8.

https://claude.ai/code/session_019FdMTv9CDuKsxC66oAadRT