### PR TITLE
Doctrine: infer the listener method of AsEntityListener

### DIFF
--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -31,7 +31,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
 {
 
     /**
-     * @see \Doctrine\ORM\Mapping\Builder\EntityListenerBuilder::EVENTS
+     * @see \Doctrine\ORM\Mapping\Builder\EntityListenerBuilder::bindEntityListener()
      */
     private const ENTITY_LISTENER_EVENTS = [
         'preRemove',
@@ -274,6 +274,18 @@ final class DoctrineUsageProvider implements MemberUsageProvider
     {
         foreach ($class->getAttributes('Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener') as $attribute) {
             $arguments = $attribute->getArguments();
+            $eventName = $arguments['event'] ?? $arguments[0] ?? null;
+
+            // With no event argument, EntityListenerBuilder binds every method that has the name of an entity
+            // lifecycle event and ignores the method argument
+            if (!is_string($eventName)) {
+                if (CaseInsensitiveName::isOneOf($methodName, self::ENTITY_LISTENER_EVENTS)) {
+                    return true;
+                }
+
+                continue;
+            }
+
             $listenerMethodName = $arguments['method'] ?? $arguments[1] ?? null;
 
             if (is_string($listenerMethodName)) {
@@ -284,23 +296,12 @@ final class DoctrineUsageProvider implements MemberUsageProvider
                 continue;
             }
 
-            $eventName = $arguments['event'] ?? $arguments[0] ?? null;
-
             // With no method argument, Doctrine calls the method that has the name of the event
             // DoctrineBundle falls back to __invoke when no such method exists
-            if (is_string($eventName)) {
-                if (
-                    CaseInsensitiveName::equals($eventName, $methodName)
-                    || CaseInsensitiveName::equals($methodName, '__invoke')
-                ) {
-                    return true;
-                }
-
-                continue;
-            }
-
-            // With no event argument, Doctrine binds every method that has the name of an entity lifecycle event
-            if (CaseInsensitiveName::isOneOf($methodName, self::ENTITY_LISTENER_EVENTS)) {
+            if (
+                CaseInsensitiveName::equals($eventName, $methodName)
+                || CaseInsensitiveName::equals($methodName, '__invoke')
+            ) {
                 return true;
             }
         }

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -30,6 +30,20 @@ use function str_starts_with;
 final class DoctrineUsageProvider implements MemberUsageProvider
 {
 
+    /**
+     * @see \Doctrine\ORM\Mapping\Builder\EntityListenerBuilder::EVENTS
+     */
+    private const ENTITY_LISTENER_EVENTS = [
+        'preRemove',
+        'postRemove',
+        'prePersist',
+        'postPersist',
+        'preUpdate',
+        'postUpdate',
+        'postLoad',
+        'preFlush',
+    ];
+
     private readonly bool $enabled;
 
     public function __construct(?bool $enabled)
@@ -259,9 +273,34 @@ final class DoctrineUsageProvider implements MemberUsageProvider
     ): bool
     {
         foreach ($class->getAttributes('Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener') as $attribute) {
-            $listenerMethodName = $attribute->getArguments()['method'] ?? $attribute->getArguments()[1] ?? null;
+            $arguments = $attribute->getArguments();
+            $listenerMethodName = $arguments['method'] ?? $arguments[1] ?? null;
 
-            if (is_string($listenerMethodName) && CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
+            if (is_string($listenerMethodName)) {
+                if (CaseInsensitiveName::equals($listenerMethodName, $methodName)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            $eventName = $arguments['event'] ?? $arguments[0] ?? null;
+
+            // With no method argument, Doctrine calls the method that has the name of the event
+            // DoctrineBundle falls back to __invoke when no such method exists
+            if (is_string($eventName)) {
+                if (
+                    CaseInsensitiveName::equals($eventName, $methodName)
+                    || CaseInsensitiveName::equals($methodName, '__invoke')
+                ) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            // With no event argument, Doctrine binds every method that has the name of an entity lifecycle event
+            if (CaseInsensitiveName::isOneOf($methodName, self::ENTITY_LISTENER_EVENTS)) {
                 return true;
             }
         }

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -39,6 +39,58 @@ class MyListener {
 
 }
 
+// With no method argument, Doctrine calls the method that has the name of the event
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'preFlush', entity: MyEntity::class)]
+class EntityListenerWithoutMethod {
+
+    public function preFlush(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenerWithoutMethod::unusedMethod
+
+}
+
+// The method argument names the only bound method
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'preFlush', method: 'handleFlush', entity: MyEntity::class)]
+class EntityListenerWithMethod {
+
+    public function handleFlush(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenerWithMethod::unusedMethod
+
+}
+
+// No method that has the name of the event, DoctrineBundle falls back to __invoke
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postLoad', entity: MyEntity::class)]
+class EntityListenerWithInvoke {
+
+    public function __invoke(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenerWithInvoke::unusedMethod
+
+}
+
+// With no event argument, Doctrine binds every method that has the name of an entity lifecycle event
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(entity: MyEntity::class)]
+class EntityListenerWithoutEvent {
+
+    public function prePersist(): void {}
+
+    public function postLoad(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenerWithoutEvent::unusedMethod
+
+}
+
+// onFlush is not an entity lifecycle event, Doctrine never binds it on an entity listener
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(entity: MyEntity::class)]
+class EntityListenerNonLifecycleEvent {
+
+    public function postUpdate(): void {}
+
+    public function onFlush(): void {}
+
+}
+
 class FooRepository extends EntityRepository {
 
     public function __construct(

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -59,6 +59,16 @@ class EntityListenerWithMethod {
 
 }
 
+// With no event argument, the method argument is ignored, EntityListenerBuilder binds by lifecycle event name
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(method: 'handleFlush', entity: MyEntity::class)]
+class EntityListenerMethodWithoutEvent {
+
+    public function prePersist(): void {}
+
+    public function handleFlush(): void {} // error: Unused Doctrine\EntityListenerMethodWithoutEvent::handleFlush
+
+}
+
 // No method that has the name of the event, DoctrineBundle falls back to __invoke
 #[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postLoad', entity: MyEntity::class)]
 class EntityListenerWithInvoke {


### PR DESCRIPTION
Draft. It has no effect until the `isProbablyDoctrineListener` heuristic gets narrower. See the note at the end.

## Problem

`isPartOfAsEntityListener` read the `method` argument only. `#[AsEntityListener]` has 3 forms, and DoctrineBundle plus ORM bind a different method in each one.

**1. With a `method` argument** — `EntityListenerPass::attachToListener()` appends it, so that method is the only bound method:

```php
if (isset($attributes['method'])) {
    $args[] = $attributes['method'];
} elseif (isset($attributes['event']) && !method_exists($class, $attributes['event']) && method_exists($class, '__invoke')) {
    $args[] = '__invoke';
}
```

**2. With an `event` argument only** — `AttachEntityListenersListener::addEntityListener()` uses the event name as the method name:

```php
'method' => $listenerCallback ?? $eventName,
```

The `elseif` above adds the `__invoke` fallback when no method has the name of the event. `ClassMetadata::addEntityListener()` then throws `MappingException` if neither exists, so one of the two must be there.

**3. With no `event` argument** — `EntityListenerBuilder::bindEntityListener()` binds every method that has the name of an entity lifecycle event:

```php
foreach (get_class_methods($class) as $method) {
    if (!isset(self::EVENTS[$method])) { continue; }
    $metadata->addEntityListener($method, $class, $method);
}
```

`EntityListenerBuilder::EVENTS` holds 8 names: `preRemove`, `postRemove`, `prePersist`, `postPersist`, `preUpdate`, `postUpdate`, `postLoad`, `preFlush`. This set is smaller than the ORM event set — `onFlush` or `loadClassMetadata` never bind on an entity listener.

## Fix

Handle all 3 forms. The `method` argument keeps priority, then the event name, then the lifecycle event names.

## Why this is a draft

All 8 entity lifecycle event names are also in the hardcoded list of `isProbablyDoctrineListener`, which marks those names used in **every** class. Forms 2 and 3 are therefore invisible today, and the new fixtures pass with or without this change.

This PR matters once that heuristic gets narrower. Merge it before or together with the heuristic change, not after.

One assertion is left out for the same reason: with `event: 'preFlush', method: 'handleFlush'`, `preFlush()` is dead, but the heuristic still marks it used.
