### PR TITLE
Doctrine: fix parsing of AutoconfigureTag doctrine.event_listener attributes

### DIFF
--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -306,25 +306,11 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             }
 
             // AutoconfigureTag(?string $name, array $attributes) nests the tag attributes in its second argument
-            $tagAttributes = $arguments[1] ?? $arguments['attributes'] ?? [];
+            $tagAttributes = $arguments[1] ?? $arguments['attributes'] ?? null;
+            $eventName = is_array($tagAttributes) ? $tagAttributes['event'] ?? null : null;
 
-            if (!is_array($tagAttributes)) {
-                continue;
-            }
-
-            $listenerMethodName = $tagAttributes['method'] ?? null;
-
-            if (is_string($listenerMethodName)) {
-                if (CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
-                    return true;
-                }
-
-                continue;
-            }
-
-            // With no method attribute, DoctrineBundle calls a method named after the event, or falls back to __invoke
-            $eventName = $tagAttributes['event'] ?? null;
-
+            // The doctrine.event_listener tag has no 'method' attribute
+            // Symfony looks for a method named after the event, or falls back to __invoke
             if (
                 (is_string($eventName) && CaseInsensitiveName::equals($eventName, $methodName))
                 || CaseInsensitiveName::equals($methodName, '__invoke')

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -24,6 +24,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
+use function is_array;
 use function is_string;
 use function str_starts_with;
 
@@ -304,16 +305,30 @@ final class DoctrineUsageProvider implements MemberUsageProvider
                 continue;
             }
 
-            $listenerMethodName = $arguments['method'] ?? null;
+            // AutoconfigureTag(?string $name, array $attributes) nests the tag attributes in its second argument
+            $tagAttributes = $arguments[1] ?? $arguments['attributes'] ?? [];
 
