### PR TITLE
Symfony: detect #[Interact] on invokable commands without #[AsCommand]

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -1626,8 +1626,12 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     {
         $class = $method->getDeclaringClass();
 
+        // Symfony scans for #[Interact] any invokable command, even without #[AsCommand]
         return $this->hasAttribute($method, 'Symfony\Component\Console\Attribute\Interact')
-            && $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand');
+            && (
+                $this->hasAttribute($class, 'Symfony\Component\Console\Attribute\AsCommand')
+                || $class->isSubclassOf('Symfony\Component\Console\Command\Command')
+            );
     }
 
     private function isMethodWithCallbackConstraintAttribute(ReflectionMethod $method): bool

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -55,6 +55,21 @@ class CreateUserCommand extends Command {
     }
 }
 
+class LegacyNamedCommand extends Command { // no #[AsCommand], name passed to parent constructor
+
+    public function __construct() {
+        parent::__construct('app:legacy-named');
+    }
+
+    public function __invoke(): int {
+        return 0;
+    }
+
+    #[Interact]
+    public function askMissing() {
+    }
+}
+
 class FooBundle extends Bundle {
     public function __construct() {
     }


### PR DESCRIPTION
## Summary

`isMethodWithInteractAttribute()` required the class to carry `#[AsCommand]`. Symfony does not: `Command::__construct` (symfony/console 7.4) wraps any `Command` subclass that defines `__invoke` without overriding `execute` in `InvokableCommand`, whose `collectInteractions()` scans all class methods for `#[Interact]` — no `#[AsCommand]` involved.

False positive: a command that sets its name via `parent::__construct('app:legacy-named')` or `configure()` gets its `#[Interact]` methods reported dead. The new `LegacyNamedCommand` fixture reproduced `Unused Symfony\LegacyNamedCommand::askMissing` before the fix.

## Fix

Accept `#[AsCommand]` or a `Command` subclass — the same check `getMapInputUsages()` already uses, so the two paths are now consistent.

**Version coverage:** `#[Interact]` exists since symfony/console 7.4 (7.4 CHANGELOG). The discovery mechanism is identical in 7.4 and 8.0 (`Command::__construct` wraps any invokable subclass that does not override `execute()`; verified on the 8.0 branch). Older versions have no such attribute, so no variant exists there.
