### PR TITLE
TestsUsageExcluder: match dev paths on directory boundary

### DIFF
--- a/src/Excluder/TestsUsageExcluder.php
+++ b/src/Excluder/TestsUsageExcluder.php
@@ -84,7 +84,11 @@ final class TestsUsageExcluder implements MemberUsageExcluder
         }
 
         foreach ($this->devPaths as $devPath) {
-            if (str_starts_with($filePath, $devPath)) {
+            if (
+                $filePath === $devPath // devPath can be a file (autoload-dev files/classmap)
+                || str_starts_with($filePath, $devPath . '/')
+                || str_starts_with($filePath, $devPath . '\\')
+            ) {
                 return true;
             }
         }

--- a/tests/Excluder/TestsUsageExcluderTest.php
+++ b/tests/Excluder/TestsUsageExcluderTest.php
@@ -24,4 +24,20 @@ final class TestsUsageExcluderTest extends PHPStanTestCase
         ], $devPathsPropertyReflection->getValue($excluder));
     }
 
+    public function testDevPathMatchesOnDirectoryBoundary(): void
+    {
+        $excluder = new TestsUsageExcluder(
+            self::getContainer()->getByType(ReflectionProvider::class),
+            new ComposerIntrospector(),
+            true,
+            [__DIR__ . '/data/boundary/tests'],
+        );
+
+        $isWithinDevPaths = (new ReflectionClass(TestsUsageExcluder::class))->getMethod('isWithinDevPaths');
+
+        self::assertTrue($isWithinDevPaths->invoke($excluder, realpath(__DIR__ . '/data/boundary/tests/Foo.php')));
+        self::assertTrue($isWithinDevPaths->invoke($excluder, realpath(__DIR__ . '/data/boundary/tests')));
+        self::assertFalse($isWithinDevPaths->invoke($excluder, realpath(__DIR__ . '/data/boundary/tests-helpers/Bar.php')));
+    }
+
 }

--- a/tests/Excluder/data/boundary/tests-helpers/Bar.php
+++ b/tests/Excluder/data/boundary/tests-helpers/Bar.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace ExcluderBoundary\TestsHelpers;
+
+class Bar
+{
+
+}

--- a/tests/Excluder/data/boundary/tests/Foo.php
+++ b/tests/Excluder/data/boundary/tests/Foo.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace ExcluderBoundary\Tests;
+
+class Foo
+{
+
+}


### PR DESCRIPTION
## Summary

`TestsUsageExcluder::isWithinDevPaths()` compared paths with a plain `str_starts_with`. A sibling directory whose name merely extends a dev path also matched: with autoload-dev path `/proj/tests`, the file `/proj/tests-helpers/Registry.php` was treated as a dev file. Two consequences:

- Usages written in such a prod directory were excluded as test usages, so prod members used only from there were reported dead.
- Declarations in such a directory were treated as dev-declared, so genuine test-only usages of them were never excluded (missed dead code).

The new `testDevPathMatchesOnDirectoryBoundary` test fails without the fix (`tests-helpers/Bar.php` matched dev path `tests`).

## Fix

Match on an exact path or a directory-separator boundary after the dev path. The exact match keeps single-file dev paths working (`autoload-dev.files` / `classmap` entries can point at files).