### PR TITLE
Fix case-sensitive comparison of the static keyword in collectors

### DIFF
--- a/src/Collector/ConstantFetchCollector.php
+++ b/src/Collector/ConstantFetchCollector.php
@@ -230,7 +230,7 @@ final class ConstantFetchCollector implements Collector
             $possibleDescendantFetch = null;
         } else {
             $ownerType = $scope->resolveTypeByName($node->class);
-            $possibleDescendantFetch = $node->class->toString() === 'static';
+            $possibleDescendantFetch = strtolower($node->class->toString()) === 'static';
         }
 
         $constantNames = $this->getConstantNames($node, $scope);

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -33,6 +33,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use function array_map;
 use function count;
 use function current;
+use function strtolower;
 
 /**
  * @implements Collector<Node, list<string>>
@@ -118,7 +119,7 @@ final class MethodCallCollector implements Collector
 
             } elseif ($methodCall->class instanceof Name) {
                 $callerType = $scope->resolveTypeByName($methodCall->class);
-                $possibleDescendantCall = $methodCall->class->toString() === 'static';
+                $possibleDescendantCall = strtolower($methodCall->class->toString()) === 'static';
 
             } else {
                 return;
@@ -155,7 +156,7 @@ final class MethodCallCollector implements Collector
 
         } else {
             $callerType = $scope->resolveTypeByName($staticCall->class);
-            $possibleDescendantCall = $staticCall->class->toString() === 'static';
+            $possibleDescendantCall = strtolower($staticCall->class->toString()) === 'static';
         }
 
         foreach ($methodNames as $methodName) {

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -36,6 +36,7 @@ use function array_map;
 use function current;
 use function in_array;
 use function str_starts_with;
+use function strtolower;
 
 /**
  * @implements Collector<Node, list<string>>
@@ -137,7 +138,7 @@ final class PropertyAccessCollector implements Collector
     ): void
     {
         $propertyNames = $this->getPropertyNames($node, $scope);
-        $possibleDescendant = $node->class instanceof Expr || $node->class->toString() === 'static';
+        $possibleDescendant = $node->class instanceof Expr || strtolower($node->class->toString()) === 'static';
 
         if ($node->class instanceof Expr) {
             $callerType = $scope->getType($node->class);

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -929,6 +929,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'method-array-callable-dynamic-name' => [__DIR__ . '/data/methods/array-callable-dynamic-name.php', self::requiresPackage('phpstan/phpstan', '>= 2.1.54')]; // is_callable() narrowing of [$obj, $method] arrays exists since 2.1.54
         yield 'method-code' => [__DIR__ . '/data/methods/basic.php'];
         yield 'method-case-insensitive' => [__DIR__ . '/data/methods/case-insensitive.php'];
+        yield 'method-static-keyword-case' => [__DIR__ . '/data/methods/static-keyword-case.php'];
         yield 'method-ctor' => [__DIR__ . '/data/methods/ctor.php'];
         yield 'method-ctor-interface' => [__DIR__ . '/data/methods/ctor-interface.php'];
         yield 'method-ctor-private' => [__DIR__ . '/data/methods/ctor-private.php'];
@@ -1044,6 +1045,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
         // constants
         yield 'const-basic' => [__DIR__ . '/data/constants/basic.php'];
+        yield 'const-static-keyword-case' => [__DIR__ . '/data/constants/static-keyword-case.php'];
         yield 'const-function' => [__DIR__ . '/data/constants/constant-function.php'];
         yield 'const-descendant-1' => [__DIR__ . '/data/constants/descendant-1.php'];
         yield 'const-descendant-2' => [__DIR__ . '/data/constants/descendant-2.php'];
@@ -1076,6 +1078,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
         // properties
         yield 'property-basic' => [__DIR__ . '/data/properties/basic.php'];
+        yield 'property-static-keyword-case' => [__DIR__ . '/data/properties/static-keyword-case.php'];
         yield 'property-static' => [__DIR__ . '/data/properties/static.php'];
         yield 'property-traits' => [__DIR__ . '/data/properties/traits.php'];
         yield 'property-dynamic' => [__DIR__ . '/data/properties/dynamic.php'];

--- a/tests/Rule/data/constants/static-keyword-case.php
+++ b/tests/Rule/data/constants/static-keyword-case.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace StaticKeywordCaseConst;
+
+class Base
+{
+
+    public const K = 1;
+
+    public function read(): int
+    {
+        return STATIC::K;
+    }
+
+}
+
+class Child extends Base
+{
+
+    public const K = 2;
+
+}
+
+(new Child())->read();

--- a/tests/Rule/data/methods/static-keyword-case.php
+++ b/tests/Rule/data/methods/static-keyword-case.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace StaticKeywordCaseMethod;
+
+class Base
+{
+
+    public function callIt(): void
+    {
+        Static::m();
+    }
+
+    public static function create(): static
+    {
+        return new STATIC();
+    }
+
+    public static function m(): void
+    {
+    }
+
+}
+
+class Child extends Base
+{
+
+    public function __construct()
+    {
+    }
+
+    public static function m(): void
+    {
+    }
+
+}
+
+(new Child())->callIt();
+Child::create();

--- a/tests/Rule/data/properties/static-keyword-case.php
+++ b/tests/Rule/data/properties/static-keyword-case.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace StaticKeywordCaseProperty;
+
+class Base
+{
+
+    public static int $p = 1;
+
+    public function touch(): int
+    {
+        Static::$p = 5;
+        return Static::$p;
+    }
+
+}
+
+class Child extends Base
+{
+
+    public static int $p = 2;
+
+}
+
+(new Child())->touch();


### PR DESCRIPTION
## Summary

PHP resolves the `static` keyword case-insensitively, but four collector sites compared it with `===`:

- `MethodCallCollector` (static calls and `new static`)
- `ConstantFetchCollector` (static constant fetches)
- `PropertyAccessCollector` (static property fetches)

A call like `Static::m()`, `STATIC::K`, `Static::$p` or `new STATIC()` therefore lost the `possibleDescendant` flag. Late-static-binding dispatch to descendant overrides became invisible, and the overrides were reported as dead.

## Reproduction tests first

Three new fixtures (methods, constants, properties) use non-lowercase `static` in a base class with a genuinely dispatched child override. Before the fix they reported:

- `Unused StaticKeywordCaseMethod\Child::m`
- `Unused StaticKeywordCaseConst\Child::K`
- `Property StaticKeywordCaseProperty\Child::$p is never read`

All three members run at runtime (the fixtures execute in `testNoFatalError`).

## Fix

Compare with `strtolower()`, the same way `ConstantFetchCollector` already handles its `self`/`parent`/`static` resolution.