### PR TITLE
Fix false positives in property hook propagation

### DIFF
--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\Cast\Array_ as ArrayCast;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
@@ -29,6 +28,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Visitor\PropertyHookBackingValueVisitor;
 use ShipMonk\PHPStan\DeadCode\Visitor\PropertyWriteVisitor;
 use function array_map;
 use function current;
@@ -255,7 +255,11 @@ final class PropertyAccessCollector implements Collector
             return false;
         }
 
-        if (!$fetch->var instanceof Variable || $fetch->var->name !== 'this') { // backing store is accessible only via $this
+        if (!PropertyHookBackingValueVisitor::isBackingValueFetch($fetch, $propertyName)) {
+            return false;
+        }
+
+        if ($scope->isInAnonymousFunction()) { // closures are separate compilation units, their $this->prop invokes the hook
             return false;
         }
 

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Cast\Array_ as ArrayCast;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
@@ -106,7 +107,7 @@ final class PropertyAccessCollector implements Collector
         $callerType = $scope->getType($node->var);
 
         foreach ($propertyNames as $propertyName) {
-            $callsHook = !$this->isSelfReferenceInPropertyHook($scope, $propertyName);
+            $callsHook = !$this->isSelfReferenceInPropertyHook($node, $scope, $propertyName);
 
             foreach ($this->getDeclaringTypesWithProperty($propertyName, $callerType, null) as $propertyRef) {
                 $this->registerUsage(
@@ -245,11 +246,16 @@ final class PropertyAccessCollector implements Collector
     }
 
     private function isSelfReferenceInPropertyHook(
+        PropertyFetch $fetch,
         Scope $scope,
         ?string $propertyName,
     ): bool
     {
         if ($propertyName === null) {
+            return false;
+        }
+
+        if (!$fetch->var instanceof Variable || $fetch->var->name !== 'this') { // backing store is accessible only via $this
             return false;
         }
 

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -736,8 +736,11 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             $shouldPropagate = $this->shouldPropagate($usages);
             $visitedWithPropagation = $visited[$calleeKey] ?? null; // null = not visited yet
 
-            $revisitAddsNothing = $visitedWithPropagation === true
-                || ($visitedWithPropagation === false && !$shouldPropagate);
+            $revisitAddsNothing = match ($visitedWithPropagation) {
+                null => false, // never visited: always enter
+                false => !$shouldPropagate, // visited weakly: only an upgrade adds something
+                true => true, // visited strongly: nothing left to mark
+            };
 
             if ($revisitAddsNothing) {
                 continue;

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -709,7 +709,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
     /**
      * @param non-empty-array<string, non-empty-list<ClassMemberUsage>> $stack callerKey => usages[]
-     * @param array<string, true> $visited
+     * @param array<string, bool> $visited memberKey => visited with transitive walk
      */
     private function markReachableAsWhite(
         array $stack,
@@ -726,18 +726,21 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             unset($this->blackMembers[$callerKey]);
         }
 
-        $visited[$callerKey] = true;
+        $visited[$callerKey] = $transitiveWalk || ($visited[$callerKey] ?? false);
 
         if (!$transitiveWalk) {
             return;
         }
 
         foreach ($callees as $calleeKey => $usages) {
-            if (isset($visited[$calleeKey])) {
+            $shouldPropagate = $this->shouldPropagate($usages);
+
+            // revisit a member reached only by non-propagating usages when a propagating usage arrives
+            if (isset($visited[$calleeKey]) && ($visited[$calleeKey] || !$shouldPropagate)) {
                 continue;
             }
 
-            $this->markReachableAsWhite(array_merge($stack, [$calleeKey => $usages]), $visited, $this->shouldPropagate($usages));
+            $this->markReachableAsWhite(array_merge($stack, [$calleeKey => $usages]), $visited, $shouldPropagate);
         }
     }
 
@@ -746,7 +749,13 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
      */
     private function shouldPropagate(array $usages): bool
     {
-        return $usages[0]->isPropagating();
+        foreach ($usages as $usage) {
+            if ($usage->isPropagating()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -726,7 +726,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             unset($this->blackMembers[$callerKey]);
         }
 
-        $visited[$callerKey] = $transitiveWalk || ($visited[$callerKey] ?? false);
+        $visited[$callerKey] = $transitiveWalk;
 
         if (!$transitiveWalk) {
             return;

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -734,9 +734,12 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
         foreach ($callees as $calleeKey => $usages) {
             $shouldPropagate = $this->shouldPropagate($usages);
+            $visitedWithPropagation = $visited[$calleeKey] ?? null; // null = not visited yet
 
-            // revisit a member reached only by non-propagating usages when a propagating usage arrives
-            if (isset($visited[$calleeKey]) && ($visited[$calleeKey] || !$shouldPropagate)) {
+            $revisitAddsNothing = $visitedWithPropagation === true
+                || ($visitedWithPropagation === false && !$shouldPropagate);
+
+            if ($revisitAddsNothing) {
                 continue;
             }
 

--- a/src/Visitor/PropertyHookBackingValueVisitor.php
+++ b/src/Visitor/PropertyHookBackingValueVisitor.php
@@ -37,18 +37,24 @@ final class PropertyHookBackingValueVisitor extends NodeVisitorAbstract
             return NodeVisitor::DONT_TRAVERSE_CHILDREN;
         }
 
-        if (
-            ($node instanceof PropertyFetch || $node instanceof NullsafePropertyFetch)
-            && $node->var instanceof Variable
-            && $node->var->name === 'this'
-            && !($node->name instanceof Expr)
-            && $node->name->toString() === $this->propertyName
-        ) {
+        if (self::isBackingValueFetch($node, $this->propertyName)) {
             $this->found = true;
             return NodeVisitor::STOP_TRAVERSAL;
         }
 
         return null;
+    }
+
+    public static function isBackingValueFetch(
+        Node $node,
+        string $propertyName,
+    ): bool
+    {
+        return ($node instanceof PropertyFetch || $node instanceof NullsafePropertyFetch)
+            && $node->var instanceof Variable
+            && $node->var->name === 'this'
+            && !($node->name instanceof Expr)
+            && $node->name->toString() === $propertyName;
     }
 
 }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1098,6 +1098,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-hooks-14' => [__DIR__ . '/data/properties/hooks-14.php'];
         yield 'property-hooks-15' => [__DIR__ . '/data/properties/hooks-15.php'];
         yield 'property-hooks-16' => [__DIR__ . '/data/properties/hooks-16.php'];
+        yield 'property-hooks-17' => [__DIR__ . '/data/properties/hooks-17.php'];
         yield 'property-overridden-1' => [__DIR__ . '/data/properties/overridden-1.php'];
         yield 'property-overridden-2' => [__DIR__ . '/data/properties/overridden-2.php'];
         yield 'property-nullsafe' => [__DIR__ . '/data/properties/nullsafe.php'];

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1095,6 +1095,9 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-hooks-11' => [__DIR__ . '/data/properties/hooks-11.php'];
         yield 'property-hooks-12' => [__DIR__ . '/data/properties/hooks-12.php'];
         yield 'property-hooks-13' => [__DIR__ . '/data/properties/hooks-13.php'];
+        yield 'property-hooks-14' => [__DIR__ . '/data/properties/hooks-14.php'];
+        yield 'property-hooks-15' => [__DIR__ . '/data/properties/hooks-15.php'];
+        yield 'property-hooks-16' => [__DIR__ . '/data/properties/hooks-16.php'];
         yield 'property-overridden-1' => [__DIR__ . '/data/properties/overridden-1.php'];
         yield 'property-overridden-2' => [__DIR__ . '/data/properties/overridden-2.php'];
         yield 'property-nullsafe' => [__DIR__ . '/data/properties/nullsafe.php'];

--- a/tests/Rule/data/properties/hooks-14.php
+++ b/tests/Rule/data/properties/hooks-14.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooks14;
+
+class Inner
+{
+
+    public string $name {
+        get {
+            $this->touch();
+            return 'inner';
+        }
+    }
+
+    public function touch(): void
+    {
+    }
+
+}
+
+class Outer
+{
+
+    public function __construct(
+        private Inner $inner,
+    )
+    {
+    }
+
+    public string $name {
+        get {
+            return $this->inner->name; // same property name as Inner::$name, but invokes its get hook
+        }
+    }
+
+}
+
+function test(): void
+{
+    $outer = new Outer(new Inner());
+    echo $outer->name;
+}

--- a/tests/Rule/data/properties/hooks-15.php
+++ b/tests/Rule/data/properties/hooks-15.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooks15;
+
+class Example
+{
+
+    public string $prop = '' {
+        get {
+            $this->prop = 'init'; // backing store write, does not invoke set hook
+            return $this->prop;
+        }
+        set(string $value) {
+            $this->log();
+            $this->prop = $value;
+        }
+    }
+
+    public string $other {
+        get {
+            $this->prop = 'from-other'; // hooked write, invokes set hook of $prop
+            return 'x';
+        }
+    }
+
+    public function log(): void
+    {
+    }
+
+}
+
+function test(Example $example): void
+{
+    echo $example->prop; // visits $prop members via non-propagating backing accesses first
+    echo $example->other;
+}

--- a/tests/Rule/data/properties/hooks-16.php
+++ b/tests/Rule/data/properties/hooks-16.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooks16;
+
+// same as hooks-15, but with reversed read order in test()
+
+class Example
+{
+
+    public string $prop = '' {
+        get {
+            $this->prop = 'init';
+            return $this->prop;
+        }
+        set(string $value) {
+            $this->log();
+            $this->prop = $value;
+        }
+    }
+
+    public string $other {
+        get {
+            $this->prop = 'from-other';
+            return 'x';
+        }
+    }
+
+    public function log(): void
+    {
+    }
+
+}
+
+function test(Example $example): void
+{
+    echo $example->other;
+    echo $example->prop;
+}

--- a/tests/Rule/data/properties/hooks-17.php
+++ b/tests/Rule/data/properties/hooks-17.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooks17;
+
+class WriteViaClosure
+{
+
+    public string $prop = '' {
+        get {
+            $fn = function (): void {
+                $this->prop = 'x'; // closure is a separate compilation unit, this invokes the set hook
+            };
+            $fn();
+            return $this->prop;
+        }
+        set(string $value) {
+            $this->log();
+            $this->prop = $value;
+        }
+    }
+
+    public function log(): void
+    {
+    }
+
+}
+
+class WriteViaArrowFunction
+{
+
+    public string $prop = '' {
+        get {
+            $fn = fn (): string => $this->prop = 'x'; // arrow function invokes the set hook
+            $fn();
+            return $this->prop;
+        }
+        set(string $value) {
+            $this->log();
+            $this->prop = $value;
+        }
+    }
+
+    public function log(): void
+    {
+    }
+
+}
+
+function test(WriteViaClosure $a, WriteViaArrowFunction $b): void
+{
+    echo $a->prop;
+    echo $b->prop;
+}


### PR DESCRIPTION
## Summary

Two entangled defects in the property-hook machinery caused false positives — methods that run at runtime were reported as unused. Each has a reproduction fixture that fails without the fix.

- **Propagation strength lost in the alive-marking walk** (`DeadCodeRule::markReachableAsWhite`): a member first reached through a non-propagating usage (e.g. a backing-store access inside its own hook) was marked visited permanently. A later propagating path into the same member was skipped, so its callees stayed black. The outcome depended on collection order: `tests/Rule/data/properties/hooks-15.php` failed (`Unused Example::log`) while the reversed-order `hooks-16.php` passed.
- **Receiver-blind self-reference check** (`PropertyAccessCollector::isSelfReferenceInPropertyHook`): only the property *name* was compared against the enclosing hook's property. Reading `$this->inner->name` inside a hook of a same-named property was misclassified as backing-store access, so the other class's hook body was considered never executed (`hooks-14.php` failed with `Unused Inner::touch`).

## Fix

- The `$visited` set now records whether a member was reached through a propagating walk, and a member visited only weakly is revisited once when a propagating usage arrives. Each member is visited at most twice, so termination is preserved.
- The self-reference check now also requires the fetched variable to be `$this` — the backing store is only accessible that way in PHP.
- `shouldPropagate()` now inspects all usages of an edge instead of only the first, so collection order no longer decides whether an edge propagates.

All 13 pre-existing hook fixtures pass unchanged.
