### PR TITLE
Symfony: support repeated #[UniqueEntity] attributes

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -201,14 +201,14 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     private function getUniqueEntityUsages(InClassNode $node): array
     {
         $repositoryClass = null;
-        $repositoryMethod = null;
+        $repositoryMethods = [];
 
         foreach ($node->getClassReflection()->getNativeReflection()->getAttributes() as $attribute) {
-            if ($attribute->getName() === 'Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity') {
+            if ($attribute->getName() === 'Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity') { // repeatable attribute, each can hold own repositoryMethod
                 $arguments = $attribute->getArguments();
 
                 if (isset($arguments['repositoryMethod']) && is_string($arguments['repositoryMethod'])) {
-                    $repositoryMethod = $arguments['repositoryMethod'];
+                    $repositoryMethods[] = $arguments['repositoryMethod'];
                 }
             }
 
@@ -221,8 +221,14 @@ final class SymfonyUsageProvider implements MemberUsageProvider
             }
         }
 
-        if ($repositoryClass !== null && $repositoryMethod !== null) {
-            $usage = new ClassMethodUsage(
+        if ($repositoryClass === null) {
+            return [];
+        }
+
+        $usages = [];
+
+        foreach ($repositoryMethods as $repositoryMethod) {
+            $usages[] = new ClassMethodUsage(
                 UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Used in #[UniqueEntity] attribute')),
                 new ClassMethodRef(
                     $repositoryClass,
@@ -230,10 +236,9 @@ final class SymfonyUsageProvider implements MemberUsageProvider
                     possibleDescendant: false,
                 ),
             );
-            return [$usage];
         }
 
-        return [];
+        return $usages;
     }
 
     /**

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -200,12 +200,22 @@ class ValidatedModel
 }
 
 
-#[UniqueEntity(repositoryMethod: 'findByUniqueName')]
+#[UniqueEntity(fields: ['name'], repositoryMethod: 'findByUniqueName')]
 #[Entity(repositoryClass: CompanyRepository::class)]
 class Company {}
 
 class CompanyRepository {
     public function findByUniqueName(): void {}
+}
+
+#[UniqueEntity(fields: ['email'], repositoryMethod: 'findByUniqueEmail')]
+#[UniqueEntity(fields: ['slug'], repositoryMethod: 'findByUniqueSlug')]
+#[Entity(repositoryClass: OrganizationRepository::class)]
+class Organization {}
+
+class OrganizationRepository {
+    public function findByUniqueEmail(): void {}
+    public function findByUniqueSlug(): void {}
 }
 
 class SomeController3 {


### PR DESCRIPTION
## Summary

`#[UniqueEntity]` is `IS_REPEATABLE`, and `UniqueEntityValidator` calls `$repository->{$constraint->repositoryMethod}(...)` per constraint instance. `SymfonyUsageProvider::getUniqueEntityUsages` overwrote a single `$repositoryMethod` variable in its attribute loop and emitted one usage after it, so with two attributes only the last `repositoryMethod` survived:

```php
#[UniqueEntity(fields: ['email'], repositoryMethod: 'findByUniqueEmail')]
#[UniqueEntity(fields: ['slug'], repositoryMethod: 'findByUniqueSlug')]
#[Entity(repositoryClass: OrganizationRepository::class)]
class Organization {}
```

reported `Unused OrganizationRepository::findByUniqueEmail` although the validator calls both methods. The extended fixture reproduces this before the fix.

## Fix

Collect the `repositoryMethod` of every `UniqueEntity` attribute and emit one usage per method.

Drive-by: the pre-existing fixture used `#[UniqueEntity(repositoryMethod: 'findByUniqueName')]` without the required `$fields` argument — invalid at runtime (`newInstance()` would fail). It now passes `fields: ['name']`; the new fixture class uses the valid form as well.