-            // If no method is specified, the listener method name is inferred from the event name
-            if ($listenerMethodName === null) {
-                $eventName = $arguments['event'] ?? null;
+            if (!is_array($tagAttributes)) {
+                continue;
+            }
 
-                if (is_string($eventName) && CaseInsensitiveName::equals($eventName, $methodName)) {
+            $listenerMethodName = $tagAttributes['method'] ?? null;
+
+            if (is_string($listenerMethodName)) {
+                if (CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
                     return true;
                 }
-            } elseif (is_string($listenerMethodName) && CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
+
+                continue;
+            }
+
+            // With no method attribute, DoctrineBundle calls a method named after the event, or falls back to __invoke
+            $eventName = $tagAttributes['event'] ?? null;
+
+            if (
+                (is_string($eventName) && CaseInsensitiveName::equals($eventName, $methodName))
+                || CaseInsensitiveName::equals($methodName, '__invoke')
+            ) {
                 return true;
             }
         }

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -98,7 +98,7 @@ class AsDoctrineListenerWithInvoke {
 
 }
 
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', event: 'postGenerateSchema')]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postGenerateSchema'])]
 class FixDoctrineMigrationTableSchemaWithAutoconfigureTag {
 
     public function postGenerateSchema(): void {}
@@ -107,7 +107,7 @@ class FixDoctrineMigrationTableSchemaWithAutoconfigureTag {
 
 }
 
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', event: 'postGenerateSchema', method: 'onPostGenerateSchema')]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postGenerateSchema', 'method' => 'onPostGenerateSchema'])]
 class FixDoctrineMigrationTableSchemaWithAutoconfigureTagAndMethod {
 
     public function onPostGenerateSchema(): void {}
@@ -133,8 +133,8 @@ class MultipleAsDoctrineListeners {
 }
 
 // Test multiple AutoconfigureTag attributes
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', event: 'postPersist')]
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', event: 'postUpdate', method: 'afterUpdate')]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postPersist'])]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postUpdate', 'method' => 'afterUpdate'])]
 class MultipleAutoconfigureTags {
 
     public function postPersist(): void {}
@@ -142,5 +142,35 @@ class MultipleAutoconfigureTags {
     public function afterUpdate(): void {}
 
     public function unusedMethod(): void {} // error: Unused Doctrine\MultipleAutoconfigureTags::unusedMethod
+
+}
+
+// Custom event dispatched via EventManager::dispatchEvent, not present in the known ORM event list
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myCustomEvent'])]
+class CustomEventAutoconfigureTag {
+
+    public function myCustomEvent(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\CustomEventAutoconfigureTag::unusedMethod
+
+}
+
+// Named-argument form of the attributes array
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag(name: 'doctrine.event_listener', attributes: ['event' => 'myOtherCustomEvent', 'method' => 'handleCustom'])]
+class CustomEventAutoconfigureTagNamedArgs {
+
+    public function handleCustom(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\CustomEventAutoconfigureTagNamedArgs::unusedMethod
+
+}
+
+// No method attribute and no method named after the event: DoctrineBundle falls back to __invoke
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myInvokedCustomEvent'])]
+class CustomEventAutoconfigureTagInvoke {
+
+    public function __invoke(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\CustomEventAutoconfigureTagInvoke::unusedMethod
 
 }

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -107,12 +107,13 @@ class FixDoctrineMigrationTableSchemaWithAutoconfigureTag {
 
 }
 
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postGenerateSchema', 'method' => 'onPostGenerateSchema'])]
-class FixDoctrineMigrationTableSchemaWithAutoconfigureTagAndMethod {
+// The doctrine.event_listener tag has no 'method' attribute, Symfony ignores such key
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myTaggedCustomEvent', 'method' => 'ignoredMethod'])]
+class AutoconfigureTagWithUnsupportedMethodAttribute {
 
-    public function onPostGenerateSchema(): void {}
+    public function myTaggedCustomEvent(): void {}
 
-    public function unusedMethod(): void {} // error: Unused Doctrine\FixDoctrineMigrationTableSchemaWithAutoconfigureTagAndMethod::unusedMethod
+    public function ignoredMethod(): void {} // error: Unused Doctrine\AutoconfigureTagWithUnsupportedMethodAttribute::ignoredMethod
 
 }
 
@@ -133,13 +134,13 @@ class MultipleAsDoctrineListeners {
 }
 
 // Test multiple AutoconfigureTag attributes
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postPersist'])]
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'postUpdate', 'method' => 'afterUpdate'])]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myFirstCustomEvent'])]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'mySecondCustomEvent'])]
 class MultipleAutoconfigureTags {
 
-    public function postPersist(): void {}
+    public function myFirstCustomEvent(): void {}
 
-    public function afterUpdate(): void {}
+    public function mySecondCustomEvent(): void {}
 
     public function unusedMethod(): void {} // error: Unused Doctrine\MultipleAutoconfigureTags::unusedMethod
 
@@ -156,16 +157,16 @@ class CustomEventAutoconfigureTag {
 }
 
 // Named-argument form of the attributes array
-#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag(name: 'doctrine.event_listener', attributes: ['event' => 'myOtherCustomEvent', 'method' => 'handleCustom'])]
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag(name: 'doctrine.event_listener', attributes: ['event' => 'myOtherCustomEvent'])]
 class CustomEventAutoconfigureTagNamedArgs {
 
-    public function handleCustom(): void {}
+    public function myOtherCustomEvent(): void {}
 
     public function unusedMethod(): void {} // error: Unused Doctrine\CustomEventAutoconfigureTagNamedArgs::unusedMethod
 
 }
 
-// No method attribute and no method named after the event: DoctrineBundle falls back to __invoke
+// No method named after the event: Symfony falls back to __invoke
 #[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myInvokedCustomEvent'])]
 class CustomEventAutoconfigureTagInvoke {
 

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -166,6 +166,14 @@ class CustomEventAutoconfigureTagNamedArgs {
 
 }
 
+// Tags other than doctrine.event_listener are not doctrine listeners
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('kernel.event_listener', ['event' => 'myKernelEvent'])]
+class OtherTagAutoconfigureTag {
+
+    public function myKernelEvent(): void {} // error: Unused Doctrine\OtherTagAutoconfigureTag::myKernelEvent
+
+}
+
 // No method named after the event: Symfony falls back to __invoke
 #[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_listener', ['event' => 'myInvokedCustomEvent'])]
 class CustomEventAutoconfigureTagInvoke {


### PR DESCRIPTION
## Problem

`isPartOfAutoconfigureTagDoctrineListener` read `$arguments['method']` / `$arguments['event']` as top-level `#[AutoconfigureTag]` arguments. The real signature is `__construct(?string $name = null, array $attributes = [])` — there are no such parameters, and the tag attributes nest in the second argument, which the provider never inspected.

Two consequences:

- Listener methods for custom events (any event outside the hardcoded ORM list in `isProbablyDoctrineListener`) were reported dead although Doctrine calls them.
- The named-argument syntax the provider expected (`event:`, `method:`) crashes real container compilation: `RegisterAutoconfigureAttributesPass` calls `newInstance()`, which throws `Unknown named parameter $event`. The fixtures used exactly that invalid syntax, so they enshrined the wrong parsing.

The provider also honoured a `method` tag attribute. That attribute does not exist for `doctrine.event_listener`. The tag accepts only `event`, `priority` and `connection`:

- `RegisterEventListenersAndSubscribersPass` of the Symfony Doctrine bridge reads `$tag['event']` only, in every maintained version.
- `ContainerAwareEventManager::getMethod()` then calls the method that has the name of the event, or `__invoke` when no such method exists.

A `method` key therefore has no effect. `method` belongs to a different tag, `doctrine.orm.entity_listener` (`#[AsEntityListener]`), which `isPartOfAsEntityListener` already handles.

## Fix

- Read `event` from the nested attributes array. Support the positional (`$arguments[1]`) and the named (`$arguments['attributes']`) form. Tag-name handling does not change.
- Remove the `method` handling.
- Mirror the `__invoke` branch of `isPartOfAsDoctrineListener`. This branch changes no output today, because `__invoke` is in `DeadCodeRule::UNSUPPORTED_MAGIC_METHODS` and is never reported. It keeps the two methods symmetric and correct if that changes.
- Fixtures now use valid syntax and cover a custom event (positional and named form), a tag that carries an unsupported `method` key, and a tag with a different tag name.

## Note

The fixtures before this change used event names from the hardcoded list in `isProbablyDoctrineListener`, which marks those names used in every class. That heuristic hid the broken parsing. The new fixtures use custom event names, so they fail if the parsing breaks again.
