### PR TITLE
TestsUsageExcluder: do not crash on missing autoload-dev path

### DIFF
--- a/src/Excluder/TestsUsageExcluder.php
+++ b/src/Excluder/TestsUsageExcluder.php
@@ -45,7 +45,9 @@ final class TestsUsageExcluder implements MemberUsageExcluder
         $this->composerIntrospector = $composerIntrospector;
         $this->enabled = $enabled;
 
-        if ($devPaths !== null) {
+        if (!$enabled) {
+            $this->devPaths = [];
+        } elseif ($devPaths !== null) {
             $resolvedPaths = [];
 
             foreach ($devPaths as $devPath) {
@@ -185,7 +187,13 @@ final class TestsUsageExcluder implements MemberUsageExcluder
                     continue;
                 }
 
-                $result[] = $this->realpath($absolutePath);
+                $realPath = $this->tryRealpath($absolutePath);
+
+                if ($realPath === null) { // autoload-dev path may be absent (e.g. dist install with export-ignored tests)
+                    continue;
+                }
+
+                $result[] = $realPath;
             }
         }
 
@@ -194,17 +202,24 @@ final class TestsUsageExcluder implements MemberUsageExcluder
 
     private function realpath(string $path): string
     {
+        $realPath = $this->tryRealpath($path);
+
+        if ($realPath === null) {
+            throw new LogicException("Unable to realpath '$path'");
+        }
+
+        return $realPath;
+    }
+
+    private function tryRealpath(string $path): ?string
+    {
         if (str_starts_with($path, 'phar://')) {
             return $path;
         }
 
         $realPath = realpath($path);
 
-        if ($realPath === false) {
-            throw new LogicException("Unable to realpath '$path'");
-        }
-
-        return $realPath;
+        return $realPath === false ? null : $realPath;
     }
 
 }

--- a/tests/Excluder/TestsUsageExcluderTest.php
+++ b/tests/Excluder/TestsUsageExcluderTest.php
@@ -24,4 +24,26 @@ final class TestsUsageExcluderTest extends PHPStanTestCase
         ], $devPathsPropertyReflection->getValue($excluder));
     }
 
+    public function testMissingAutoloadDevPathIsSkipped(): void
+    {
+        $excluder = new TestsUsageExcluder(self::getContainer()->getByType(ReflectionProvider::class), new ComposerIntrospector(), true, null);
+
+        $extractAutoloadPaths = (new ReflectionClass(TestsUsageExcluder::class))->getMethod('extractAutoloadPaths');
+
+        self::assertSame([], $extractAutoloadPaths->invoke($excluder, __DIR__, ['App\\Tests\\' => 'this-dir-does-not-exist']));
+        self::assertSame(
+            [realpath(__DIR__)],
+            $extractAutoloadPaths->invoke($excluder, __DIR__, ['App\\Tests\\' => ['this-dir-does-not-exist', '.']]),
+        );
+    }
+
+    public function testNoAutodetectionWhenDisabled(): void
+    {
+        $excluder = new TestsUsageExcluder(self::getContainer()->getByType(ReflectionProvider::class), new ComposerIntrospector(), false, null);
+
+        $devPathsPropertyReflection = (new ReflectionClass(TestsUsageExcluder::class))->getProperty('devPaths');
+
+        self::assertSame([], $devPathsPropertyReflection->getValue($excluder));
+    }
+
 }


### PR DESCRIPTION
## Summary

`TestsUsageExcluder` resolved autodetected `autoload-dev` paths with a `realpath()` helper that throws `LogicException("Unable to realpath ...")` when the path is absent. Analysing any project whose `composer.json` lists an autoload-dev directory that does not exist on disk (common for dist installs where `tests/` is export-ignored) aborted the whole PHPStan run. Only glob (`*`) paths were guarded. The autodetection also ran unconditionally in the constructor, even with the excluder disabled — so the crash hit users who never enabled it.

Both reproduce in the new tests: `testMissingAutoloadDevPathIsSkipped` threw `LogicException` and `testNoAutodetectionWhenDisabled` found autodetected paths despite `enabled: false`.

## Fix

- A nonexistent autoload-dev path cannot contain any analyzed file, so it is now skipped instead of throwing (`tryRealpath`). Explicitly configured `devPaths` still fail loudly — a typo in `phpstan.neon` should surface.
- The constructor skips path resolution entirely when the excluder is disabled.