### PR TITLE
Detect property writes in nested destructuring assignments

### DIFF
--- a/src/Visitor/PropertyWriteVisitor.php
+++ b/src/Visitor/PropertyWriteVisitor.php
@@ -96,18 +96,12 @@ final class PropertyWriteVisitor extends NodeVisitorAbstract
             }
         }
 
-        if ($expr instanceof List_) { // [$this->first, $this->last] =
+        if ($expr instanceof List_) { // [$this->first, [$this->last]] =
             foreach ($expr->items as $item) {
                 if ($item === null) {
                     continue;
                 }
-                if ($this->isFetch($item->value)) {
-                    $item->value->setAttribute(self::IS_PROPERTY_WRITE, true);
-
-                    if (!$this->hasUnusedResult()) {
-                        $item->value->setAttribute(self::IS_PROPERTY_WRITE_AND_READ, true);
-                    }
-                }
+                $this->markPropertyWrites($item->value);
             }
         }
 

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1105,6 +1105,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-attribute' => [__DIR__ . '/data/properties/attribute.php'];
         yield 'property-write-array' => [__DIR__ . '/data/properties/write-array.php'];
         yield 'property-write-multi' => [__DIR__ . '/data/properties/write-multi.php'];
+        yield 'property-write-multi-nested' => [__DIR__ . '/data/properties/write-multi-nested.php'];
         yield 'property-write-coalesce' => [__DIR__ . '/data/properties/write-coalesce.php'];
         yield 'property-write-inc-dec' => [__DIR__ . '/data/properties/write-inc-dec.php'];
         yield 'property-native-reads' => [__DIR__ . '/data/properties/native-reads.php'];

--- a/tests/Rule/data/properties/write-multi-nested.php
+++ b/tests/Rule/data/properties/write-multi-nested.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace PropertyMultiWriteNested;
+
+class Person
+{
+    public string $flat; // error: Property PropertyMultiWriteNested\Person::$flat is never read
+    public string $nested; // error: Property PropertyMultiWriteNested\Person::$nested is never read
+    public string $keyed; // error: Property PropertyMultiWriteNested\Person::$keyed is never read
+    public string $legacy; // error: Property PropertyMultiWriteNested\Person::$legacy is never read
+}
+
+function test(Person $p) {
+    [$p->flat] = ['a'];
+    [[$p->nested]] = [['b']];
+    ['k' => ['j' => $p->keyed]] = ['k' => ['j' => 'c']];
+    list(list($p->legacy)) = [['d']];
+}


### PR DESCRIPTION
## Summary

`PropertyWriteVisitor::markPropertyWrites` handled destructuring targets only one level deep: the `List_` branch checked each direct item for a property fetch. A property in a nested destructuring target was classified as a read, so the detector reported a false positive:

```php
class Person {
    public string $nested;
}

[[$p->nested]] = [['b']]; // writes $nested, but was reported "is never written"
```

The new fixture `tests/Rule/data/properties/write-multi-nested.php` fails without the fix for nested arrays, keyed nesting (`['k' => [$p->keyed]] = ...`), and legacy `list(list(...))`; the flat case passes before and after (control).

## Fix

The `List_` branch now recurses into each item value via `markPropertyWrites`. Nested lists of any depth resolve to the same handling as flat items.