### PR TITLE
Compare native function names case-insensitively in collectors

### DIFF
--- a/src/Collector/ConstantFetchCollector.php
+++ b/src/Collector/ConstantFetchCollector.php
@@ -27,6 +27,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassConstantUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use ShipMonk\PHPStan\DeadCode\Visitor\PhpDocConstFetchCollectingVisitor;
 use function array_map;
 use function count;
@@ -102,7 +103,7 @@ final class ConstantFetchCollector implements Collector
         }
 
         foreach ($functionNames as $functionName) {
-            if ($functionName !== 'constant') {
+            if (!CaseInsensitiveName::equals($functionName, 'constant')) {
                 continue;
             }
 

--- a/src/Collector/MethodCallCollector.php
+++ b/src/Collector/MethodCallCollector.php
@@ -30,6 +30,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use function array_map;
 use function count;
 use function current;
@@ -264,7 +265,7 @@ final class MethodCallCollector implements Collector
         }
 
         foreach ($functionNames as $functionName) {
-            if ($functionName !== 'clone') {
+            if (!CaseInsensitiveName::equals($functionName, 'clone')) {
                 continue;
             }
 

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -30,11 +30,11 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
 use ShipMonk\PHPStan\DeadCode\Visitor\PropertyHookBackingValueVisitor;
 use ShipMonk\PHPStan\DeadCode\Visitor\PropertyWriteVisitor;
 use function array_map;
 use function current;
-use function in_array;
 use function str_starts_with;
 use function strtolower;
 
@@ -389,7 +389,7 @@ final class PropertyAccessCollector implements Collector
         $firstArgType = $scope->getType(current($args)->value);
 
         foreach ($functionNames as $functionName) {
-            if (in_array($functionName, ['get_object_vars', 'get_mangled_object_vars'], true)) {
+            if (CaseInsensitiveName::isOneOf($functionName, ['get_object_vars', 'get_mangled_object_vars'])) {
                 $this->registerAllPropertyReadsForType($firstArgType, $node, $scope);
 
                 if ($this->getObjectClassReflections($firstArgType) === []) {
@@ -405,15 +405,15 @@ final class PropertyAccessCollector implements Collector
                 }
             }
 
-            if ($functionName === 'json_encode') {
+            if (CaseInsensitiveName::equals($functionName, 'json_encode')) {
                 $this->registerJsonEncodePropertyReads($firstArgType, $node, $scope);
             }
 
-            if ($functionName === 'serialize') {
+            if (CaseInsensitiveName::equals($functionName, 'serialize')) {
                 $this->registerSerializePropertyReads($firstArgType, $node, $scope);
             }
 
-            if ($functionName === 'array_column') {
+            if (CaseInsensitiveName::equals($functionName, 'array_column')) {
                 $this->registerArrayColumnPropertyReads($firstArgType, $args, $node, $scope);
             }
         }

--- a/tests/Rule/data/constants/constant-function.php
+++ b/tests/Rule/data/constants/constant-function.php
@@ -5,6 +5,8 @@ namespace DeadConstFn;
 class TestParent {
     const B = 'b';
     const C = 'c'; // error: Unused DeadConstFn\TestParent::C
+    const D = 'd';
+    const E = 'e';
 }
 
 class Test extends TestParent {
@@ -14,7 +16,10 @@ class Test extends TestParent {
 
 function test() {
     $fn = 'constant';
+    $upperFn = 'CONSTANT';
     echo constant('DeadConstFn\Test::A');
     echo constant('Unknown::A');
     echo $fn('\DeadConstFn\Test::B');
+    echo CONSTANT('DeadConstFn\Test::D'); // function names are case-insensitive
+    echo $upperFn('\DeadConstFn\Test::E');
 }

--- a/tests/Rule/data/methods/clone.php
+++ b/tests/Rule/data/methods/clone.php
@@ -32,9 +32,28 @@ class Coord
     public function __clone() {}
 }
 
+class UppercaseCloneFn
+{
+    public function __construct() {}
+
+    public function __clone() {}
+}
+
+class UppercaseCloneString
+{
+    public function __construct() {}
+
+    public function __clone() {}
+}
+
 clone new CloneClass1();
 clone new ChildClass();
 
 clone(new Coord(), [ // PHP 8.5 clone with
     'y' => 1,
 ]);
+
+\CLONE(new UppercaseCloneFn()); // function names are case-insensitive
+
+$cloneFn = 'CLONE';
+$cloneFn(new UppercaseCloneString());

--- a/tests/Rule/data/properties/native-reads.php
+++ b/tests/Rule/data/properties/native-reads.php
@@ -404,3 +404,53 @@ function testSerialize(): void
     $outerWithMagic = new SerializeOuterWithMagicNested();
     serialize($outerWithMagic);
 }
+
+// --- uppercase native function names (PHP resolves function names case-insensitively) ---
+
+class UppercaseGetObjectVars
+{
+    public string $prop;
+
+    public function __construct()
+    {
+        $this->prop = 'a';
+    }
+}
+
+class UppercaseJsonEncode
+{
+    public string $prop;
+
+    public function __construct()
+    {
+        $this->prop = 'a';
+    }
+}
+
+class UppercaseSerialize
+{
+    public string $prop;
+
+    public function __construct()
+    {
+        $this->prop = 'a';
+    }
+}
+
+class UppercaseArrayColumn
+{
+    public string $col;
+
+    public function __construct()
+    {
+        $this->col = 'a';
+    }
+}
+
+function testUppercaseNativeReads(): void
+{
+    GET_OBJECT_VARS(new UppercaseGetObjectVars());
+    JSON_ENCODE(new UppercaseJsonEncode());
+    SERIALIZE(new UppercaseSerialize());
+    ARRAY_COLUMN([new UppercaseArrayColumn()], 'col');
+}


### PR DESCRIPTION
## Summary

PHP resolves function names case-insensitively, but three collectors compared them with strict equality. A member used only through an uppercase-spelled call was reported as dead. Every site below is covered by a reproduction fixture that fails without the fix (8 false positives total):

- `ConstantFetchCollector` (`'constant'`): `CONSTANT('DeadConstFn\Test::D')` and `$fn = 'CONSTANT'; $fn(...)` → `Unused TestParent::D/E` (fixture `tests/Rule/data/constants/constant-function.php`)
- `MethodCallCollector` (`'clone'`): `\CLONE($object)` and `$fn = 'CLONE'; $fn($object)` → `Unused …::__clone` (fixture `tests/Rule/data/methods/clone.php`)
- `PropertyAccessCollector` (`get_object_vars`/`get_mangled_object_vars`, `json_encode`, `serialize`, `array_column`): `GET_OBJECT_VARS(...)`, `JSON_ENCODE(...)`, `SERIALIZE(...)`, `ARRAY_COLUMN(...)` → `$prop is never read` (fixture `tests/Rule/data/properties/native-reads.php`)

## Fix

Use the existing `CaseInsensitiveName` helper (`equals` / `isOneOf`) at each comparison. Both the direct-name path (`$node->name instanceof Name`) and the constant-string callable path go through the same comparison, so both forms are fixed.

The `static` keyword comparisons in the same collectors are a separate defect and are left for their own PR.