### PR TITLE
Detect partial analysis only from positional path arguments

### DIFF
--- a/src/Formatter/FilterOutUnmatchedInlineIgnoresFormatter.php
+++ b/src/Formatter/FilterOutUnmatchedInlineIgnoresFormatter.php
@@ -9,14 +9,32 @@ use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\MissingServiceException;
+use function array_slice;
+use function in_array;
 use function str_contains;
 use function str_ends_with;
+use function str_starts_with;
 
 /**
  * This formatter solves the following issue https://github.com/phpstan/phpstan/issues/12328
  */
 final class FilterOutUnmatchedInlineIgnoresFormatter implements ErrorFormatter
 {
+
+    /**
+     * Options of the analyse command that consume the next argv token as their value.
+     * Symfony binds a space-separated value even to VALUE_OPTIONAL options.
+     */
+    private const OPTIONS_WITH_VALUE = [
+        '--configuration', '-c',
+        '--level', '-l',
+        '--autoload-file', '-a',
+        '--error-format',
+        '--generate-baseline', '-b',
+        '--memory-limit',
+        '--tmp-file',
+        '--instead-of',
+    ];
 
     private readonly ErrorFormatter $originalFormatter;
 
@@ -95,7 +113,19 @@ final class FilterOutUnmatchedInlineIgnoresFormatter implements ErrorFormatter
     {
         /** @var array<string> $argv */
         $argv = $_SERVER['argv'] ?? [];
-        foreach ($argv as $arg) {
+        $skipNext = false;
+
+        foreach (array_slice($argv, 1) as $arg) { // skip the binary name
+            if ($skipNext) {
+                $skipNext = false;
+                continue;
+            }
+
+            if (str_starts_with($arg, '-')) { // option or option=value, never an analysed path
+                $skipNext = in_array($arg, self::OPTIONS_WITH_VALUE, true);
+                continue;
+            }
+
             if (str_ends_with($arg, '.php')) {
                 return true;
             }

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -736,13 +736,54 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
 
     public function testFilterOutUnmatchedInlineIgnores(): void
     {
+        // partial analysis (file path in argv)
+        $receivedErrors = $this->runFilterOutUnmatchedInlineIgnoresFormatter(['phpstan', 'analyse', __DIR__ . '/data/partial-analysis/inline-ignore.php']);
+
+        self::assertCount(2, $receivedErrors);
+        self::assertSame('No error with identifier invalid.ignore is reported on line 5.', $receivedErrors[0]->getMessage());
+        self::assertSame('Unused Filtering\Example::FOO2', $receivedErrors[1]->getMessage());
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    #[DataProvider('provideFullAnalysisArgv')]
+    public function testKeepUnmatchedInlineIgnoresOnFullAnalysis(array $argv): void
+    {
+        $receivedErrors = $this->runFilterOutUnmatchedInlineIgnoresFormatter($argv);
+
+        $messages = array_map(
+            static fn (Error $error): string => $error->getMessage(),
+            $receivedErrors,
+        );
+
+        self::assertCount(3, $receivedErrors);
+        self::assertContains('No error with identifier shipmonk.deadMethod is reported on line 16.', $messages);
+    }
+
+    /**
+     * @return Traversable<string, array{0: list<string>}>
+     */
+    public static function provideFullAnalysisArgv(): Traversable
+    {
+        yield 'config option value' => [['phpstan', 'analyse', '-c', 'phpstan.php']];
+        yield 'config option with equals' => [['phpstan', 'analyse', '--configuration=phpstan.php']];
+        yield 'autoload file option value' => [['phpstan', 'analyse', '--autoload-file', 'bootstrap.php']];
+        yield 'php wrapper binary' => [['custom-phpstan.php', 'analyse']];
+    }
+
+    /**
+     * @param list<string> $argv
+     * @return list<Error>
+     */
+    private function runFilterOutUnmatchedInlineIgnoresFormatter(array $argv): array
+    {
         $file = __DIR__ . '/data/partial-analysis/inline-ignore.php';
 
         $originalArgv = $_SERVER['argv'] ?? [];
 
         try {
-            // simulate partial analysis (file path in argv)
-            $_SERVER['argv'] = ['phpstan', 'analyse', $file];
+            $_SERVER['argv'] = $argv;
 
             $analyserErrors = $this->gatherAnalyserErrors([$file]);
             $receivedErrors = null;
@@ -772,9 +813,8 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             $formatter->formatErrors($this->createAnalysisResult($analyserErrors), $output);
 
             self::assertNotNull($receivedErrors);
-            self::assertCount(2, $receivedErrors);
-            self::assertSame('No error with identifier invalid.ignore is reported on line 5.', $receivedErrors[0]->getMessage());
-            self::assertSame('Unused Filtering\Example::FOO2', $receivedErrors[1]->getMessage());
+
+            return $receivedErrors;
 
         } finally {
             $_SERVER['argv'] = $originalArgv;


### PR DESCRIPTION
## Summary

`FilterOutUnmatchedInlineIgnoresFormatter::isPartialAnalysis()` treated **any** CLI argument ending in `.php` as a sign of partial (per-file) analysis. A full-directory run invoked as `phpstan analyse -c phpstan.php`, with `--autoload-file bootstrap.php`, or through a wrapper binary named `*.php` was misclassified as partial — and legitimate `ignore.unmatchedIdentifier` errors for `shipmonk.dead*` identifiers were silently suppressed, hiding removable inline ignores.

The new `testKeepUnmatchedInlineIgnoresOnFullAnalysis` covers four such argv shapes; all four failed before the fix (the unmatched-ignore error was filtered out). The existing partial-analysis test stays green.

## Fix

`isPartialAnalysis()` now inspects only positional path arguments:

- the binary name (`argv[0]`) is skipped,
- option tokens (`-…`, including `--opt=value`) are skipped,
- values of `analyse` options that consume the next argv token are skipped (`-c/--configuration`, `-l/--level`, `-a/--autoload-file`, `--error-format`, `-b/--generate-baseline`, `--memory-limit`, `--tmp-file`, `--instead-of`).

The option list was verified against the bundled PHPStan phar: Symfony's `ArgvInput::addLongOption` binds a space-separated value even to `VALUE_OPTIONAL` options, so `--generate-baseline` belongs in the list.