### PR TITLE
Symfony: complete kernel event names in listener heuristic

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -1743,10 +1743,15 @@ final class SymfonyUsageProvider implements MemberUsageProvider
     {
         $methodName = $method->getName();
 
-        return CaseInsensitiveName::isOneOf($methodName, [
-            'onKernelResponse',
-            'onKernelException',
+        return CaseInsensitiveName::isOneOf($methodName, [ // conventional method names for all KernelEvents and ConsoleEvents
             'onKernelRequest',
+            'onKernelException',
+            'onKernelController',
+            'onKernelControllerArguments',
+            'onKernelView',
+            'onKernelResponse',
+            'onKernelFinishRequest',
+            'onKernelTerminate',
             'onConsoleError',
             'onConsoleCommand',
             'onConsoleSignal',

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -1011,6 +1011,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-symfony' => [__DIR__ . '/data/providers/symfony.php'];
         yield 'provider-symfony-7.1' => [__DIR__ . '/data/providers/symfony-gte71.php', self::requiresPackage('symfony/dependency-injection', '>= 7.1')];
         yield 'provider-symfony-callback-closure' => [__DIR__ . '/data/providers/symfony-callback-closure.php'];
+        yield 'provider-symfony-listener-heuristic' => [__DIR__ . '/data/providers/symfony-listener-heuristic.php'];
         yield 'provider-symfony-map-payload' => [__DIR__ . '/data/providers/symfony-map-payload.php', self::requiresPackage('symfony/http-kernel', '>= 6.3')];
         yield 'provider-symfony-map-payload-type' => [__DIR__ . '/data/providers/symfony-map-payload-type.php', self::requiresPackage('symfony/http-kernel', '>= 7.1')];
         yield 'provider-symfony-scheduler' => [__DIR__ . '/data/providers/symfony-scheduler.php', self::requiresPackage('symfony/scheduler', '>= 6.3')];

--- a/tests/Rule/data/providers/symfony-listener-heuristic.php
+++ b/tests/Rule/data/providers/symfony-listener-heuristic.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace SymfonyListenerHeuristic;
+
+// registered as kernel.event_listener via YAML config, which the analyser cannot see;
+// the listener methods survive only thanks to the isProbablySymfonyListener heuristic
+class YamlRegisteredListener
+{
+
+    public function onKernelRequest(): void
+    {
+    }
+
+    public function onKernelController(): void
+    {
+    }
+
+    public function onKernelControllerArguments(): void
+    {
+    }
+
+    public function onKernelView(): void
+    {
+    }
+
+    public function onKernelFinishRequest(): void
+    {
+    }
+
+    public function onKernelTerminate(): void
+    {
+    }
+
+    public function someHelper(): void // error: Unused SymfonyListenerHeuristic\YamlRegisteredListener::someHelper
+    {
+    }
+
+}


### PR DESCRIPTION
## Summary

`SymfonyUsageProvider::isProbablySymfonyListener()` is the fallback for listeners the analyser cannot see (registered via YAML `kernel.event_listener` tags, no container XML available). Its method-name list covered all conventional `ConsoleEvents` names but only three of the eight `KernelEvents` names. Listeners using `onKernelController`, `onKernelControllerArguments`, `onKernelView`, `onKernelFinishRequest` or `onKernelTerminate` were reported dead.

The omitted names are exactly what `RegisterListenersPass` derives as the default method (`'on' . CamelCase(event)`) from the real `KernelEvents` constants (verified against symfony/http-kernel 7.4.7 and symfony/event-dispatcher `RegisterListenersPass:91-95`).

## Test

The heuristic had no fixture at all. The new rule fixture `symfony-listener-heuristic.php` defines a plain class with all eight `onKernel*` names plus a dead control method. Without the fix it fails with five false `Unused` reports; the covered `onKernelRequest` control passes, proving the heuristic path is exercised.

## Fix

Complete the list with the five missing kernel names. The list now contains the conventional name of every `KernelEvents` and `ConsoleEvents` event.