### PR TITLE
Serve offloaded collector data from one bundle file

### DIFF
--- a/src/Cache/UsageCacheStorage.php
+++ b/src/Cache/UsageCacheStorage.php
@@ -7,19 +7,61 @@ use LogicException;
 use RuntimeException;
 use ShipMonk\PHPStan\DeadCode\Graph\CollectedUsage;
 use function array_map;
+use function clearstatcache;
+use function count;
 use function explode;
+use function fclose;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function filesize;
+use function fopen;
+use function fread;
+use function fseek;
+use function fwrite;
+use function getmypid;
 use function implode;
+use function intdiv;
 use function is_dir;
+use function is_int;
 use function md5;
 use function mkdir;
+use function pack;
+use function rename;
+use function rmdir;
+use function str_split;
+use function strlen;
 use function substr;
 use function unlink;
+use function unpack;
+use const LOCK_EX;
 
 final class UsageCacheStorage
 {
+
+    private const BUNDLE_DATA_FILE = 'bundle.dat';
+
+    private const BUNDLE_INDEX_FILE = 'bundle.idx';
+
+    private const BUNDLE_INDEX_MAGIC = 'DCD1';
+
+    /**
+     * Each index entry is a 32 char hex hash plus a 64bit packed position.
+     */
+    private const BUNDLE_INDEX_ENTRY_SIZE = 40;
+
+    /**
+     * Offset and length of an entry share a single int so that the position block can be
+     * decoded by a single unpack() call.
+     */
+    private const BUNDLE_LENGTH_BITS = 24;
+
+    private const BUNDLE_ENTRY_SIZE_LIMIT = (1 << self::BUNDLE_LENGTH_BITS) - 1;
+
+    /**
+     * Rewriting the whole bundle only pays off once enough of it became garbage.
+     */
+    private const BUNDLE_GARBAGE_RATIO_LIMIT = 0.2;
 
     private readonly string $cacheDir;
 
@@ -29,6 +71,20 @@ final class UsageCacheStorage
      * @var array<string, true>
      */
     private array $readHashes = [];
+
+    /**
+     * hash => (offset << BUNDLE_LENGTH_BITS) | length
+     *
+     * @var array<string, int>|null
+     */
+    private ?array $bundleIndex = null;
+
+    /**
+     * @var resource|null
+     */
+    private $bundleHandle = null;
+
+    private ?int $bundleHandlePid = null;
 
     public function __construct(
         string $tmpDir,
@@ -86,19 +142,18 @@ final class UsageCacheStorage
 
         $this->readHashes[$data] = true;
 
-        $filePath = $this->getFilePath($data);
+        $content = $this->readFromBundle($data);
 
-        if (!file_exists($filePath)) {
-            throw new LogicException(
-                "DCD cache file not found for hash '{$data}' at '{$filePath}'. "
-                . 'Please clear the PHPStan result cache and re-run the analysis.',
-            );
-        }
+        if ($content === null) {
+            $filePath = $this->getFilePath($data);
+            $content = @file_get_contents($filePath);
 
-        $content = file_get_contents($filePath);
-
-        if ($content === false) {
-            throw new LogicException("Could not read DCD cache file: {$filePath}");
+            if ($content === false) {
+                throw new LogicException(
+                    "DCD cache file not found for hash '{$data}' at '{$filePath}'. "
+                    . 'Please clear the PHPStan result cache and re-run the analysis.',
+                );
+            }
         }
 
         return array_map(
@@ -108,7 +163,8 @@ final class UsageCacheStorage
     }
 
     /**
-     * Delete all files in cacheDir that were not read by this cache instance
+     * Delete everything that was not read by this run, then merge what survived into the
+     * bundle so that the next run does not have to open one file per hash.
      */
     public function gc(): void
     {
@@ -116,11 +172,223 @@ final class UsageCacheStorage
             return;
         }
 
+        $looseFiles = [];
+
+        foreach ($this->findLooseFiles() as $hash => $path) {
+            if (!isset($this->readHashes[$hash])) {
+                @unlink($path);
+                continue;
+            }
+
+            if (isset($this->loadBundleIndex()[$hash])) {
+                @unlink($path); // already bundled, the loose copy is redundant
+                continue;
+            }
+
+            $looseFiles[$hash] = $path;
+        }
+
+        $index = $this->loadBundleIndex();
+        $garbage = 0;
+
+        foreach ($index as $hash => $position) {
+            if (!isset($this->readHashes[$hash])) {
+                $garbage++;
+            }
+        }
+
+        if ($index !== [] && $garbage / count($index) > self::BUNDLE_GARBAGE_RATIO_LIMIT) {
+            $this->compactBundle($looseFiles);
+        } elseif ($looseFiles !== []) {
+            $this->appendToBundle($looseFiles);
+        }
+
+        $this->removeEmptyDirectories();
+        $this->closeBundle();
+    }
+
+    private function removeEmptyDirectories(): void
+    {
         try {
             $subdirs = new DirectoryIterator($this->cacheDir);
         } catch (RuntimeException $e) {
             return;
         }
+
+        foreach ($subdirs as $subdir) {
+            if ($subdir->isDot() || !$subdir->isDir()) {
+                continue;
+            }
+
+            @rmdir($subdir->getPathname());
+        }
+    }
+
+    /**
+     * Rewrites the bundle from scratch, keeping only entries read by this run.
+     *
+     * @param array<string, string> $looseFiles hash => file path
+     */
+    private function compactBundle(array $looseFiles): void
+    {
+        $index = $this->loadBundleIndex();
+
+        // readHashes is insertion ordered, so laying the bundle out in that order makes
+        // the next run read it front to back instead of seeking all over the file
+        $sources = [];
+
+        foreach ($this->readHashes as $hash => $read) {
+            if (isset($looseFiles[$hash])) {
+                $sources[$hash] = $looseFiles[$hash];
+            } elseif (isset($index[$hash])) {
+                $sources[$hash] = null; // read from the current bundle
+            }
+        }
+
+        $dataPath = $this->cacheDir . '/' . self::BUNDLE_DATA_FILE;
+        $tmpPath = $dataPath . '.tmp';
+
+        $handle = @fopen($tmpPath, 'wb');
+
+        if ($handle === false) {
+            return;
+        }
+
+        $hashes = '';
+        $positions = '';
+        $offset = 0;
+        $merged = [];
+
+        foreach ($sources as $hash => $path) {
+            $content = $path === null ? $this->readFromBundle($hash) : @file_get_contents($path);
+
+            if ($content === null || $content === false || strlen($content) > self::BUNDLE_ENTRY_SIZE_LIMIT) {
+                continue;
+            }
+
+            if (fwrite($handle, $content) === false) {
+                fclose($handle);
+                @unlink($tmpPath);
+                return;
+            }
+
+            $hashes .= $hash;
+            $positions .= pack('J', ($offset << self::BUNDLE_LENGTH_BITS) | strlen($content));
+            $offset += strlen($content);
+            $merged[$hash] = $path;
+        }
+
+        fclose($handle);
+        $this->closeBundle();
+
+        if (!@rename($tmpPath, $dataPath)) {
+            @unlink($tmpPath);
+            return;
+        }
+
+        $this->writeBundleIndex($hashes, $positions);
+        $this->dropMergedFiles($merged);
+    }
+
+    /**
+     * @param array<string, string> $looseFiles hash => file path
+     */
+    private function appendToBundle(array $looseFiles): void
+    {
+        $dataPath = $this->cacheDir . '/' . self::BUNDLE_DATA_FILE;
+
+        clearstatcache(true, $dataPath);
+        $size = file_exists($dataPath) ? filesize($dataPath) : 0;
+        $offset = $size === false ? 0 : $size;
+
+        if ($offset === 0) {
+            $this->compactBundle($looseFiles);
+            return;
+        }
+
+        $handle = @fopen($dataPath, 'ab');
+
+        if ($handle === false) {
+            return;
+        }
+
+        $hashes = '';
+        $positions = '';
+        $merged = [];
+
+        foreach ($looseFiles as $hash => $path) {
+            $content = @file_get_contents($path);
+
+            if ($content === false || strlen($content) > self::BUNDLE_ENTRY_SIZE_LIMIT) {
+                continue;
+            }
+
+            if (fwrite($handle, $content) === false) {
+                break;
+            }
+
+            $hashes .= $hash;
+            $positions .= pack('J', ($offset << self::BUNDLE_LENGTH_BITS) | strlen($content));
+            $offset += strlen($content);
+            $merged[$hash] = $path;
+        }
+
+        fclose($handle);
+
+        if ($merged === []) {
+            return;
+        }
+
+        // hashes and positions live in separate blocks, so appending means rewriting the
+        // index; it is three orders of magnitude smaller than the data file
+        $existingHashes = '';
+        $existingPositions = '';
+
+        foreach ($this->loadBundleIndex() as $hash => $position) {
+            $existingHashes .= $hash;
+            $existingPositions .= pack('J', $position);
+        }
+
+        $this->writeBundleIndex($existingHashes . $hashes, $existingPositions . $positions);
+        $this->dropMergedFiles($merged);
+    }
+
+    private function writeBundleIndex(
+        string $hashes,
+        string $positions,
+    ): void
+    {
+        @file_put_contents(
+            $this->cacheDir . '/' . self::BUNDLE_INDEX_FILE,
+            self::BUNDLE_INDEX_MAGIC . $hashes . $positions,
+            LOCK_EX,
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $merged hash => file path
+     */
+    private function dropMergedFiles(array $merged): void
+    {
+        foreach ($merged as $path) {
+            if ($path !== null) {
+                @unlink($path);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string> hash => file path
+     */
+    private function findLooseFiles(): array
+    {
+        try {
+            $subdirs = new DirectoryIterator($this->cacheDir);
+        } catch (RuntimeException $e) {
+            return [];
+        }
+
+        $result = [];
 
         foreach ($subdirs as $subdir) {
             if ($subdir->isDot() || !$subdir->isDir()) {
@@ -138,13 +406,114 @@ final class UsageCacheStorage
                     continue;
                 }
 
-                $hash = $subdir->getFilename() . $file->getBasename('.dat');
-
-                if (!isset($this->readHashes[$hash])) {
-                    @unlink($file->getPathname());
-                }
+                $result[$subdir->getFilename() . $file->getBasename('.dat')] = $file->getPathname();
             }
         }
+
+        return $result;
+    }
+
+    private function readFromBundle(string $hash): ?string
+    {
+        $position = $this->loadBundleIndex()[$hash] ?? null;
+
+        if ($position === null) {
+            return null;
+        }
+
+        $pid = getmypid();
+
+        if ($this->bundleHandle === null || $pid === false || $this->bundleHandlePid !== $pid) {
+            $handle = @fopen($this->cacheDir . '/' . self::BUNDLE_DATA_FILE, 'rb');
+
+            if ($handle === false) {
+                return null;
+            }
+
+            // a forked child inherits the parent descriptor together with its file
+            // offset, so it must open its own instead of seeking in a shared one
+            $this->bundleHandle = $handle;
+            $this->bundleHandlePid = $pid === false ? null : $pid;
+        }
+
+        $length = $position & self::BUNDLE_ENTRY_SIZE_LIMIT;
+
+        if ($length === 0) {
+            return '';
+        }
+
+        fseek($this->bundleHandle, $position >> self::BUNDLE_LENGTH_BITS);
+        $content = fread($this->bundleHandle, $length);
+
+        if ($content === false || strlen($content) !== $length) {
+            return null; // truncated bundle, fall back to the loose file
+        }
+
+        return $content;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function loadBundleIndex(): array
+    {
+        if ($this->bundleIndex !== null) {
+            return $this->bundleIndex;
+        }
+
+        $this->bundleIndex = [];
+
+        $raw = @file_get_contents($this->cacheDir . '/' . self::BUNDLE_INDEX_FILE);
+
+        if ($raw === false || substr($raw, 0, 4) !== self::BUNDLE_INDEX_MAGIC) {
+            return $this->bundleIndex;
+        }
+
+        if ((strlen($raw) - 4) % self::BUNDLE_INDEX_ENTRY_SIZE !== 0) {
+            return $this->bundleIndex;
+        }
+
+        $entries = intdiv(strlen($raw) - 4, self::BUNDLE_INDEX_ENTRY_SIZE);
+
+        if ($entries === 0) {
+            return $this->bundleIndex;
+        }
+
+        $hashes = str_split(substr($raw, 4, $entries * 32), 32);
+        $positions = unpack('J*', substr($raw, 4 + ($entries * 32))); // one call for the whole block
+
+        if ($positions === false) {
+            return $this->bundleIndex;
+        }
+
+        $index = [];
+        $position = 1; // unpack() numbers its results from one
+
+        foreach ($hashes as $hash) {
+            $offsetAndLength = $positions[$position] ?? null;
+            $position++;
+
+            if (!is_int($offsetAndLength)) {
+                return $this->bundleIndex; // truncated index, everything falls back to loose files
+            }
+
+            $index[$hash] = $offsetAndLength;
+        }
+
+        $this->bundleIndex = $index;
+
+        return $this->bundleIndex;
+    }
+
+    private function closeBundle(): void
+    {
+        if ($this->bundleHandle !== null) {
+            fclose($this->bundleHandle);
+            $this->bundleHandle = null;
+            $this->bundleHandlePid = null;
+        }
+
+        $this->bundleIndex = null;
     }
 
     private function getFilePath(string $hash): string

--- a/src/Debug/DebugUsagePrinter.php
+++ b/src/Debug/DebugUsagePrinter.php
@@ -355,6 +355,10 @@ final class DebugUsagePrinter
         array $alternativeKeys,
     ): void
     {
+        if ($this->debugMembers === []) {
+            return;
+        }
+
         if ($alternativeKeys === []) {
             // this can happen for references outside analysed files
             $originalRef = $collectedUsage->getUsage()->getMemberRef();

--- a/src/Graph/ClassMemberRef.php
+++ b/src/Graph/ClassMemberRef.php
@@ -5,6 +5,7 @@ namespace ShipMonk\PHPStan\DeadCode\Graph;
 use LogicException;
 use ShipMonk\PHPStan\DeadCode\Enum\AccessType;
 use ShipMonk\PHPStan\DeadCode\Enum\MemberType;
+use function implode;
 
 /**
  * @template-covariant C of string|null
@@ -73,6 +74,16 @@ abstract class ClassMemberRef
             $result[] = "$prefix/$this->className::$this->memberName";
         }
         return $result;
+    }
+
+    /**
+     * Cheap identity for memoization; covers everything toKeys() derives its result from.
+     */
+    public function toCacheKey(AccessType $accessType): string
+    {
+        return implode(',', $this->getKeyPrefixes($accessType))
+            . ($this->possibleDescendant ? '/1/' : '/0/')
+            . ($this->className ?? '?') . '::' . ($this->memberName ?? '?');
     }
 
     /**

--- a/src/Rule/DeadCodeRule.php
+++ b/src/Rule/DeadCodeRule.php
@@ -44,7 +44,6 @@ use function array_unique;
 use function array_values;
 use function in_array;
 use function ksort;
-use function serialize;
 use function str_starts_with;
 use function strcasecmp;
 use function strtolower;
@@ -555,7 +554,7 @@ final class DeadCodeRule implements Rule, DiagnoseExtension
             throw new LogicException('Those were eliminated above, should never happen');
         }
 
-        $cacheKey = serialize([$member, $accessType]);
+        $cacheKey = $member->toCacheKey($accessType);
 
         if (isset($this->memberAlternativesCache[$cacheKey])) {
             return $this->memberAlternativesCache[$cacheKey];


### PR DESCRIPTION
## What is slow

I profiled the `CollectedDataNode` run of PHPStan's `AnalyserResultFinalizer`, which is single threaded and happens after the parallel analysis is finished. `DeadCodeRule` is essentially all of it — every other CollectedDataNode rule on phpstan-src combined takes 25 ms, `DeadCodeRule` takes 1.7 s. On a ~16k-file codebase with a warm result cache it takes **~40 s**.

Phase breakdown on that codebase (1.59M collected usages, 81,348 cache files, 677 MB):

| phase | time |
|---|---|
| unpack loop | **19,971 ms** (file I/O 15,031 + deserialize 4,486) |
| usage graph build | **3,932 ms** |
| everything else | < 500 ms each |

## Why

With `offloadCollectorData` enabled (the default), `pack()` writes one md5-named `.dat` file per class per collector. The finalizer then reads all of them back one by one.

The bytes are not the problem, the file count is. A probe reading the same 6,217 files twice inside one PHPStan process:

```
first pass:  1437 ms
second pass:  245 ms
```

On APFS a cold `open`+`read`+`close` is ~230 µs against ~40 µs once the path is in the process's realpath cache. 81k of those is ~19 seconds of pure syscall and metadata work. Reading the same 34 MB when warm takes 235 ms, so the data volume is irrelevant.

## What this changes

`gc()` already walks the whole cache directory to drop entries the run did not read. It now also merges the survivors into `bundle.dat` plus a `bundle.idx` (a block of 32-char hashes followed by a block of `pack('J')` positions, where offset and length share one int). `unpack()` serves them with `fseek`/`fread` on a single descriptor.

Design points worth calling out:

* **Loose files stay the write path.** `pack()` runs in parallel workers; content-addressed files need no locking and dedupe for free. They are removed once merged into the bundle.
* **The bundle is laid out in read order.** `readHashes` is insertion-ordered, so writing the bundle in that order means the next run reads it roughly front to back rather than seeking all over it. This is most of the win:

  | layout | read time |
  |---|---|
  | loose files (current) | 1045 ms |
  | bundle, directory order | 343 ms |
  | bundle, read order | **49 ms** |

* **Compaction is amortized.** The bundle is rewritten only when more than a fifth of its entries became garbage; otherwise new entries are appended and only the (much smaller) index is rewritten.
* **The descriptor is guarded by `getmypid()`**, because a forked child inherits it together with its file offset.
* A truncated bundle or index is detected and falls back to the loose files, which produces the existing "clear the result cache" message rather than a half-parsed line.

Two smaller things in the same commit, both in the second-hottest phase:

* `getAlternativeMemberKeys()` used `serialize([$member, $accessType])` as its memoization key. It is called once per collected usage — 1.59M times on the codebase above. `ClassMemberRef::toCacheKey()` builds the same identity as a plain string from the key prefixes, the descendant flag and `class::member`; 2.2× cheaper per call, and the resulting array keys are ~60 bytes instead of ~200.
* `DebugUsagePrinter::recordUsage()` returns early when no debug members are configured, which is the normal case.

## Numbers

Measured against `master` (`05054d4`), timing `DeadCodeRule::processNode()` only.

**phpstan-src** (2,467 files, 6,214 cache files, 139k usages) — three variants run interleaved, order reversed every round, 6 rounds:

| | mean |
|---|---|
| master | 1,617 ms |
| this PR | 800 ms |

6/6 rounds favour the PR, paired t = 26.8. **−50.5%.** For context, on a run where nothing changed this rule was ~45% of phpstan-src's total wall time; every other CollectedDataNode rule combined is 25 ms.

**~16k-file codebase** (81,348 cache files / 677 MB, 1.59M usages), warm result cache:

| | `DeadCodeRule::processNode()` | peak memory |
|---|---|---|
| master | 20,184 ms | 3,133 MB |
| this PR | 7,554 ms | 3,016 MB |

**−62.6%.** The cache directory goes from 81,348 files across 677 MB to a single ~470 MB `bundle.dat` plus a 3.2 MB index.

The one run that pays extra is the first one after upgrading, which reads the old loose files and writes the bundle: 38.7 s once, then 7.5 s from there on.

## Correctness

I dumped every error group the rule produces (message, file, line, identifier, tips) on both codebases and compared master against this PR, across a fresh full analysis, a warm run, and a full re-analysis on top of an existing bundle. All identical — with one caveat that turned out to be a pre-existing bug: the order of *tips within one error* varies between runs on master, because `buildError()` calls `ksort()` on a list, which does nothing. Two runs of unmodified master produce different tip order. Once tip order is normalized, all dumps match exactly. That is fixed separately in #426; this PR does not depend on it.

`composer check` passes: 858 tests, PHPStan, phpcs, dependency and collision checks.

## Known limitation (unchanged from master)

Two PHPStan runs sharing one `tmpDir` still interfere — master's `gc()` already deletes files the other run is about to read. The bundle does not make this worse (`rename()` is atomic, and an open descriptor keeps reading the old inode), but it does not fix it either.

## Possible follow-ups, not in this PR

* `CollectedUsage::deserialize()` is now the biggest remaining cost — 4.5 s on the large codebase, one `json_decode` plus four object constructions per usage. A compact line format would likely halve it, but it changes the on-disk format.
* On a full re-analysis the workers rewrite all 81k loose files even though the bundle already has them, and `gc()` then unlinks them (~3 s). Sorting the index hash block would let `pack()` binary-search membership on a 2.6 MB string without loading the map into every worker.
