### PR TITLE
Symfony: honor inherited members of #[MapInput] DTOs

### DIFF
--- a/src/Provider/SymfonyUsageProvider.php
+++ b/src/Provider/SymfonyUsageProvider.php
@@ -752,11 +752,8 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         $note = 'Console input DTO via #[MapInput]';
         $usages = [];
 
+        // MapInput::tryFrom() iterates getProperties()/getMethods(), so inherited members are mapped too
         foreach ($nativeReflection->getProperties() as $property) {
-            if ($property->getDeclaringClass()->getName() !== $dtoClassName) {
-                continue;
-            }
-
             $isInputProperty = $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\Argument')
                 || $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\Option');
             $nestedMapInput = $this->hasAttribute($property, 'Symfony\Component\Console\Attribute\MapInput');
@@ -782,14 +779,10 @@ final class SymfonyUsageProvider implements MemberUsageProvider
         }
 
         foreach ($nativeReflection->getMethods() as $dtoMethod) {
-            if ($dtoMethod->getDeclaringClass()->getName() !== $dtoClassName) {
-                continue;
-            }
-
             if ($this->hasAttribute($dtoMethod, 'Symfony\Component\Console\Attribute\Interact')) {
                 $usages[] = new ClassMethodUsage(
                     UsageOrigin::createVirtual($this, VirtualUsageData::withNote($note)),
-                    new ClassMethodRef($dtoClassName, $dtoMethod->getName(), possibleDescendant: false),
+                    new ClassMethodRef($dtoMethod->getDeclaringClass()->getName(), $dtoMethod->getName(), possibleDescendant: false),
                 );
             }
         }

--- a/tests/Rule/data/providers/symfony.php
+++ b/tests/Rule/data/providers/symfony.php
@@ -300,6 +300,31 @@ class ImportCommand extends Command {
     }
 }
 
+abstract class BaseImportInput {
+    #[\Symfony\Component\Console\Attribute\Option]
+    public bool $dryRun = false;
+
+    public string $notAnInputInBase; // error: Property Symfony\BaseImportInput::$notAnInputInBase is never read // error: Property Symfony\BaseImportInput::$notAnInputInBase is never written
+
+    #[Interact]
+    public function askBase(): void {}
+}
+
+class ExtendedImportInput extends BaseImportInput {
+    #[\Symfony\Component\Console\Attribute\Argument]
+    public string $source;
+}
+
+#[AsCommand(name: 'app:import-extended')]
+class ExtendedImportCommand extends Command {
+    public function __invoke(
+        #[\Symfony\Component\Console\Attribute\MapInput] ExtendedImportInput $input,
+    ): int {
+        echo $input->source;
+        return 0;
+    }
+}
+
 class OrphanedInput {
     #[\Symfony\Component\Console\Attribute\Argument]
     public string $name; // error: Property Symfony\OrphanedInput::$name is never read // error: Property Symfony\OrphanedInput::$name is never written


### PR DESCRIPTION
## Summary

`SymfonyUsageProvider::collectMapInputDtoUsages()` skipped every property and `#[Interact]` method whose declaring class differs from the DTO class, and never walked the parent. But Symfony's `MapInput::tryFrom()` iterates `getProperties()`/`getMethods()`, which include inherited public members — an input property must be public, and `resolveValue()` writes it on the concrete instance. So with:

```php
abstract class BaseImportInput {
    #[Option]
    public bool $dryRun = false;

    #[Interact]
    public function askBase(): void {}
}

class ExtendedImportInput extends BaseImportInput { ... }
```

used via `#[MapInput] ExtendedImportInput $input`, the provider reported `BaseImportInput::$dryRun is never read` and `Unused BaseImportInput::askBase` although Symfony maps and calls both. The extended fixture reproduces exactly these two false positives without the fix.

## Fix

Drop the declaring-class guards and emit each usage against the member's declaring class — the same approach `collectPayloadDtoUsages()` already uses for `#[MapRequestPayload]` DTOs. Non-input members of the parent class keep being reported (covered by the fixture's `$notAnInputInBase`).