### PR TITLE
Sort transitive tips instead of ksorting a list

### DIFF
--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -45,6 +45,7 @@ use function array_values;
 use function in_array;
 use function ksort;
 use function serialize;
+use function sort;
 use function str_starts_with;
 use function strcasecmp;
 use function strtolower;
@@ -919,7 +920,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
 
         $builder->metadata($metadata);
 
-        ksort($tips);
+        sort($tips);
 
         foreach ($tips as $tip) {
             $builder->addTip($tip);

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -827,16 +827,16 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 [
                     'Unused Grouping\Example::boo',
                     29,
+                    "• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused\n" .
                     "• Thus Grouping\Example::bag is transitively unused\n" .
-                    "• Thus Grouping\Example::bar is transitively unused\n" .
-                    '• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused',
+                    '• Thus Grouping\Example::bar is transitively unused',
                 ],
                 [
                     'Unused Grouping\Example::foo',
                     23,
-                    "• Thus Grouping\Example::bar is transitively unused\n" .
+                    "• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused\n" .
                     "• Thus Grouping\Example::bag is transitively unused\n" .
-                    '• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused',
+                    '• Thus Grouping\Example::bar is transitively unused',
                 ],
                 [
                     'Unused Grouping\Example::recur',
@@ -910,8 +910,8 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
                 [
                     'Unused GroupingProperty\Writer::__construct',
                     7,
-                    "• Thus GroupingProperty\Writer::\$data is transitively never written\n" .
-                    '• Thus GroupingProperty\Writer::$data is transitively never read',
+                    "• Thus GroupingProperty\Writer::\$data is transitively never read\n" .
+                    '• Thus GroupingProperty\Writer::$data is transitively never written',
                 ],
             ],
         ];


### PR DESCRIPTION
`buildError()` collects transitive tips into a list:

```php
$tips = [];

foreach (array_slice($blackMembersGroup, 1) as $transitivelyDeadMember) {
    $tips[] = $this->buildTransitiveErrorMessages($transitivelyDeadMember) . $exclusionMessage;
    // ...
}

$builder->metadata($metadata);

ksort($tips);
```

Since `$tips` is appended to with `$tips[]`, its keys are already `0..n-1` in ascending order, so `ksort()` is a no-op. The tips are emitted in insertion order, which is the order of `getTransitiveDeadCalls()` → the insertion order of `$usageGraph` → the order PHPStan hands over collected data. That last one is **not stable across parallel runs**.

I noticed this while profiling the extension on a ~16k-file codebase: two runs of identical code produced different tip order for the same error, so diffing analysis output between runs showed spurious changes.

The existing test expectations show the same thing — `Grouping\Example::boo` and `Grouping\Example::foo` have the same three transitively dead members, but the fixture encoded them in two different orders:

```php
'Unused Grouping\Example::boo',
"• Thus Grouping\Example::bag is transitively unused\n" .
"• Thus Grouping\Example::bar is transitively unused\n" .
'• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused',

'Unused Grouping\Example::foo',
"• Thus Grouping\Example::bar is transitively unused\n" .   // <- flipped
"• Thus Grouping\Example::bag is transitively unused\n" .
'• Thus Grouping\Example::TRANSITIVELY_UNUSED_CONST is transitively unused',
```

`sort($tips)` gives the deterministic order the `ksort()` call was clearly reaching for. I updated the three affected expectations; the full suite passes (858 tests), as do `phpstan` and `phpcs`.

I also opened https://github.com/phpstan/phpstan/issues/15126 asking for a rule that reports `ksort()` on a list, since PHPStan already reports the analogous `array_values()` on a list and would have caught this.
