### PR TITLE
Fix auto-removal scoping bugs in RemoveClassMemberVisitor

### DIFF
--- a/src/Transformer/RemoveClassMemberVisitor.php
+++ b/src/Transformer/RemoveClassMemberVisitor.php
@@ -11,24 +11,20 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\EnumCase;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
 use function array_filter;
+use function array_key_last;
 use function array_pop;
-use function end;
 use function is_string;
-use function ltrim;
 
 final class RemoveClassMemberVisitor extends NodeVisitorAbstract
 {
 
-    private string $currentNamespace = '';
-
     /**
-     * @var list<string|null> null stands for anonymous class
+     * @var list<string|null> fully qualified names filled by NameResolver; null stands for anonymous class
      */
     private array $currentClassStack = [];
 
@@ -43,11 +39,8 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?Node
     {
-        if ($node instanceof Namespace_) {
-            $this->currentNamespace = $node->name === null ? '' : $node->name->toString();
-
-        } elseif ($node instanceof ClassLike) {
-            $this->currentClassStack[] = $node->name === null ? null : $node->name->name;
+        if ($node instanceof ClassLike) {
+            $this->currentClassStack[] = $node->namespacedName?->toString();
         }
 
         return null;
@@ -116,16 +109,13 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
         return null;
     }
 
+    /**
+     * Null when outside of any class; dead members inside anonymous classes are never removed
+     */
     private function getCurrentClass(): ?string
     {
-        $stack = $this->currentClassStack;
-        $currentClassName = end($stack);
-
-        if ($currentClassName === false || $currentClassName === null) { // outside of any class; dead members inside anonymous classes are never removed
-            return null;
-        }
-
-        return ltrim($this->currentNamespace . '\\' . $currentClassName, '\\');
+        $lastKey = array_key_last($this->currentClassStack);
+        return $lastKey === null ? null : $this->currentClassStack[$lastKey];
     }
 
 }

--- a/src/Transformer/RemoveClassMemberVisitor.php
+++ b/src/Transformer/RemoveClassMemberVisitor.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
+use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -16,6 +17,8 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
 use function array_filter;
+use function array_pop;
+use function end;
 use function is_string;
 use function ltrim;
 
@@ -24,7 +27,10 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
 
     private string $currentNamespace = '';
 
-    private string $currentClass = '';
+    /**
+     * @var list<string|null> null stands for anonymous class
+     */
+    private array $currentClassStack = [];
 
     /**
      * @param array<string, array<value-of<MemberType>, array<string, mixed>>> $deadMembers className => [type => [memberName => mixed]]
@@ -37,11 +43,11 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?Node
     {
-        if ($node instanceof Namespace_ && $node->name !== null) {
-            $this->currentNamespace = $node->name->toString();
+        if ($node instanceof Namespace_) {
+            $this->currentNamespace = $node->name === null ? '' : $node->name->toString();
 
-        } elseif ($node instanceof ClassLike && $node->name !== null) {
-            $this->currentClass = $node->name->name;
+        } elseif ($node instanceof ClassLike) {
+            $this->currentClassStack[] = $node->name === null ? null : $node->name->name;
         }
 
         return null;
@@ -49,13 +55,24 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): ?int
     {
+        if ($node instanceof ClassLike) {
+            array_pop($this->currentClassStack);
+            return null;
+        }
+
+        $currentClass = $this->getCurrentClass();
+
+        if ($currentClass === null) {
+            return null;
+        }
+
         if ($node instanceof ClassMethod) {
-            if (isset($this->deadMembers[$this->getCurrentClass()][MemberType::METHOD->value][$node->name->name])) {
+            if (isset($this->deadMembers[$currentClass][MemberType::METHOD->value][$node->name->name])) {
                 return NodeTraverser::REMOVE_NODE;
             }
 
             // Handle promoted properties in constructor parameters
-            $node->params = array_filter($node->params, function (Param $param): bool {
+            $node->params = array_filter($node->params, function (Param $param) use ($currentClass): bool {
                 if (!$param->isPromoted() || !$param->var instanceof Variable) {
                     return true;
                 }
@@ -66,58 +83,49 @@ final class RemoveClassMemberVisitor extends NodeVisitorAbstract
                     return true;
                 }
 
-                return !isset($this->deadMembers[$this->getCurrentClass()][MemberType::PROPERTY->value][$paramName]);
+                return !isset($this->deadMembers[$currentClass][MemberType::PROPERTY->value][$paramName]);
             });
         }
 
-        if ($node instanceof ClassConst) {
-            $allDead = true;
-
-            foreach ($node->consts as $const) {
-                if (!isset($this->deadMembers[$this->getCurrentClass()][MemberType::CONSTANT->value][$const->name->name])) {
-                    $allDead = false;
-                    break;
-                }
-            }
-
-            if ($allDead) {
-                return NodeTraverser::REMOVE_NODE;
-            }
+        if ($node instanceof ClassConst && $node->consts === []) {
+            return NodeTraverser::REMOVE_NODE;
         }
 
         if ($node instanceof Const_) {
-            if (isset($this->deadMembers[$this->getCurrentClass()][MemberType::CONSTANT->value][$node->name->name])) {
+            if (isset($this->deadMembers[$currentClass][MemberType::CONSTANT->value][$node->name->name])) {
                 return NodeTraverser::REMOVE_NODE;
             }
         }
 
         if ($node instanceof EnumCase) {
-            if (isset($this->deadMembers[$this->getCurrentClass()][MemberType::CONSTANT->value][$node->name->name])) {
+            if (isset($this->deadMembers[$currentClass][MemberType::CONSTANT->value][$node->name->name])) {
                 return NodeTraverser::REMOVE_NODE;
             }
         }
 
-        if ($node instanceof Property) {
-            $allDead = true;
-
-            foreach ($node->props as $prop) {
-                if (!isset($this->deadMembers[$this->getCurrentClass()][MemberType::PROPERTY->value][$prop->name->name])) {
-                    $allDead = false;
-                    break;
-                }
-            }
-
-            if ($allDead) {
+        if ($node instanceof PropertyItem) {
+            if (isset($this->deadMembers[$currentClass][MemberType::PROPERTY->value][$node->name->name])) {
                 return NodeTraverser::REMOVE_NODE;
             }
+        }
+
+        if ($node instanceof Property && $node->props === []) {
+            return NodeTraverser::REMOVE_NODE;
         }
 
         return null;
     }
 
-    private function getCurrentClass(): string
+    private function getCurrentClass(): ?string
     {
-        return ltrim($this->currentNamespace . '\\' . $this->currentClass, '\\');
+        $stack = $this->currentClassStack;
+        $currentClassName = end($stack);
+
+        if ($currentClassName === false || $currentClassName === null) { // outside of any class; dead members inside anonymous classes are never removed
+            return null;
+        }
+
+        return ltrim($this->currentNamespace . '\\' . $currentClassName, '\\');
     }
 
 }

--- a/src/Transformer/RemoveDeadCodeTransformer.php
+++ b/src/Transformer/RemoveDeadCodeTransformer.php
@@ -6,6 +6,7 @@ use LogicException;
 use PhpParser\Lexer;
 use PhpParser\NodeTraverser as PhpTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\Parser\Php8;
 use PhpParser\PrettyPrinter\Standard as PhpPrinter;
@@ -38,6 +39,7 @@ final class RemoveDeadCodeTransformer
         $this->cloningTraverser->addVisitor(new CloningVisitor());
 
         $this->removingTraverser = new PhpTraverser();
+        $this->removingTraverser->addVisitor(new NameResolver(null, ['replaceNodes' => false]));
         $this->removingTraverser->addVisitor(new RemoveClassMemberVisitor($deadMembersByClass));
 
         $this->phpPrinter = new PhpPrinter();

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1180,6 +1180,10 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'no-namespace' => [__DIR__ . '/data/removing/no-namespace.php'];
         yield 'properties' => [__DIR__ . '/data/removing/properties.php'];
         yield 'promoted-properties' => [__DIR__ . '/data/removing/promoted-properties.php'];
+        yield 'anonymous-class' => [__DIR__ . '/data/removing/anonymous-class.php'];
+        yield 'global-constant' => [__DIR__ . '/data/removing/global-constant.php'];
+        yield 'mixed-namespaces' => [__DIR__ . '/data/removing/mixed-namespaces.php'];
+        yield 'property-group' => [__DIR__ . '/data/removing/property-group.php'];
     }
 
     private function getAutoremoveTransformedFilePath(string $file): string

--- a/tests/Rule/data/removing/anonymous-class.output.txt
+++ b/tests/Rule/data/removing/anonymous-class.output.txt
@@ -1,0 +1,3 @@
+ • Removed method Removal\ClassWithAnonymousClass::foo
+
+Removed 1 dead member in 1 file.

--- a/tests/Rule/data/removing/anonymous-class.php
+++ b/tests/Rule/data/removing/anonymous-class.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithAnonymousClass
+{
+
+    public function foo(): void
+    {
+    }
+
+    public function run(): void
+    {
+        $object = new class {
+
+            public function foo(): int
+            {
+                return 1;
+            }
+
+        };
+        echo $object->foo();
+    }
+
+}
+
+function useAnonymousClass(): void
+{
+    (new ClassWithAnonymousClass())->run();
+}

--- a/tests/Rule/data/removing/anonymous-class.transformed.php
+++ b/tests/Rule/data/removing/anonymous-class.transformed.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithAnonymousClass
+{
+
+    public function run(): void
+    {
+        $object = new class {
+
+            public function foo(): int
+            {
+                return 1;
+            }
+
+        };
+        echo $object->foo();
+    }
+
+}
+
+function useAnonymousClass(): void
+{
+    (new ClassWithAnonymousClass())->run();
+}

--- a/tests/Rule/data/removing/global-constant.output.txt
+++ b/tests/Rule/data/removing/global-constant.output.txt
@@ -1,0 +1,3 @@
+ • Removed constant Removal\ClassWithGlobalConstSibling::FOO
+
+Removed 1 dead member in 1 file.

--- a/tests/Rule/data/removing/global-constant.php
+++ b/tests/Rule/data/removing/global-constant.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithGlobalConstSibling
+{
+
+    public const FOO = 1;
+
+    public function getUsedValue(): string
+    {
+        return 'used';
+    }
+
+}
+
+const FOO = 2;
+
+function useGlobalConst(): string
+{
+    return (new ClassWithGlobalConstSibling())->getUsedValue() . FOO;
+}

--- a/tests/Rule/data/removing/global-constant.transformed.php
+++ b/tests/Rule/data/removing/global-constant.transformed.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithGlobalConstSibling
+{
+
+    public function getUsedValue(): string
+    {
+        return 'used';
+    }
+
+}
+
+const FOO = 2;
+
+function useGlobalConst(): string
+{
+    return (new ClassWithGlobalConstSibling())->getUsedValue() . FOO;
+}

--- a/tests/Rule/data/removing/mixed-namespaces.output.txt
+++ b/tests/Rule/data/removing/mixed-namespaces.output.txt
@@ -1,0 +1,4 @@
+ • Removed method Removal\MixedNamespaceDup::foo
+ • Removed method MixedNamespaceDup::bar
+
+Removed 2 dead members in 1 file.

--- a/tests/Rule/data/removing/mixed-namespaces.php
+++ b/tests/Rule/data/removing/mixed-namespaces.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace Removal {
+
+    class MixedNamespaceDup
+    {
+
+        public function foo(): void
+        {
+        }
+
+    }
+
+    function useNamespacedDup(): void
+    {
+        new MixedNamespaceDup();
+    }
+
+}
+
+namespace {
+
+    class MixedNamespaceDup
+    {
+
+        public function foo(): void
+        {
+        }
+
+        public function bar(): void
+        {
+        }
+
+    }
+
+    function useGlobalDup(): void
+    {
+        (new MixedNamespaceDup())->foo();
+    }
+
+}

--- a/tests/Rule/data/removing/mixed-namespaces.transformed.php
+++ b/tests/Rule/data/removing/mixed-namespaces.transformed.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Removal {
+
+    class MixedNamespaceDup
+    {
+    }
+
+    function useNamespacedDup(): void
+    {
+        new MixedNamespaceDup();
+    }
+
+}
+
+namespace {
+
+    class MixedNamespaceDup
+    {
+
+        public function foo(): void
+        {
+        }
+
+    }
+
+    function useGlobalDup(): void
+    {
+        (new MixedNamespaceDup())->foo();
+    }
+
+}

--- a/tests/Rule/data/removing/property-group.output.txt
+++ b/tests/Rule/data/removing/property-group.output.txt
@@ -1,0 +1,3 @@
+ • Removed property Removal\ClassWithPropertyGroup::deadGrouped
+
+Removed 1 dead member in 1 file.

--- a/tests/Rule/data/removing/property-group.php
+++ b/tests/Rule/data/removing/property-group.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithPropertyGroup
+{
+
+    public int $deadGrouped = 1, $usedGrouped = 2;
+
+    public function getUsed(): int
+    {
+        return $this->usedGrouped;
+    }
+
+}
+
+function usePropertyGroup(): void
+{
+    echo (new ClassWithPropertyGroup())->getUsed();
+}

--- a/tests/Rule/data/removing/property-group.transformed.php
+++ b/tests/Rule/data/removing/property-group.transformed.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Removal;
+
+class ClassWithPropertyGroup
+{
+
+    public int $usedGrouped = 2;
+
+    public function getUsed(): int
+    {
+        return $this->usedGrouped;
+    }
+
+}
+
+function usePropertyGroup(): void
+{
+    echo (new ClassWithPropertyGroup())->getUsed();
+}


### PR DESCRIPTION
## Summary

`RemoveClassMemberVisitor` never reset its class and namespace context. This caused four defects in the auto-removal feature. Each defect has a new reproduction fixture that fails without the fix.

- **Anonymous classes** (`tests/Rule/data/removing/anonymous-class.php`): inside `new class { }`, the visitor still used the enclosing class. A live method in the anonymous class was removed when its name collided with a dead member of the outer class. The output was broken code.
- **Global constant after a class** (`tests/Rule/data/removing/global-constant.php`): the stale class context matched a top-level `const FOO = 2;` against the dead class constant `FOO`. The removal produced invalid `const ;` — the written file no longer parsed.
- **Braced namespaces** (`tests/Rule/data/removing/mixed-namespaces.php`): a global `namespace { }` block after `namespace Removal { }` kept the previous namespace. The transformer removed a live member of the global class and kept its dead member.
- **Partially dead property groups** (`tests/Rule/data/removing/property-group.php`): in `public int $dead = 1, $used = 2;` the dead item was not removed, because only whole `Property` statements were handled. The formatter still reported it as removed.

## Fix

- Track the current class with a stack. Push `null` for anonymous classes; pop on leave. Skip member handling outside of a named class.
- Reset the namespace for global `namespace { }` blocks.
- Remove dead grouped properties per `PropertyItem`, the same way grouped constants are removed per `Const_`. Drop the whole statement only when it becomes empty.

Dead members inside anonymous classes are intentionally left untouched (never removed), which is the safe direction.
