### PR TITLE
Fix case-sensitive matching of trait adaptation names

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -428,24 +428,34 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
         foreach ($usedTraits as $traitName => $adaptations) {
             $traitMethods = $this->typeDefinitions[$traitName]['methods'] ?? [];
 
-            $excludedMethods = array_merge(
-                $overriddenMethods,
-                $adaptations['excluded'] ?? [],
+            // method names are case-insensitive in PHP, but adaptations are stored as written
+            $excludedMethods = array_map(
+                static fn (string $excludedMethod): string => strtolower($excludedMethod),
+                array_merge(
+                    $overriddenMethods,
+                    $adaptations['excluded'] ?? [],
+                ),
             );
+
+            $aliases = [];
+
+            foreach ($adaptations['aliases'] ?? [] as $sourceMethodName => $newMethodName) {
+                $aliases[strtolower($sourceMethodName)] = $newMethodName;
+            }
 
             foreach ($traitMethods as $traitMethod => $traitMethodData) {
                 if ($traitMethodData['abstract']) {
                     continue; // abstract trait methods are ignored, should correlate with isNeverReportedAsDead
                 }
 
-                $aliasMethodName = $adaptations['aliases'][$traitMethod] ?? null;
+                $aliasMethodName = $aliases[strtolower($traitMethod)] ?? null;
 
                 // both method names need to work
                 if ($aliasMethodName !== null) {
                     $this->traitMembers[MemberType::METHOD->value][$typeName][$traitName][$aliasMethodName] = $traitMethod;
                 }
 
-                if (in_array($traitMethod, $excludedMethods, true)) {
+                if (in_array(strtolower($traitMethod), $excludedMethods, true)) {
                     continue; // was replaced by insteadof
                 }
 

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -977,6 +977,8 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'method-trait-23' => [__DIR__ . '/data/methods/traits-23.php'];
         yield 'method-trait-24' => [__DIR__ . '/data/methods/traits-24.php'];
         yield 'method-trait-25' => [__DIR__ . '/data/methods/traits-25.php'];
+        yield 'method-trait-26' => [__DIR__ . '/data/methods/traits-26.php'];
+        yield 'method-trait-27' => [__DIR__ . '/data/methods/traits-27.php'];
         yield 'method-nullsafe' => [__DIR__ . '/data/methods/nullsafe.php'];
         yield 'method-parent-1' => [__DIR__ . '/data/methods/parent-1.php'];
         yield 'method-parent-2' => [__DIR__ . '/data/methods/parent-2.php'];

--- a/tests/Rule/data/methods/traits-26.php
+++ b/tests/Rule/data/methods/traits-26.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace DeadTrait26;
+
+trait A {
+    public function talk() {
+        echo 'A';
+    }
+}
+
+class CaseMismatchedAlias {
+    use A {
+        TALK as speak; // PHP resolves the source method name case-insensitively
+    }
+}
+
+$o = new CaseMismatchedAlias();
+$o->speak();

--- a/tests/Rule/data/methods/traits-27.php
+++ b/tests/Rule/data/methods/traits-27.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace DeadTrait27;
+
+trait A {
+    public function talk() { // error: Unused DeadTrait27\A::talk
+        echo 'A';
+    }
+}
+
+trait B {
+    public function talk() {
+        echo 'B';
+    }
+}
+
+class CaseMismatchedInsteadof {
+    use A, B {
+        B::TALK insteadof A; // PHP resolves the method name case-insensitively
+    }
+}
+
+$o = new CaseMismatchedInsteadof();
+$o->talk();


### PR DESCRIPTION
## Summary

PHP resolves method names in trait `use` adaptations case-insensitively, but `DeadCodeRule::fillTraitMethodUsages` compared them as written. Both reproduction fixtures are valid runnable PHP (executed by `testNoFatalError`), and both failed before the fix:

- **Alias, case-mismatched source name** (`tests/Rule/data/methods/traits-26.php`): `use A { TALK as speak; }` — the alias map lookup missed, `speak()` matched nothing, and `A::talk` was falsely reported unused although `$o->speak()` dispatches to it at runtime.
- **`insteadof`, case-mismatched name** (`tests/Rule/data/methods/traits-27.php`): `use A, B { B::TALK insteadof A; }` — the exclusion missed, so `A::talk` stayed registered and (being processed first) shadowed `B::talk` in the overridden list. The detector then reported the **live** `B::talk` as unused and missed the genuinely dead `A::talk` — the `insteadof` semantics were fully inverted, not just a missed report.

## Fix

Lowercase both sides of the alias lookup and the exclusion check at lookup time in `fillTraitMethodUsages`. The fix is at lookup rather than collection so the collected adaptation data keeps its written spelling (useful for output, and no change to the collected data shape). Constant adaptations are untouched — PHP constant names are case-sensitive, so the exact matching there is correct.