### PR TITLE
Collect property writes in foreach targets

### DIFF
--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -288,15 +288,7 @@ final class PropertyAccessCollector implements Collector
             $targets[] = $node->keyVar;
         }
 
-        if ($node->valueVar instanceof List_) { // foreach ($rows as [$this->first, $this->second])
-            foreach ($node->valueVar->items as $item) {
-                if ($item !== null) {
-                    $targets[] = $item->value;
-                }
-            }
-        } else {
-            $targets[] = $node->valueVar;
-        }
+        $this->flattenForeachTarget($node->valueVar, $targets);
 
         foreach ($targets as $target) {
             if ($target instanceof PropertyFetch) {
@@ -307,6 +299,27 @@ final class PropertyAccessCollector implements Collector
                 $this->registerStaticPropertyAccess($target, $scope, AccessType::WRITE);
             }
         }
+    }
+
+    /**
+     * @param list<Expr> $targets
+     */
+    private function flattenForeachTarget(
+        Expr $target,
+        array &$targets,
+    ): void
+    {
+        if ($target instanceof List_) { // foreach ($rows as [$this->first, [$this->nested]])
+            foreach ($target->items as $item) {
+                if ($item !== null) {
+                    $this->flattenForeachTarget($item->value, $targets);
+                }
+            }
+
+            return;
+        }
+
+        $targets[] = $target;
     }
 
     private function registerPromotedPropertyWrites(

--- a/src/Collector/PropertyAccessCollector.php
+++ b/src/Collector/PropertyAccessCollector.php
@@ -8,9 +8,11 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Cast\Array_ as ArrayCast;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Foreach_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\InClassMethodNode;
@@ -84,6 +86,10 @@ final class PropertyAccessCollector implements Collector
 
         if ($node instanceof InClassMethodNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
             $this->registerPromotedPropertyWrites($node, $scope);
+        }
+
+        if ($node instanceof Foreach_) { // NodeScopeResolver never dispatches property fetches in foreach targets
+            $this->registerForeachTargetWrites($node, $scope);
         }
 
         if ($node instanceof ArrayCast) {
@@ -269,6 +275,38 @@ final class PropertyAccessCollector implements Collector
         }
 
         return $function->isMethodOrPropertyHook() && $function->getHookedPropertyName() === $propertyName;
+    }
+
+    private function registerForeachTargetWrites(
+        Foreach_ $node,
+        Scope $scope,
+    ): void
+    {
+        $targets = [];
+
+        if ($node->keyVar !== null) {
+            $targets[] = $node->keyVar;
+        }
+
+        if ($node->valueVar instanceof List_) { // foreach ($rows as [$this->first, $this->second])
+            foreach ($node->valueVar->items as $item) {
+                if ($item !== null) {
+                    $targets[] = $item->value;
+                }
+            }
+        } else {
+            $targets[] = $node->valueVar;
+        }
+
+        foreach ($targets as $target) {
+            if ($target instanceof PropertyFetch) {
+                $this->registerInstancePropertyAccess($target, $scope, AccessType::WRITE);
+            }
+
+            if ($target instanceof StaticPropertyFetch) {
+                $this->registerStaticPropertyAccess($target, $scope, AccessType::WRITE);
+            }
+        }
     }
 
     private function registerPromotedPropertyWrites(

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1109,6 +1109,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'property-write-coalesce' => [__DIR__ . '/data/properties/write-coalesce.php'];
         yield 'property-write-inc-dec' => [__DIR__ . '/data/properties/write-inc-dec.php'];
         yield 'property-write-ref' => [__DIR__ . '/data/properties/write-ref.php'];
+        yield 'property-write-foreach' => [__DIR__ . '/data/properties/write-foreach.php'];
         yield 'property-native-reads' => [__DIR__ . '/data/properties/native-reads.php'];
         yield 'property-mixed' => [__DIR__ . '/data/properties/mixed/tracked.php'];
 

--- a/tests/Rule/data/properties/write-foreach.php
+++ b/tests/Rule/data/properties/write-foreach.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace PropertyWriteForeach;
+
+class Test
+{
+    private int $asValue;
+    private string $asKey;
+    private int $asListItem;
+    private static int $asStaticValue; // error: Property PropertyWriteForeach\Test::$asStaticValue is never read
+    private int $writeOnly; // error: Property PropertyWriteForeach\Test::$writeOnly is never read
+
+    /**
+     * @param list<int> $items
+     * @param array<string, mixed> $map
+     * @param list<array{int}> $rows
+     * @param list<int> $other
+     */
+    public function fill(array $items, array $map, array $rows, array $other): void
+    {
+        foreach ($items as $this->asValue) {
+        }
+
+        foreach ($map as $this->asKey => $ignored) {
+        }
+
+        foreach ($rows as [$this->asListItem]) {
+        }
+
+        foreach ($other as $this->writeOnly) {
+        }
+
+        foreach ($items as self::$asStaticValue) {
+        }
+    }
+
+    public function read(): string
+    {
+        return $this->asValue . $this->asKey . $this->asListItem;
+    }
+}
+
+function test(Test $test): void
+{
+    $test->fill([], [], [], []);
+    echo $test->read();
+}

--- a/tests/Rule/data/properties/write-foreach.php
+++ b/tests/Rule/data/properties/write-foreach.php
@@ -7,6 +7,7 @@ class Test
     private int $asValue;
     private string $asKey;
     private int $asListItem;
+    private int $asNestedListItem;
     private static int $asStaticValue; // error: Property PropertyWriteForeach\Test::$asStaticValue is never read
     private int $writeOnly; // error: Property PropertyWriteForeach\Test::$writeOnly is never read
 
@@ -14,9 +15,10 @@ class Test
      * @param list<int> $items
      * @param array<string, mixed> $map
      * @param list<array{int}> $rows
+     * @param list<array{array{int}}> $nested
      * @param list<int> $other
      */
-    public function fill(array $items, array $map, array $rows, array $other): void
+    public function fill(array $items, array $map, array $rows, array $nested, array $other): void
     {
         foreach ($items as $this->asValue) {
         }
@@ -25,6 +27,9 @@ class Test
         }
 
         foreach ($rows as [$this->asListItem]) {
+        }
+
+        foreach ($nested as [[$this->asNestedListItem]]) {
         }
 
         foreach ($other as $this->writeOnly) {
@@ -36,12 +41,12 @@ class Test
 
     public function read(): string
     {
-        return $this->asValue . $this->asKey . $this->asListItem;
+        return $this->asValue . $this->asKey . $this->asListItem . $this->asNestedListItem;
     }
 }
 
 function test(Test $test): void
 {
-    $test->fill([], [], [], []);
+    $test->fill([], [], [], [], []);
     echo $test->read();
 }


### PR DESCRIPTION
## Summary

A property written as a `foreach` target is reported as `is never written` although it is written on every iteration:

```php
foreach ($items as $this->value) {}            // value target
foreach ($map as $this->key => $ignored) {}    // key target
foreach ($rows as [$this->item]) {}            // flat destructuring target
foreach ($items as self::$staticValue) {}      // static property target
```

Root cause: PHPStan's `NodeScopeResolver` dispatches foreach targets to node callbacks only when they are plain variables (`VariableAssignNode`) or lists (a virtual `Assign` of the whole list). A `PropertyFetch`/`StaticPropertyFetch` target — and the fetches inside a list target — never reach collectors at all, so no write (nor any access) was collected. This also means the existing `PropertyWriteVisitor` attribute mechanism cannot help here: the marked nodes are never delivered.

Reproduced by the new fixture `tests/Rule/data/properties/write-foreach.php`, which fails without the fix (all five properties reported `is never written`).

## Fix

`PropertyAccessCollector` now handles `Foreach_` statements itself and registers a `WRITE` access for the key variable, the value variable, and flat `List_` items when they are property fetches. Write-only foreach targets stay write-only — the fixture's `$writeOnly` and `$asStaticValue` are still correctly reported as `is never read`.

Nested destructuring targets (`foreach ($x as [[$this->a]])`) share a root cause with nested destructuring in plain assignments and are left for a separate fix.

**Update:** nested destructuring targets (`foreach ($rows as [[$this->prop]])`) are now flattened recursively too — the first version handled only direct list items.
