### PR TITLE
Detect property writes through references

### DIFF
--- a/src/Visitor/PropertyWriteVisitor.php
+++ b/src/Visitor/PropertyWriteVisitor.php
@@ -49,6 +49,11 @@ final class PropertyWriteVisitor extends NodeVisitorAbstract
             $this->markPropertyWrites($node->var);
         }
 
+        if ($node instanceof AssignRef && $this->isFetch($node->expr)) { // $ref = &$this->prop; any later access of $ref hits the property
+            $node->expr->setAttribute(self::IS_PROPERTY_WRITE, true);
+            $node->expr->setAttribute(self::IS_PROPERTY_WRITE_AND_READ, true);
+        }
+
         if (
             $node instanceof PostInc
             || $node instanceof PostDec

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1108,6 +1108,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-write-multi-nested' => [__DIR__ . '/data/properties/write-multi-nested.php'];
         yield 'property-write-coalesce' => [__DIR__ . '/data/properties/write-coalesce.php'];
         yield 'property-write-inc-dec' => [__DIR__ . '/data/properties/write-inc-dec.php'];
+        yield 'property-write-ref' => [__DIR__ . '/data/properties/write-ref.php'];
         yield 'property-native-reads' => [__DIR__ . '/data/properties/native-reads.php'];
         yield 'property-mixed' => [__DIR__ . '/data/properties/mixed/tracked.php'];
 

--- a/tests/Rule/data/properties/write-ref.php
+++ b/tests/Rule/data/properties/write-ref.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PropertyWriteRef;
+
+class Holder
+{
+
+    private int $instanceValue;
+
+    private static int $staticValue;
+
+    public function updateInstance(): void
+    {
+        $ref = &$this->instanceValue;
+        $ref = 5;
+    }
+
+    public static function updateStatic(): void
+    {
+        $ref = &self::$staticValue;
+        $ref = 6;
+    }
+
+    /**
+     * @return array{int, int}
+     */
+    public function read(): array
+    {
+        return [$this->instanceValue, self::$staticValue];
+    }
+
+}
+
+function test(Holder $holder): void
+{
+    $holder->updateInstance();
+    Holder::updateStatic();
+    print_r($holder->read());
+}


### PR DESCRIPTION
## Summary

A write through a reference alias was invisible to the property-write detection:

```php
class Holder
{
    private int $value;

    public function update(): void
    {
        $ref = &$this->value;
        $ref = 5; // writes $this->value at runtime
    }
}
```

`PropertyWriteVisitor` only marked the `var` side of `AssignRef`, so `$this->value` on the `expr` side was collected as a plain read → false positive `Property Holder::$value is never written`. Same for static properties (`$ref = &self::$value`).

Reproduction fixture: `tests/Rule/data/properties/write-ref.php` (fails without the fix with two false "is never written" reports, for an instance and a static property).

## Fix

Taking a reference to a property (`$ref = &$this->prop`) now marks the fetch as a potential write and read. This is a deliberate conservative over-approximation — any later access of the alias hits the property, and tracking the alias flow statically is not feasible. The cost is only that a reference-taken property can no longer be reported as never written/never read; it introduces no new reports.

This follows the existing convention for methods: first-class callables and constant array callables register a usage at the point where the handle is created (`MethodCallCollector`), without tracking whether the handle is invoked later. Taking a reference to a property is the property-flavored equivalent of that.
