### PR TITLE
Doctrine: skip the listener guess when the class has a listener attribute

### DIFF
--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
 use PHPStan\Node\InClassNode;
@@ -24,6 +25,7 @@ use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyRef;
 use ShipMonk\PHPStan\DeadCode\Graph\ClassPropertyUsage;
 use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
 use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
+use function is_array;
 use function is_string;
 use function str_starts_with;
 
@@ -118,6 +120,43 @@ final class DoctrineUsageProvider implements MemberUsageProvider
 
             if ($usageNote !== null) {
                 $usages[] = $this->createMethodUsage($classReflection->getNativeMethod($method->getName()), $usageNote);
+            }
+        }
+
+        return [
+            ...$usages,
+            ...$this->getUsagesOfEntityListeners($nativeReflection),
+        ];
+    }
+
+    /**
+     * AttributeDriver binds the listed classes by the lifecycle event names when no method of them has a callback attribute.
+     *
+     * @return list<ClassMethodUsage>
+     */
+    private function getUsagesOfEntityListeners(ReflectionClass|ReflectionEnum $class): array
+    {
+        $usages = [];
+
+        foreach ($class->getAttributes('Doctrine\ORM\Mapping\EntityListeners') as $attribute) {
+            $arguments = $attribute->getArguments();
+            $listenerClassNames = $arguments[0] ?? $arguments['value'] ?? null;
+
+            if (!is_array($listenerClassNames)) {
+                continue;
+            }
+
+            foreach ($listenerClassNames as $listenerClassName) {
+                if (!is_string($listenerClassName)) {
+                    continue;
+                }
+
+                foreach (self::ENTITY_LISTENER_EVENTS as $eventName) {
+                    $usages[] = new ClassMethodUsage(
+                        UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Entity listener of ' . $class->getName())),
+                        new ClassMethodRef($listenerClassName, $eventName, possibleDescendant: false),
+                    );
+                }
             }
         }
 

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -30,6 +30,12 @@ use function str_starts_with;
 final class DoctrineUsageProvider implements MemberUsageProvider
 {
 
+    private const LISTENER_ATTRIBUTES = [
+        'Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener',
+        'Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener',
+        'Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag',
+    ];
+
     /**
      * @see \Doctrine\ORM\Mapping\Builder\EntityListenerBuilder::EVENTS
      */
@@ -200,7 +206,7 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             return 'Is part of AutoconfigureTag doctrine.event_listener methods';
         }
 
-        if ($this->isProbablyDoctrineListener($methodName)) {
+        if ($this->isProbablyDoctrineListener($methodName) && !$this->hasListenerAttribute($class)) {
             return 'Is probable listener method';
         }
 
@@ -235,6 +241,21 @@ final class DoctrineUsageProvider implements MemberUsageProvider
     }
 
     /**
+     * The attributes tell exactly which methods Doctrine calls, so the guess below must not add more.
+     */
+    private function hasListenerAttribute(ReflectionClass $class): bool
+    {
+        foreach (self::LISTENER_ATTRIBUTES as $attributeName) {
+            if ($class->getAttributes($attributeName) !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Used only for classes with no listener attribute, where the registration is invisible (DIC xml, addEventListener call).
      * Ideally, we would need to parse DIC xml to know this for sure just like phpstan-symfony does.
      * - see Doctrine\ORM\Events::* and Doctrine\ORM\Tools\ToolEvents::*
      */

--- a/src/Provider/DoctrineUsageProvider.php
+++ b/src/Provider/DoctrineUsageProvider.php
@@ -30,12 +30,6 @@ use function str_starts_with;
 final class DoctrineUsageProvider implements MemberUsageProvider
 {
 
-    private const LISTENER_ATTRIBUTES = [
-        'Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener',
-        'Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener',
-        'Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag',
-    ];
-
     /**
      * @see \Doctrine\ORM\Mapping\Builder\EntityListenerBuilder::bindEntityListener()
      */
@@ -240,13 +234,20 @@ final class DoctrineUsageProvider implements MemberUsageProvider
             || $this->hasAttribute($method, 'Doctrine\ORM\Mapping\PreUpdate');
     }
 
-    /**
-     * The attributes tell exactly which methods Doctrine calls, so the guess below must not add more.
-     */
     private function hasListenerAttribute(ReflectionClass $class): bool
     {
-        foreach (self::LISTENER_ATTRIBUTES as $attributeName) {
-            if ($class->getAttributes($attributeName) !== []) {
+        if (
+            $class->getAttributes('Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener') !== []
+            || $class->getAttributes('Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener') !== []
+        ) {
+            return true;
+        }
+
+        // AutoconfigureTag adds any tag, only the doctrine.event_listener tag declares a doctrine listener
+        foreach ($class->getAttributes('Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag') as $attribute) {
+            $arguments = $attribute->getArguments();
+
+            if (($arguments[0] ?? $arguments['name'] ?? null) === 'doctrine.event_listener') {
                 return true;
             }
         }

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -142,6 +142,31 @@ class ListenerWithAttributeAndOtherEventNames {
 
 }
 
+// An unrelated tag does not declare a doctrine listener, so the guess still applies
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('container.hot_path')]
+class ListenerWithUnrelatedAutoconfigureTag {
+
+    public function onFlush(): void {}
+
+    public function deadCode(): void {} // error: Unused Doctrine\ListenerWithUnrelatedAutoconfigureTag::deadCode
+
+}
+
+// The subscriber tag is not the listener tag, so the guess still applies
+#[\Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag('doctrine.event_subscriber')]
+class SubscriberWithDynamicEvents implements \Doctrine\Common\EventSubscriber {
+
+    /** @var list<string> */
+    private array $events = [];
+
+    public function getSubscribedEvents() {
+        return $this->events;
+    }
+
+    public function onFlush(): void {}
+
+}
+
 class MySubscriber implements \Doctrine\Common\EventSubscriber {
 
     public function getSubscribedEvents() {

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -49,11 +49,13 @@ class EntityListenerWithoutMethod {
 
 }
 
-// The method argument names the only bound method
+// The method argument names the only bound method, the event name binds nothing
 #[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'preFlush', method: 'handleFlush', entity: MyEntity::class)]
 class EntityListenerWithMethod {
 
     public function handleFlush(): void {}
+
+    public function preFlush(): void {} // error: Unused Doctrine\EntityListenerWithMethod::preFlush
 
     public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenerWithMethod::unusedMethod
 
@@ -87,7 +89,7 @@ class EntityListenerNonLifecycleEvent {
 
     public function postUpdate(): void {}
 
-    public function onFlush(): void {}
+    public function onFlush(): void {} // error: Unused Doctrine\EntityListenerNonLifecycleEvent::onFlush
 
 }
 
@@ -102,6 +104,7 @@ class FooRepository extends EntityRepository {
 
 }
 
+// No listener attribute, the registration is invisible, so the event names stay used
 class OldListenerHeuristics {
 
     public function postUpdate(): void {}
@@ -116,6 +119,16 @@ class OldListenerHeuristics {
     {
 
     }
+
+}
+
+// The attribute tells exactly which methods Doctrine calls, so unrelated event names are dead
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: 'onFlush')]
+class ListenerWithAttributeAndOtherEventNames {
+
+    public function onFlush(): void {}
+
+    public function postUpdate(): void {} // error: Unused Doctrine\ListenerWithAttributeAndOtherEventNames::postUpdate
 
 }
 

--- a/tests/Rule/data/providers/doctrine.php
+++ b/tests/Rule/data/providers/doctrine.php
@@ -29,8 +29,8 @@ class MyEntity
 
 }
 
-#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postUpdate', method: 'afterUpdate')]
-#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postPersist')]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postUpdate', method: 'afterUpdate', entity: MyEntity::class)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postPersist', entity: MyEntity::class)]
 class MyListener {
 
     public function afterUpdate(): void {}
@@ -139,6 +139,41 @@ class ListenerWithAttributeAndOtherEventNames {
     public function onFlush(): void {}
 
     public function postUpdate(): void {} // error: Unused Doctrine\ListenerWithAttributeAndOtherEventNames::postUpdate
+
+}
+
+// Positional arguments of AsEntityListener and AsDoctrineListener
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener('postLoad', 'handleLoad', entity: MyEntity::class)]
+class PositionalEntityListener {
+
+    public function handleLoad(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\PositionalEntityListener::unusedMethod
+
+}
+
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener('myPositionalEvent')]
+class PositionalDoctrineListener {
+
+    public function myPositionalEvent(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\PositionalDoctrineListener::unusedMethod
+
+}
+
+// EntityListeners binds the listener by the lifecycle event names, the attribute of the listener adds nothing
+#[\Doctrine\ORM\Mapping\Entity]
+#[\Doctrine\ORM\Mapping\EntityListeners([EntityListenersTarget::class])]
+class EntityWithListeners {}
+
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener(event: 'postLoad', entity: EntityWithListeners::class)]
+class EntityListenersTarget {
+
+    public function postLoad(): void {}
+
+    public function prePersist(): void {}
+
+    public function unusedMethod(): void {} // error: Unused Doctrine\EntityListenersTarget::unusedMethod
 
 }
 


### PR DESCRIPTION
Draft, stacked on #424. **Merge order is #420 → #424 → #425**, then base this back to `master`.

## Problem

`isProbablyDoctrineListener` marks 15 hardcoded event names used in **every** class, whatever the class is and whatever attributes it carries. It is a fallback for listeners that static analysis cannot see: a `doctrine.event_listener` tag in services.yaml, an `EventManager::addEventListener()` call, an `#[Autoconfigure(tags:)]` attribute.

For a class that carries `#[AsEntityListener]`, `#[AsDoctrineListener]` or `#[AutoconfigureTag('doctrine.event_listener')]`, the bindings are visible. The provider reads them and knows exactly which methods Doctrine calls. The guess then only adds methods that Doctrine never calls.

Example, before this PR:

```php
#[AsDoctrineListener(event: 'onFlush')]
class MyListener {
    public function onFlush(): void {}
    public function postUpdate(): void {}  // never called, never reported
}
```

The same masking applies to `#[AsEntityListener]`, where all 8 lifecycle event names of #424 are in the hardcoded list.

## Fix

Run the guess only for classes with no doctrine listener attribute. The 15 names and the fallback behaviour do not change for those classes.

`AutoconfigureTag` adds any tag, so the guard matches the tag name, not just the attribute class. A class tagged for `kernel.reset`, `messenger.message_handler` or `doctrine.event_subscriber` keeps the guess.

## Effect

Two assertions that #424 could not make are now possible:

- `#[AsEntityListener(event: 'preFlush', method: 'handleFlush')]` — `preFlush()` is dead, because the `method` argument names the only bound method.
- `#[AsEntityListener(entity: MyEntity::class)]` — `onFlush()` is dead, because `onFlush` is not an entity lifecycle event.

`OldListenerHeuristics` keeps its current behaviour: no attribute, so the guess still applies.

## Why the merge order matters

Before #420, `isPartOfAutoconfigureTagDoctrineListener` cannot read the real `#[AutoconfigureTag('doctrine.event_listener', ['event' => 'x'])]` syntax. Merging this PR first would turn that gap into a false positive, because the guess would stop rescuing those listeners.

## Risk

A class that carries a doctrine listener attribute **and** is registered a second time through services.yaml for a different event. The second registration becomes invisible. This is rare, and the same class already loses the guess for every event that the attribute does not name.
