### PR TITLE
E2E: fix michalspacek.cz job after upstream dev-tools move

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
                     -
                         repo: spaze/michalspacek.cz
                         php: 8.5
-                        composer-working-directory: app/vendor-dev
+                        composer-working-directory: dev-tools
                         working-directory: app
-                        executable: vendor-dev/vendor/phpstan/phpstan/phpstan
+                        executable: ../dev-tools/vendor/phpstan/phpstan/phpstan
 
             fail-fast: false
         steps:


### PR DESCRIPTION
The `e2e (spaze/michalspacek.cz)` job fails at setup since 2026-08-15: the upstream repo moved its dev tooling from `app/vendor-dev/` to `dev-tools/` at the repository root (spaze/michalspacek.cz@cbc984f9f2eb63c3dbf78b8e3f0ac0dddbaa39f1). The `composer require` step aborts because the working directory `app/vendor-dev` no longer exists. First seen on #406, which triggered the first E2E run since the upstream change.

The matrix entry now points to the new layout:
- `composer-working-directory: dev-tools` (holds `phpstan/phpstan` and `shipmonk/dead-code-detector`)
- `executable: ../dev-tools/vendor/phpstan/phpstan/phpstan` — the same path the upstream `app/Makefile` `phpstan` target uses

This PR's own E2E run verifies the fix.
