### PR TITLE
Laravel: detect handle() usage via laravel-actions run()/runIf()/runUnless()

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ parameters:
 - Gates & policies — `Gate::define()`, `Gate::policy()`, `$this->authorize()` with automatic policy class resolution
 - Real-time facades — `\Facades\...` static calls mapped to the underlying class
 - Console commands, jobs, service providers, middleware, notifications, form requests, mailables, broadcast events, JSON resources, notifiable routing
+- Actions ([`lorisleiva/laravel-actions`](https://github.com/lorisleiva/laravel-actions)) — `handle()` called via `run()`/`runIf()`/`runUnless()` on classes using `AsAction`/`AsObject`
 
 #### Eloquent:
 - Model methods — constructor, `boot`, `booted`, `casts`, `newFactory`, query scopes, relationships, attribute accessors (modern + legacy)

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "editorconfig-checker/editorconfig-checker": "^10.7.0",
         "ergebnis/composer-normalize": "^2.48.1",
         "laravel/framework": "^10.0 || ^11.0 || ^12.0",
+        "lorisleiva/laravel-actions": "^2.9.1",
         "nette/application": "^3.1",
         "nette/component-model": "^3.0",
         "nette/neon": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d3c7506f74ddf845d74a1f0fe77a2af",
+    "content-hash": "5ae1bdeae2d2f167b203fdef246a192a",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -3828,6 +3828,164 @@
                 "source": "https://github.com/localheinz/diff/tree/1.3.0"
             },
             "time": "2025-08-30T09:44:18+00:00"
+        },
+        {
+            "name": "lorisleiva/laravel-actions",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/laravel-actions.git",
+                "reference": "8d58b11d4fbca08fbcdb87243a4607bb3ae1db8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/laravel-actions/zipball/8d58b11d4fbca08fbcdb87243a4607bb3ae1db8d",
+                "reference": "8d58b11d4fbca08fbcdb87243a4607bb3ae1db8d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "lorisleiva/lody": "^0.7",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "larastan/larastan": "^3.0",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.5|^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "Lorisleiva\\Actions\\Facades\\Actions"
+                    },
+                    "providers": [
+                        "Lorisleiva\\Actions\\ActionServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\Actions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris Leiva",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel components that take care of one specific task",
+            "homepage": "https://github.com/lorisleiva/laravel-actions",
+            "keywords": [
+                "action",
+                "command",
+                "component",
+                "controller",
+                "job",
+                "laravel",
+                "listener",
+                "object"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/laravel-actions/issues",
+                "source": "https://github.com/lorisleiva/laravel-actions/tree/v2.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-25T14:17:11+00:00"
+        },
+        {
+            "name": "lorisleiva/lody",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/lody.git",
+                "reference": "018d3d384872d4b28f5194dae5fd05894db7fabe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/lody/zipball/018d3d384872d4b28f5194dae5fd05894db7fabe",
+                "reference": "018d3d384872d4b28f5194dae5fd05894db7fabe",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpunit/phpunit": "^11.5|^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Lody": "Lorisleiva\\Lody\\Lody"
+                    },
+                    "providers": [
+                        "Lorisleiva\\Lody\\LodyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\Lody\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris Leiva",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Load files and classes as lazy collections in Laravel.",
+            "homepage": "https://github.com/lorisleiva/lody",
+            "keywords": [
+                "classes",
+                "collection",
+                "files",
+                "laravel",
+                "load"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/lody/issues",
+                "source": "https://github.com/lorisleiva/lody/tree/v0.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-09-01T11:53:49+00:00"
         },
         {
             "name": "marc-mabe/php-enum",

--- a/rules.neon
+++ b/rules.neon
@@ -143,6 +143,13 @@ services:
             enabled: %shipmonkDeadCode.usageProviders.laravel.enabled%
 
     -
+        class: ShipMonk\PHPStan\DeadCode\Provider\LaravelActionsUsageProvider
+        tags:
+            - shipmonk.deadCode.memberUsageProvider
+        arguments:
+            enabled: %shipmonkDeadCode.usageProviders.laravelActions.enabled%
+
+    -
         class: ShipMonk\PHPStan\DeadCode\Provider\BladeUsageProvider
         tags:
             - shipmonk.deadCode.memberUsageProvider
@@ -305,6 +312,8 @@ parameters:
                 enabled: null
             laravel:
                 enabled: null
+            laravelActions:
+                enabled: null
             blade:
                 enabled: null
                 deduplicateAcrossViews: true
@@ -404,6 +413,9 @@ parametersSchema:
                 enabled: schema(bool(), nullable())
             ])
             laravel: structure([
+                enabled: schema(bool(), nullable())
+            ])
+            laravelActions: structure([
                 enabled: schema(bool(), nullable())
             ])
             blade: structure([

--- a/src/Provider/LaravelActionsUsageProvider.php
+++ b/src/Provider/LaravelActionsUsageProvider.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\DeadCode\Provider;
+
+use Composer\InstalledVersions;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Naming\CaseInsensitiveName;
+
+/**
+ * lorisleiva/laravel-actions gives a class using the AsObject (or AsAction) trait
+ * static run()/runIf()/runUnless() methods that call $this->handle(...) from within
+ * the trait itself. That call site lives in vendor code and is never analysed, so
+ * handle() otherwise looks unused however many places call it via ::run().
+ */
+final class LaravelActionsUsageProvider implements MemberUsageProvider
+{
+
+    private const ACTION_TRAIT = 'Lorisleiva\Actions\Concerns\AsObject';
+
+    private const RUN_METHODS = ['run', 'runIf', 'runUnless'];
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ?bool $enabled,
+    )
+    {
+        $this->enabled = $enabled ?? InstalledVersions::isInstalled('lorisleiva/laravel-actions');
+    }
+
+    public function getUsages(
+        Node $node,
+        Scope $scope,
+    ): array
+    {
+        if (!$this->enabled) {
+            return [];
+        }
+
+        if (!$node instanceof StaticCall || !$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (!CaseInsensitiveName::isOneOf($node->name->name, self::RUN_METHODS)) {
+            return [];
+        }
+
+        $callerType = $node->class instanceof Expr
+            ? $scope->getType($node->class)
+            : $scope->resolveTypeByName($node->class);
+
+        $usages = [];
+
+        foreach ($callerType->getObjectClassReflections() as $classReflection) {
+            if (!$this->isAction($classReflection)) {
+                continue;
+            }
+
+            $usages[] = new ClassMethodUsage(
+                UsageOrigin::createRegular($node, $scope),
+                new ClassMethodRef($classReflection->getName(), 'handle', possibleDescendant: true),
+            );
+        }
+
+        return $usages;
+    }
+
+    private function isAction(ClassReflection $classReflection): bool
+    {
+        return $classReflection->hasTraitUse(self::ACTION_TRAIT);
+    }
+
+}

--- a/tests/Rule/DeadCodeRuleTest.php
+++ b/tests/Rule/DeadCodeRuleTest.php
@@ -56,6 +56,7 @@ use ShipMonk\PHPStan\DeadCode\Provider\ComposerUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\DoctrineUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EloquentUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\EnumUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\LaravelActionsUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\LaravelUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\NetteTesterUsageProvider;
@@ -1030,6 +1031,7 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
         yield 'provider-phpat' => [__DIR__ . '/data/providers/phpat.php'];
         yield 'provider-eloquent' => [__DIR__ . '/data/providers/eloquent.php'];
         yield 'provider-laravel' => [__DIR__ . '/data/providers/laravel.php'];
+        yield 'provider-laravel-actions' => [__DIR__ . '/data/providers/laravel-actions.php'];
         yield 'provider-blade' => [__DIR__ . '/data/providers/blade.php'];
         yield 'provider-nette' => [__DIR__ . '/data/providers/nette.php'];
         yield 'provider-nette-container' => [__DIR__ . '/data/providers/nette-container.php'];
@@ -1262,6 +1264,9 @@ final class DeadCodeRuleTest extends ShipMonkRuleTestCase
             ),
             new LaravelUsageProvider(
                 self::getContainer()->getByType(ReflectionProvider::class),
+                $this->providersEnabled,
+            ),
+            new LaravelActionsUsageProvider(
                 $this->providersEnabled,
             ),
             new BladeUsageProvider(

--- a/tests/Rule/data/providers/laravel-actions.php
+++ b/tests/Rule/data/providers/laravel-actions.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace LaravelActions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\AsObject;
+
+// --- Actions whose handle() is only reachable through the trait's run() methods ---
+
+class CreateOrder
+{
+    use AsAction;
+
+    public function handle(int $orderId): void
+    {
+    }
+}
+
+class UpdateOrder
+{
+    use AsObject;
+
+    public function handle(int $orderId): void
+    {
+    }
+}
+
+class ArchiveOrder
+{
+    use AsAction;
+
+    public function handle(int $orderId): void
+    {
+    }
+}
+
+// A scalar-typed first parameter, unlike a class-typed one, is not recognised by
+// Laravel's own event-listener auto-discovery heuristic - this is the shape that
+// exposed the bug this provider fixes.
+class ListOrders
+{
+    use AsAction;
+
+    public function handle(?int $perPage = null): void
+    {
+    }
+}
+
+class UncalledAction
+{
+    use AsAction;
+
+    public function handle(int $orderId): void // error: Unused LaravelActions\UncalledAction::handle
+    {
+    }
+}
+
+// Not an Action - its own static run() is unrelated to lorisleiva/laravel-actions
+class PlainRunner
+{
+    public static function run(): void
+    {
+    }
+
+    private static function unusedHelper(): void // error: Unused LaravelActions\PlainRunner::unusedHelper
+    {
+    }
+}
+
+function callActions(): void
+{
+    CreateOrder::run(1);
+    UpdateOrder::runIf(true, 2);
+    ArchiveOrder::runUnless(false, 3);
+    ListOrders::run();
+    PlainRunner::run();
+}


### PR DESCRIPTION
Fixes #428. `AsObject`/`AsAction`'s `run()`, `runIf()` and `runUnless()` call `handle()` from inside the trait itself, so that call is invisible to the analyser and an Action's `handle()` is reported dead no matter how many callers it has.

Adds `LaravelActionsUsageProvider`, which resolves `run()`/`runIf()`/`runUnless()` calls back to `handle()` on any class using the `AsObject` trait (recursively, since `AsAction` composes it along with the other concern traits). Auto-enabled when `lorisleiva/laravel-actions` is installed, same as the other Laravel-related providers.

Left `LaravelUsageProvider::isEventListenerMethod()`'s class-typed-first-param heuristic untouched - narrowing it for Action classes would also fix the false negative described in the issue, but it couples that provider to a separate optional package and can regress a setup with laravel-actions installed and this new provider explicitly disabled, so it needs your input first.
