### PR TITLE
Symfony: fix crash on `#[Assert\Callback]` with closure callback (PHP 8.5)

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -9,10 +9,8 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
@@ -1629,34 +1627,26 @@ final class SymfonyUsageProvider implements MemberUsageProvider
 
     private function isMethodWithCallbackConstraintAttribute(ReflectionMethod $method): bool
     {
-        $attributes = $method->getDeclaringClass()->getAttributes('Symfony\Component\Validator\Constraints\Callback');
+        $declaringClassName = $method->getDeclaringClass()->getName();
 
-        foreach ($attributes as $attribute) {
-            $expressions = $attribute->getArgumentsExpressions();
-            $callbackExpression = $expressions['callback'] ?? $expressions[0] ?? null;
-
-            if ($callbackExpression === null) {
-                continue;
-            }
-
-            if ($callbackExpression instanceof String_) {
-                if (CaseInsensitiveName::equals($callbackExpression->value, $method->getName())) {
-                    return true;
+        if ($this->reflectionProvider->hasClass($declaringClassName)) {
+            foreach ($this->reflectionProvider->getClass($declaringClassName)->getAttributes() as $attribute) {
+                if ($attribute->getName() !== 'Symfony\Component\Validator\Constraints\Callback') {
+                    continue;
                 }
 
-                continue;
-            }
+                // Type-level access never compiles argument values, so closure callbacks (PHP 8.5+) cause no error
+                $callbackType = $attribute->getArgumentTypes()['callback'] ?? null;
 
-            try { // e.g. #[Callback(self::CALLBACK_METHOD)] needs compilation
-                $arguments = $attribute->getArguments();
-            } catch (UnableToCompileNode $e) { // @phpstan-ignore catch.internalClass, catch.neverThrown (PHP 8.5 allows closures in attributes, those have no compile-time value)
-                continue;
-            }
+                if ($callbackType === null) {
+                    continue;
+                }
 
-            $callback = $arguments['callback'] ?? $arguments[0] ?? null;
-
-            if (is_string($callback) && CaseInsensitiveName::equals($callback, $method->getName())) {
-                return true;
+                foreach ($callbackType->getConstantStrings() as $constantString) {
+                    if (CaseInsensitiveName::equals($constantString->getValue(), $method->getName())) {
+                        return true;
+                    }
+                }
             }
         }
 

--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -9,8 +9,10 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
@@ -1630,7 +1632,26 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         $attributes = $method->getDeclaringClass()->getAttributes('Symfony\Component\Validator\Constraints\Callback');
 
         foreach ($attributes as $attribute) {
-            $arguments = $attribute->getArguments();
+            $expressions = $attribute->getArgumentsExpressions();
+            $callbackExpression = $expressions['callback'] ?? $expressions[0] ?? null;
+
+            if ($callbackExpression === null) {
+                continue;
+            }
+
+            if ($callbackExpression instanceof String_) {
+                if (CaseInsensitiveName::equals($callbackExpression->value, $method->getName())) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            try { // e.g. #[Callback(self::CALLBACK_METHOD)] needs compilation
+                $arguments = $attribute->getArguments();
+            } catch (UnableToCompileNode $e) { // @phpstan-ignore catch.internalClass, catch.neverThrown (PHP 8.5 allows closures in attributes, those have no compile-time value)
+                continue;
+            }
 
             $callback = $arguments['callback'] ?? $arguments[0] ?? null;
 

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1010,6 +1010,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-reflection-properties' => [__DIR__ . '/data/providers/reflection-properties.php'];
         yield 'provider-symfony' => [__DIR__ . '/data/providers/symfony.php'];
         yield 'provider-symfony-7.1' => [__DIR__ . '/data/providers/symfony-gte71.php', self::requiresPackage('symfony/dependency-injection', '>= 7.1')];
+        yield 'provider-symfony-callback-closure' => [__DIR__ . '/data/providers/symfony-callback-closure.php'];
         yield 'provider-symfony-map-payload' => [__DIR__ . '/data/providers/symfony-map-payload.php', self::requiresPackage('symfony/http-kernel', '>= 6.3')];
         yield 'provider-symfony-map-payload-type' => [__DIR__ . '/data/providers/symfony-map-payload-type.php', self::requiresPackage('symfony/http-kernel', '>= 7.1')];
         yield 'provider-symfony-scheduler' => [__DIR__ . '/data/providers/symfony-scheduler.php', self::requiresPackage('symfony/scheduler', '>= 6.3')];

--- a/tests/Rule/data/providers/symfony-callback-closure.php
+++ b/tests/Rule/data/providers/symfony-callback-closure.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace SymfonyCallbackClosure;
+
+use DateTimeImmutable;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+#[Assert\Callback(static function (self $object, ExecutionContextInterface $context): void {
+    if ($object->from !== null || $object->to !== null) {
+        return;
+    }
+
+    $context->buildViolation('You must specify at least one date.')
+        ->atPath('from')
+        ->addViolation();
+})]
+#[Assert\Callback('validateRange')]
+#[Assert\Callback(self::CALLBACK_METHOD)]
+class CreatedAt
+{
+
+    private const CALLBACK_METHOD = 'validateConst';
+
+    public function __construct(
+        public readonly ?DateTimeImmutable $from = null,
+        public readonly ?DateTimeImmutable $to = null,
+    )
+    {
+    }
+
+    public function validateRange(ExecutionContextInterface $context): void
+    {
+    }
+
+    public function validateConst(ExecutionContextInterface $context): void
+    {
+    }
+
+    public function unusedMethod(): void // error: Unused SymfonyCallbackClosure\CreatedAt::unusedMethod
+    {
+    }
+
+}
+
+new CreatedAt();


### PR DESCRIPTION
Fixes #404

PHP 8.5 allows closures in attribute arguments. `SymfonyUsageProvider` called `ReflectionAttribute::getArguments()` for every `#[Assert\Callback]` attribute. PHPStan reflection cannot compile a closure expression to a value, so the call threw `UnableToCompileNode` and the analysis failed with a non-ignorable `phpstan.reflection` error.

The provider now reads the callback argument via PHPStan's `AttributeReflection::getArgumentTypes()`, as recommended upstream in ondrejmirtes/BetterReflection#44 (comment). Type-level access never compiles argument values:

- A closure callback becomes a `ClosureType` with no constant strings, so it is skipped without any error. It cannot reference a method by name, so no usage is lost.
- String and constant-referenced callbacks (`#[Assert\Callback(self::CALLBACK_METHOD)]`) resolve to `ConstantStringType` and keep working. PHPStan also normalizes positional arguments to parameter names, so `callback:` named and positional forms need no separate handling.

The new test fixture covers the closure callback (the crash), a string callback on the same class (a crashing sibling attribute must not break detection) and a constant-referenced callback.

Upstream context: Roave/BetterReflection#1574 (declined, conflicts with the library's no-autoloading invariant) and ondrejmirtes/BetterReflection#44, where the type-based approach used here was recommended instead.

Co-Authored-By: Claude Code